### PR TITLE
Editorial hero redesign – full-viewport dark layout with display typography

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1622,3 +1622,402 @@ opacity:0
 .dtr-timeline-highlight .dtr-timeline-text h5 {
     color: #6138bd;
 }
+
+/*----------------------------------------*/
+/*----- Hero V3 – Editorial Layout -----*/
+/*----------------------------------------*/
+
+/* Section shell */
+.dtr-hv3 {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    background: #0a0b0f;
+    overflow: hidden;
+    padding-top: 80px;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Ambient glows */
+.dtr-hv3-glow {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+    z-index: 0;
+    pointer-events: none;
+}
+.dtr-hv3-glow-1 {
+    width: 700px;
+    height: 500px;
+    background: radial-gradient(ellipse at center, rgba(97,56,189,0.20), transparent 70%);
+    top: 30%;
+    right: 5%;
+}
+.dtr-hv3-glow-2 {
+    width: 500px;
+    height: 400px;
+    background: radial-gradient(ellipse at center, rgba(97,56,189,0.12), transparent 70%);
+    top: 20%;
+    left: 0;
+}
+
+/* Display typography */
+.dtr-hv3-display {
+    position: absolute;
+    top: 50%;
+    -webkit-transform: translateY(-52%);
+    transform: translateY(-52%);
+    width: 100%;
+    padding: 0 3vw;
+    z-index: 1;
+    pointer-events: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+.dtr-hv3-row1 {
+    display: block;
+    font-family: 'Jost', sans-serif;
+    font-weight: 700;
+    font-size: clamp(54px, 16vw, 230px);
+    line-height: 0.88;
+    letter-spacing: -0.02em;
+    color: #fff;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+.dtr-hv3-row2 {
+    display: block;
+    font-family: 'Jost', sans-serif;
+    font-weight: 700;
+    font-size: clamp(34px, 9.8vw, 142px);
+    line-height: 0.92;
+    letter-spacing: -0.02em;
+    color: rgba(255,255,255,0.80);
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+/* Portrait photo */
+.dtr-hv3-portrait {
+    position: absolute;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
+    top: 80px;
+    height: calc(100vh - 80px - 90px);
+    z-index: 2;
+    pointer-events: none;
+}
+.dtr-hv3-portrait img {
+    height: 100%;
+    width: auto;
+    max-width: 45vw;
+    -o-object-fit: cover;
+    object-fit: cover;
+    -o-object-position: top center;
+    object-position: top center;
+    display: block;
+    -webkit-mask-image: radial-gradient(ellipse 55% 95% at 50% 15%, black 35%, rgba(0,0,0,0.9) 55%, transparent 80%);
+    mask-image: radial-gradient(ellipse 55% 95% at 50% 15%, black 35%, rgba(0,0,0,0.9) 55%, transparent 80%);
+}
+
+/* Info panel (bottom-left) */
+.dtr-hv3-info {
+    position: absolute;
+    bottom: 100px;
+    left: 4vw;
+    z-index: 3;
+    max-width: 380px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* Status badge */
+.dtr-hv3-status {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.13);
+    color: rgba(255,255,255,0.80);
+    font-size: 13px;
+    font-weight: 500;
+    padding: 7px 14px;
+    border-radius: 50px;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+}
+.dtr-hv3-dot {
+    width: 8px;
+    height: 8px;
+    background: #22c55e;
+    border-radius: 50%;
+    -webkit-animation: dtr-hv3-pulse-green 2s ease-in-out infinite;
+    animation: dtr-hv3-pulse-green 2s ease-in-out infinite;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+}
+@-webkit-keyframes dtr-hv3-pulse-green {
+    0%, 100% { -webkit-box-shadow: 0 0 0 0 rgba(34,197,94,0.6); box-shadow: 0 0 0 0 rgba(34,197,94,0.6); opacity: 1; }
+    50% { -webkit-box-shadow: 0 0 0 5px rgba(34,197,94,0); box-shadow: 0 0 0 5px rgba(34,197,94,0); opacity: 0.75; }
+}
+@keyframes dtr-hv3-pulse-green {
+    0%, 100% { -webkit-box-shadow: 0 0 0 0 rgba(34,197,94,0.6); box-shadow: 0 0 0 0 rgba(34,197,94,0.6); opacity: 1; }
+    50% { -webkit-box-shadow: 0 0 0 5px rgba(34,197,94,0); box-shadow: 0 0 0 5px rgba(34,197,94,0); opacity: 0.75; }
+}
+
+/* Bio text */
+.dtr-hv3-bio {
+    color: rgba(255,255,255,0.60);
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* Actions row */
+.dtr-hv3-actions {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: 16px;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
+/* CTA button */
+.dtr-hv3-btn {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: 8px;
+    background: #fff;
+    color: #0a0b0f !important;
+    font-family: 'Jost', sans-serif;
+    font-weight: 600;
+    font-size: 14px;
+    padding: 11px 22px;
+    border-radius: 50px;
+    text-decoration: none !important;
+    -webkit-transition: background 0.2s, -webkit-transform 0.2s;
+    transition: background 0.2s, -webkit-transform 0.2s;
+    transition: background 0.2s, transform 0.2s;
+    transition: background 0.2s, transform 0.2s, -webkit-transform 0.2s;
+}
+.dtr-hv3-btn:hover {
+    background: rgba(255,255,255,0.90);
+    -webkit-transform: translateY(-1px);
+    transform: translateY(-1px);
+}
+.dtr-hv3-arrow {
+    width: 18px;
+    height: 18px;
+}
+
+/* Social icons */
+.dtr-hv3-socials {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    gap: 10px;
+}
+.dtr-hv3-social {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 50%;
+    color: rgba(255,255,255,0.70) !important;
+    text-decoration: none !important;
+    -webkit-transition: background 0.2s, color 0.2s;
+    transition: background 0.2s, color 0.2s;
+}
+.dtr-hv3-social:hover {
+    background: rgba(255,255,255,0.14);
+    color: #fff !important;
+}
+.dtr-hv3-social svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Logo marquee strip */
+.dtr-hv3-strip {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 88px;
+    z-index: 3;
+    border-top: 1px solid rgba(255,255,255,0.07);
+    overflow: hidden;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+}
+.dtr-hv3-strip-track {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    gap: 60px;
+    -webkit-animation: dtr-hv3-marquee 20s linear infinite;
+    animation: dtr-hv3-marquee 20s linear infinite;
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+    padding: 0 30px;
+}
+@-webkit-keyframes dtr-hv3-marquee {
+    from { -webkit-transform: translateX(0); transform: translateX(0); }
+    to   { -webkit-transform: translateX(-50%); transform: translateX(-50%); }
+}
+@keyframes dtr-hv3-marquee {
+    from { -webkit-transform: translateX(0); transform: translateX(0); }
+    to   { -webkit-transform: translateX(-50%); transform: translateX(-50%); }
+}
+.dtr-hv3-strip-logo {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+}
+.dtr-hv3-strip-logo img {
+    height: 32px;
+    width: auto;
+    display: block;
+    -webkit-filter: brightness(0) invert(1);
+    filter: brightness(0) invert(1);
+    opacity: 0.40;
+    -webkit-transition: opacity 0.2s;
+    transition: opacity 0.2s;
+}
+.dtr-hv3-strip-logo img:hover {
+    opacity: 0.70;
+}
+.dtr-hv3-strip-dot {
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.25);
+}
+
+/* ---- Responsive: tablets ---- */
+@media (max-width: 991px) {
+    .dtr-hv3-display {
+        top: 48%;
+    }
+    .dtr-hv3-row1 {
+        font-size: clamp(44px, 13vw, 160px);
+    }
+    .dtr-hv3-row2 {
+        font-size: clamp(27px, 8vw, 100px);
+    }
+    .dtr-hv3-portrait {
+        height: calc(100vh - 80px - 110px);
+        max-width: 60vw;
+    }
+    .dtr-hv3-portrait img {
+        max-width: 60vw;
+    }
+    .dtr-hv3-info {
+        bottom: 110px;
+        max-width: 320px;
+    }
+}
+
+/* ---- Responsive: mobile ---- */
+@media (max-width: 767px) {
+    .dtr-hv3 {
+        min-height: 100svh;
+    }
+    .dtr-hv3-display {
+        top: auto;
+        -webkit-transform: none;
+        transform: none;
+        bottom: 88px;
+        padding: 0 4vw;
+    }
+    .dtr-hv3-row1 {
+        font-size: clamp(40px, 15vw, 100px);
+        white-space: normal;
+        word-break: break-word;
+    }
+    .dtr-hv3-row2 {
+        font-size: clamp(24px, 9vw, 62px);
+        white-space: normal;
+        word-break: break-word;
+    }
+    .dtr-hv3-portrait {
+        left: 50%;
+        -webkit-transform: translateX(-50%);
+        transform: translateX(-50%);
+        top: 80px;
+        height: 52vh;
+        max-width: 80vw;
+    }
+    .dtr-hv3-portrait img {
+        max-width: 80vw;
+        -webkit-mask-image: radial-gradient(ellipse 65% 85% at 50% 15%, black 30%, rgba(0,0,0,0.8) 55%, transparent 80%);
+        mask-image: radial-gradient(ellipse 65% 85% at 50% 15%, black 30%, rgba(0,0,0,0.8) 55%, transparent 80%);
+    }
+    .dtr-hv3-info {
+        position: static;
+        padding: 16px 4vw 0;
+        max-width: 100%;
+        background: linear-gradient(to bottom, transparent, #0a0b0f 30%);
+    }
+    .dtr-hv3-display {
+        position: static;
+        padding: 12px 4vw 0;
+        bottom: auto;
+    }
+    .dtr-hv3 {
+        padding-top: 80px;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-pack: start;
+        -ms-flex-pack: start;
+        justify-content: flex-start;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -117,111 +117,85 @@
 
         <!-- hero section starts
 ================================================== -->
-        <section id="home" class="dtr-hero-v2">
+        <section id="home" class="dtr-hv3">
 
-            <!-- animated background layers -->
-            <div class="dtr-hv2-bg-grid"></div>
-            <div class="dtr-hv2-orb dtr-hv2-orb-1"></div>
-            <div class="dtr-hv2-orb dtr-hv2-orb-2"></div>
-            <div class="dtr-hv2-orb dtr-hv2-orb-3"></div>
+            <!-- ambient purple glows -->
+            <div class="dtr-hv3-glow dtr-hv3-glow-1"></div>
+            <div class="dtr-hv3-glow dtr-hv3-glow-2"></div>
 
-            <div class="container dtr-hv2-inner">
-
-                <!-- LEFT: text content -->
-                <div class="dtr-hv2-content">
-
-                    <!-- PhD credential badge -->
-                    <div class="dtr-hv2-eyebrow">
-                        <span class="dtr-hv2-eyebrow-dot"></span>
-                        PhD &nbsp;·&nbsp; Human Interface Technology &nbsp;·&nbsp; University of Canterbury, NZ
-                    </div>
-
-                    <!-- Name -->
-                    <h1 class="dtr-hv2-name">
-                        <span class="dtr-hv2-name-first">Yasas Sri</span>
-                        <span class="dtr-hv2-name-last">Wickramasinghe</span>
-                    </h1>
-
-                    <!-- Typewriter role -->
-                    <div class="dtr-hv2-role-wrap">
-                        <span class="dtr-hv2-role" id="dtrHeroRole"></span><span class="dtr-hv2-cursor">|</span>
-                    </div>
-
-                    <!-- Bio -->
-                    <p class="dtr-hv2-bio">
-                        Pioneering research in Augmented Reality and Spatial Computing.
-                        Teaching Masters-level programs and building the next generation of XR practitioners.
-                    </p>
-
-                    <!-- Stats -->
-                    <div class="dtr-hv2-stats">
-                        <div class="dtr-hv2-stat">
-                            <strong><span class="dtr-count" data-target="10">0</span>+</strong>
-                            <span>Years in Tech</span>
-                        </div>
-                        <div class="dtr-hv2-stat-sep"></div>
-                        <div class="dtr-hv2-stat">
-                            <strong><span class="dtr-count" data-target="500">0</span>+</strong>
-                            <span>Students Taught</span>
-                        </div>
-                        <div class="dtr-hv2-stat-sep"></div>
-                        <div class="dtr-hv2-stat">
-                            <strong><span class="dtr-count" data-target="20">0</span>+</strong>
-                            <span>Publications &amp; Talks</span>
-                        </div>
-                    </div>
-
-                    <!-- Action buttons + socials -->
-                    <div class="dtr-hv2-actions">
-                        <a href="#contact" class="dtr-hv2-btn-primary">
-                            Get In Touch
-                            <svg viewBox="0 0 20 20" fill="none" class="dtr-hv2-btn-arrow"><path d="M4 10h12M12 6l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                        </a>
-                        <a href="#portfolio" class="dtr-hv2-btn-ghost">View Research</a>
-                        <div class="dtr-hv2-social-row">
-                            <a href="https://www.linkedin.com/in/yasassri" target="_blank" class="dtr-hv2-social" title="LinkedIn">
-                                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4v-7a6 6 0 016-6zM2 9h4v12H2z"/><circle cx="4" cy="4" r="2"/></svg>
-                            </a>
-                            <a href="https://www.instagram.com/yasassri.me" target="_blank" class="dtr-hv2-social" title="Instagram">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="5"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor" stroke="none"/></svg>
-                            </a>
-                            <a href="https://www.facebook.com/yasas.s.wickramasinghe" target="_blank" class="dtr-hv2-social" title="Facebook">
-                                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/></svg>
-                            </a>
-                        </div>
-                    </div>
-
-                </div>
-                <!-- LEFT ends -->
-
-                <!-- RIGHT: photo -->
-                <div class="dtr-hv2-visual">
-                    <div class="dtr-hv2-photo-frame">
-                        <div class="dtr-hv2-ring dtr-hv2-ring-1"></div>
-                        <div class="dtr-hv2-ring dtr-hv2-ring-2"></div>
-                        <div class="dtr-hv2-ring dtr-hv2-ring-3"></div>
-                        <img src="assets/images/phd-graduation.jpg"
-                             alt="Dr Yasas Sri Wickramasinghe – PhD in Human Interface Technology"
-                             class="dtr-hv2-photo"
-                             onerror="this.onerror=null;this.src='assets/images/personal_img.png'">
-                        <!-- floating PhD tag -->
-                        <div class="dtr-hv2-photo-tag">
-                            <svg viewBox="0 0 20 20" fill="currentColor" class="dtr-hv2-cap-icon"><path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/></svg>
-                            <div class="dtr-hv2-tag-text">
-                                <strong>Dr. Yasas Sri</strong>
-                                <span>PhD · Human Interface Technology</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- RIGHT ends -->
-
+            <!-- full-width display type — sits behind the photo -->
+            <div class="dtr-hv3-display" aria-hidden="true">
+                <span class="dtr-hv3-row1">YASAS SRI</span>
+                <span class="dtr-hv3-row2">WICKRAMASINGHE</span>
             </div>
 
-            <!-- scroll mouse cue -->
-            <div class="dtr-hv2-scroll-cue">
-                <div class="dtr-hv2-scroll-mouse">
-                    <div class="dtr-hv2-scroll-wheel"></div>
+            <!-- centred portrait photo — floats in front of type -->
+            <div class="dtr-hv3-portrait">
+                <img src="assets/images/phd-graduation.jpg"
+                     alt="Dr Yasas Sri Wickramasinghe – PhD in Human Interface Technology"
+                     onerror="this.onerror=null;this.src='assets/images/personal_img.png'">
+            </div>
+
+            <!-- bottom-left info panel -->
+            <div class="dtr-hv3-info">
+                <div class="dtr-hv3-status">
+                    <span class="dtr-hv3-dot"></span>
+                    Open for Research Collaboration
+                </div>
+                <p class="dtr-hv3-bio">
+                    Hey! I'm a PhD Researcher &amp; Senior Lecturer<br>
+                    specialising in Human Interface Technology &amp; XR.
+                </p>
+                <div class="dtr-hv3-actions">
+                    <a href="#contact" class="dtr-hv3-btn">
+                        Schedule a Call
+                        <svg viewBox="0 0 20 20" fill="none" class="dtr-hv3-arrow"><path d="M4 10h12M12 6l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </a>
+                    <div class="dtr-hv3-socials">
+                        <a href="https://www.linkedin.com/in/yasassri" target="_blank" class="dtr-hv3-social" title="LinkedIn">
+                            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4v-7a6 6 0 016-6zM2 9h4v12H2z"/><circle cx="4" cy="4" r="2"/></svg>
+                        </a>
+                        <a href="https://www.instagram.com/yasassri.me" target="_blank" class="dtr-hv3-social" title="Instagram">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="5"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor" stroke="none"/></svg>
+                        </a>
+                        <a href="https://www.facebook.com/yasas.s.wickramasinghe" target="_blank" class="dtr-hv3-social" title="Facebook">
+                            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/></svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- scrolling affiliation logo strip -->
+            <div class="dtr-hv3-strip">
+                <div class="dtr-hv3-strip-track">
+                    <!-- set 1 -->
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-yoobee.png" alt="Yoobee Colleges"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-hitlabnz.png" alt="HITLabNZ"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <!-- set 2 (duplicate for seamless loop) -->
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-yoobee.png" alt="Yoobee Colleges"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-hitlabnz.png" alt="HITLabNZ"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <!-- set 3 -->
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-yoobee.png" alt="Yoobee Colleges"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-hitlabnz.png" alt="HITLabNZ"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <!-- set 4 (completes second half for seamless 50% loop) -->
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-yoobee.png" alt="Yoobee Colleges"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
+                    <span class="dtr-hv3-strip-logo"><img src="assets/images/logo-hitlabnz.png" alt="HITLabNZ"></span>
+                    <span class="dtr-hv3-strip-dot"></span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Replaces the hero section with a full-viewport editorial layout inspired by modern portfolio design
- Massive display typography (first/last name split across two lines, fluid `clamp()` sizing from ~40px to 230px)
- Centred graduation photo floats over the text, blended into the dark background via CSS `mask-image`
- Bottom-left info panel with a green pulsing "Open for Research Collaboration" status badge, bio text, white pill CTA button, and social icons
- Seamless CSS-only marquee logo strip at the bottom (Yoobee Colleges · Niantic Spatial · HITLabNZ)
- Ambient purple glow orbs add depth without distraction
- Fully responsive — dedicated breakpoints for tablet (≤991px) and mobile (≤767px) with stacked layout on small screens

## Test plan

- [ ] Desktop (≥1200px): display name fills the viewport width, photo centred over text, info panel bottom-left, logo strip scrolling
- [ ] Tablet (768–991px): font sizes scale down, photo adjusts
- [ ] Mobile (≤767px): portrait photo tops the view, display name and info panel stack below it
- [ ] Logo images load and appear white/monochrome; fallback `onerror` works if any logo is missing
- [ ] Green dot pulses, CTA button hover lifts, social icon hover brightens
- [ ] Marquee loops seamlessly with no jump

https://claude.ai/code/session_01Dwo1g78uGzHBSJAEMGMzRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dwo1g78uGzHBSJAEMGMzRe)_