### PR TITLE
Redesign portfolio with premium dark editorial theme

### DIFF
--- a/assets/css/premium.css
+++ b/assets/css/premium.css
@@ -1,0 +1,989 @@
+/* ==========================================================================
+   Dr. Yasas Sri Wickramasinghe — Portfolio Design System
+   Editorial dark theme · Fraunces + Inter + IBM Plex Mono
+   ========================================================================== */
+
+:root {
+  --bg: #0b0b0d;
+  --bg-elev: #121214;
+  --bg-card: #141417;
+  --line: rgba(242, 239, 233, 0.1);
+  --line-strong: rgba(242, 239, 233, 0.22);
+  --text: #f2efe9;
+  --text-dim: #b5b1a8;
+  --muted: #8a867d;
+  --accent: #c9a45c;
+  --accent-soft: rgba(201, 164, 92, 0.12);
+  --serif: "Fraunces", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: "IBM Plex Mono", "SF Mono", monospace;
+  --max: 1240px;
+  --pad: clamp(20px, 5vw, 72px);
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+::selection { background: var(--accent); color: #0b0b0d; }
+
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+ul { list-style: none; }
+button { font: inherit; background: none; border: none; cursor: pointer; color: inherit; }
+
+/* --- Film grain overlay ------------------------------------------------- */
+body::after {
+  content: "";
+  position: fixed;
+  inset: -50%;
+  width: 200%;
+  height: 200%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grain 8s steps(10) infinite;
+}
+@keyframes grain {
+  0%, 100% { transform: translate(0, 0); }
+  20% { transform: translate(-2%, 2%); }
+  40% { transform: translate(2%, -1%); }
+  60% { transform: translate(-1%, -2%); }
+  80% { transform: translate(1%, 1%); }
+}
+
+/* --- Scroll progress ----------------------------------------------------- */
+.progress-bar {
+  position: fixed;
+  top: 0; left: 0;
+  height: 2px;
+  width: 0;
+  background: var(--accent);
+  z-index: 1001;
+  transition: width 0.1s linear;
+}
+
+/* --- Navigation ----------------------------------------------------------- */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 1000;
+  transition: background 0.4s var(--ease), border-color 0.4s var(--ease);
+  border-bottom: 1px solid transparent;
+}
+.nav.scrolled {
+  background: rgba(11, 11, 13, 0.82);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border-bottom-color: var(--line);
+}
+.nav-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 20px var(--pad);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.nav-logo {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.nav-logo em { font-style: italic; color: var(--accent); }
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 36px;
+}
+.nav-links a:not(.btn) {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  position: relative;
+  padding: 4px 0;
+  transition: color 0.3s;
+}
+.nav-links a:not(.btn)::after {
+  content: "";
+  position: absolute;
+  left: 0; bottom: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 0.4s var(--ease);
+}
+.nav-links a:not(.btn):hover { color: var(--text); }
+.nav-links a:not(.btn):hover::after { transform: scaleX(1); transform-origin: left; }
+.nav-links a.active { color: var(--accent); }
+.nav-links a.active::after { transform: scaleX(1); }
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+  z-index: 1002;
+}
+.nav-toggle span {
+  display: block;
+  width: 28px;
+  height: 1.5px;
+  background: var(--text);
+  transition: transform 0.4s var(--ease), opacity 0.3s;
+}
+.nav-toggle.open span:nth-child(1) { transform: translateY(7.5px) rotate(45deg); }
+.nav-toggle.open span:nth-child(2) { opacity: 0; }
+.nav-toggle.open span:nth-child(3) { transform: translateY(-7.5px) rotate(-45deg); }
+
+.mobile-menu {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--pad);
+  gap: 8px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s var(--ease), visibility 0.4s;
+}
+.mobile-menu.open { opacity: 1; visibility: visible; }
+.mobile-menu a {
+  font-family: var(--serif);
+  font-size: clamp(32px, 8vw, 52px);
+  font-weight: 400;
+  color: var(--text-dim);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  transition: color 0.3s, padding-left 0.3s var(--ease);
+}
+.mobile-menu a:hover, .mobile-menu a.active { color: var(--accent); padding-left: 12px; }
+.mobile-menu a .idx {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.14em;
+}
+
+/* --- Buttons --------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 14px 28px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--text);
+  position: relative;
+  overflow: hidden;
+  transition: color 0.4s var(--ease), border-color 0.4s;
+  background: transparent;
+}
+.btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  transform: translateY(101%);
+  transition: transform 0.45s var(--ease);
+  z-index: -1;
+  border-radius: inherit;
+}
+.btn:hover { color: #0b0b0d; border-color: var(--accent); }
+.btn:hover::before { transform: translateY(0); }
+.btn .arrow { transition: transform 0.4s var(--ease); }
+.btn:hover .arrow { transform: translateX(4px); }
+.btn-solid {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0b0b0d;
+}
+.btn-solid::before { background: var(--text); }
+.btn-solid:hover { border-color: var(--text); }
+
+.link-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  transition: gap 0.3s var(--ease);
+}
+.link-arrow:hover { gap: 16px; }
+
+/* --- Layout helpers --------------------------------------------------------- */
+.container {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding-left: var(--pad);
+  padding-right: var(--pad);
+}
+.section { padding: clamp(80px, 12vw, 150px) 0; border-top: 1px solid var(--line); }
+.section.no-line { border-top: none; }
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+  margin-bottom: clamp(40px, 6vw, 72px);
+  flex-wrap: wrap;
+}
+.section-head .idx {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+}
+.section-head h2 {
+  font-family: var(--serif);
+  font-size: clamp(34px, 5vw, 58px);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.section-head h2 em { font-style: italic; color: var(--accent); font-weight: 300; }
+.section-head .head-link { margin-left: auto; }
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.eyebrow::before {
+  content: "";
+  width: 36px;
+  height: 1px;
+  background: var(--accent);
+}
+
+.lead {
+  font-size: clamp(17px, 2vw, 21px);
+  line-height: 1.75;
+  color: var(--text-dim);
+  font-weight: 300;
+}
+
+/* --- Hero ------------------------------------------------------------------- */
+.hero {
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+  padding-top: 120px;
+  padding-bottom: 60px;
+  overflow: hidden;
+}
+.hero-glow {
+  position: absolute;
+  width: 70vw;
+  height: 70vw;
+  max-width: 900px;
+  max-height: 900px;
+  top: -20%;
+  right: -20%;
+  background: radial-gradient(circle, rgba(201, 164, 92, 0.07) 0%, transparent 65%);
+  pointer-events: none;
+}
+.hero h1 {
+  font-family: var(--serif);
+  font-size: clamp(44px, 7.6vw, 110px);
+  font-weight: 350;
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+  max-width: 13ch;
+}
+.hero h1 em {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--accent);
+}
+.hero-sub {
+  margin-top: clamp(28px, 4vw, 44px);
+  max-width: 560px;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: clamp(32px, 4vw, 48px);
+  align-items: center;
+}
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin-top: 40px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hero-meta a { transition: color 0.3s; }
+.hero-meta a:hover { color: var(--accent); }
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #7cb87c;
+  margin-right: 8px;
+  animation: pulse 2s infinite;
+}
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(124, 184, 124, 0.5); }
+  50% { box-shadow: 0 0 0 6px rgba(124, 184, 124, 0); }
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.25fr 0.75fr;
+  gap: clamp(40px, 6vw, 90px);
+  align-items: center;
+}
+.hero-portrait {
+  position: relative;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  border-radius: 4px;
+}
+.hero-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+  filter: grayscale(100%) contrast(1.05);
+  transition: filter 1s var(--ease), transform 1.2s var(--ease);
+  transform: scale(1.02);
+}
+.hero-portrait:hover img { filter: grayscale(0%); transform: scale(1.06); }
+.hero-portrait::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  pointer-events: none;
+}
+.hero-portrait .frame {
+  position: absolute;
+  bottom: -14px;
+  left: -14px;
+  width: 90px;
+  height: 90px;
+  border-left: 1px solid var(--accent);
+  border-bottom: 1px solid var(--accent);
+  opacity: 0.6;
+}
+.portrait-caption {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: rgba(11, 11, 13, 0.7);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  padding: 8px 14px;
+  border-radius: 3px;
+  color: var(--text-dim);
+}
+
+.scroll-hint {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+.scroll-hint::after {
+  content: "";
+  width: 1px;
+  height: 44px;
+  background: linear-gradient(var(--accent), transparent);
+  animation: drop 2s var(--ease) infinite;
+}
+@keyframes drop {
+  0% { transform: scaleY(0); transform-origin: top; }
+  50% { transform: scaleY(1); transform-origin: top; }
+  51% { transform-origin: bottom; }
+  100% { transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* --- Marquee ------------------------------------------------------------------ */
+.marquee {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  overflow: hidden;
+  padding: 22px 0;
+  display: flex;
+  user-select: none;
+}
+.marquee-track {
+  display: flex;
+  flex-shrink: 0;
+  gap: 0;
+  animation: marquee 36s linear infinite;
+}
+.marquee:hover .marquee-track { animation-play-state: paused; }
+.marquee-track span {
+  font-family: var(--serif);
+  font-size: clamp(18px, 2.4vw, 26px);
+  font-weight: 300;
+  white-space: nowrap;
+  color: var(--text-dim);
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  gap: 36px;
+}
+.marquee-track span::after {
+  content: "✦";
+  font-size: 12px;
+  color: var(--accent);
+}
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+/* --- Two-column section layout -------------------------------------------------- */
+.split {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.85fr) 2fr;
+  gap: clamp(36px, 6vw, 90px);
+  align-items: start;
+}
+.split .sticky-col { position: sticky; top: 120px; }
+.split .sticky-col h2 {
+  font-family: var(--serif);
+  font-size: clamp(30px, 3.6vw, 44px);
+  font-weight: 400;
+  line-height: 1.15;
+  margin-top: 18px;
+}
+.split .sticky-col h2 em { font-style: italic; color: var(--accent); font-weight: 300; }
+
+/* --- Cards ------------------------------------------------------------------------ */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: clamp(24px, 3vw, 36px);
+  transition: border-color 0.4s var(--ease), transform 0.4s var(--ease), background 0.4s;
+  position: relative;
+  overflow: hidden;
+}
+.card:hover { border-color: var(--line-strong); transform: translateY(-3px); }
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(90deg, var(--accent), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.4s;
+}
+.card:hover::before { opacity: 1; }
+.card h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 450;
+  line-height: 1.3;
+  margin-bottom: 10px;
+}
+.card .kicker {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 14px;
+}
+.card p { color: var(--text-dim); font-size: 15px; font-weight: 300; }
+
+.tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+.tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border: 1px solid var(--line);
+  padding: 5px 12px;
+  border-radius: 999px;
+  transition: border-color 0.3s, color 0.3s;
+}
+.card:hover .tag { border-color: var(--line-strong); }
+.tag.gold { color: var(--accent); border-color: rgba(201, 164, 92, 0.35); }
+
+/* --- Timeline ----------------------------------------------------------------------- */
+.timeline { display: flex; flex-direction: column; }
+.timeline-item {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: clamp(20px, 4vw, 56px);
+  padding: clamp(28px, 4vw, 44px) 0;
+  border-bottom: 1px solid var(--line);
+  transition: background 0.4s, padding-left 0.4s var(--ease);
+}
+.timeline-item:first-child { border-top: 1px solid var(--line); }
+.timeline-item:hover { background: rgba(242, 239, 233, 0.015); }
+.timeline-date {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  padding-top: 8px;
+  text-transform: uppercase;
+}
+.timeline-body h3 {
+  font-family: var(--serif);
+  font-size: clamp(22px, 2.6vw, 30px);
+  font-weight: 450;
+  line-height: 1.25;
+}
+.timeline-body .org { color: var(--accent); font-size: 14px; font-family: var(--mono); letter-spacing: 0.06em; margin-top: 4px; display: block; }
+.timeline-body p { color: var(--text-dim); font-weight: 300; font-size: 15px; margin-top: 14px; max-width: 62ch; }
+
+/* --- Publications index ----------------------------------------------------------------- */
+.pub-year {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+  padding: 36px 0 12px;
+  border-bottom: 1px solid var(--line-strong);
+  display: block;
+}
+.pub-row {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  gap: clamp(16px, 3vw, 40px);
+  align-items: baseline;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--line);
+  transition: padding-left 0.35s var(--ease), background 0.35s;
+}
+.pub-row:hover { padding-left: 14px; background: rgba(242, 239, 233, 0.015); }
+.pub-type {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.pub-title {
+  font-family: var(--serif);
+  font-size: clamp(17px, 1.8vw, 21px);
+  font-weight: 450;
+  line-height: 1.4;
+  transition: color 0.3s;
+}
+.pub-row:hover .pub-title { color: var(--accent); }
+.pub-venue { font-size: 13.5px; color: var(--text-dim); font-style: italic; margin-top: 6px; font-weight: 300; }
+.pub-venue .cite { font-style: normal; color: var(--accent); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; }
+.pub-links { display: flex; gap: 18px; flex-wrap: wrap; margin-top: 10px; }
+.pub-links a {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 2px;
+  transition: color 0.3s, border-color 0.3s;
+}
+.pub-links a:hover { color: var(--accent); border-color: var(--accent); }
+.pub-arrow {
+  font-family: var(--serif);
+  font-size: 24px;
+  color: var(--muted);
+  transition: transform 0.35s var(--ease), color 0.3s;
+  align-self: center;
+}
+.pub-row:hover .pub-arrow { transform: translate(4px, -4px); color: var(--accent); }
+
+/* --- Stats ---------------------------------------------------------------------------------- */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+.stat {
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  padding: clamp(28px, 4vw, 48px) clamp(20px, 3vw, 36px);
+  transition: background 0.4s;
+}
+.stat:hover { background: rgba(201, 164, 92, 0.04); }
+.stat-value {
+  font-family: var(--serif);
+  font-size: clamp(40px, 5vw, 64px);
+  font-weight: 300;
+  line-height: 1;
+  color: var(--text);
+}
+.stat-value .suffix { color: var(--accent); }
+.stat-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 14px;
+  display: block;
+}
+
+/* --- Grid of cards ----------------------------------------------------------------------------- */
+.grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+
+/* --- Blog / article cards ------------------------------------------------------------------------ */
+.article-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-card);
+  transition: border-color 0.4s, transform 0.4s var(--ease);
+}
+.article-card:hover { border-color: var(--line-strong); transform: translateY(-4px); }
+.article-cover {
+  aspect-ratio: 16 / 9;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  padding: 16px;
+}
+.article-cover::after {
+  content: attr(data-num);
+  position: absolute;
+  top: 10px;
+  right: 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: rgba(242, 239, 233, 0.4);
+}
+.article-cover .cat {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text);
+  background: rgba(11, 11, 13, 0.55);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  padding: 6px 12px;
+  border-radius: 999px;
+}
+.article-body { padding: 22px 24px 26px; display: flex; flex-direction: column; gap: 8px; flex: 1; }
+.article-body .src {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.article-body h3 {
+  font-family: var(--serif);
+  font-size: 19px;
+  font-weight: 450;
+  line-height: 1.35;
+  transition: color 0.3s;
+}
+.article-card:hover .article-body h3 { color: var(--accent); }
+.article-body .read {
+  margin-top: auto;
+  padding-top: 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: color 0.3s, gap 0.3s var(--ease);
+}
+.article-card:hover .read { color: var(--accent); gap: 14px; }
+
+/* Cover gradients */
+.cov-violet { background: linear-gradient(135deg, #15082b 0%, #341259 55%, #5b2a9a 100%); }
+.cov-forest { background: linear-gradient(135deg, #041f10 0%, #0e3d22 55%, #1c6e3c 100%); }
+.cov-teal   { background: linear-gradient(135deg, #02201e 0%, #074440 55%, #0f766e 100%); }
+.cov-ember  { background: linear-gradient(135deg, #270803 0%, #581c0c 55%, #9a3412 100%); }
+.cov-navy   { background: linear-gradient(135deg, #050d22 0%, #122a56 55%, #1d4ed8 100%); }
+.cov-plum   { background: linear-gradient(135deg, #230418 0%, #4b1038 55%, #86195e 100%); }
+.cov-slate  { background: linear-gradient(135deg, #0c1016 0%, #1f2937 55%, #475569 100%); }
+.cov-gold   { background: linear-gradient(135deg, #211503 0%, #4d3404 55%, #92660a 100%); }
+.article-cover .deco {
+  position: absolute;
+  inset: 0;
+  opacity: 0.35;
+  transition: transform 0.8s var(--ease);
+}
+.article-card:hover .article-cover .deco { transform: scale(1.08) rotate(1deg); }
+
+/* --- Feature rows (research bento) ---------------------------------------------------------------- */
+.feature-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(28px, 5vw, 70px);
+  align-items: center;
+  padding: clamp(36px, 5vw, 64px) 0;
+  border-bottom: 1px solid var(--line);
+}
+.feature-row:first-of-type { border-top: 1px solid var(--line); }
+.feature-media {
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: var(--bg-elev);
+}
+.feature-media img { width: 100%; transition: transform 0.9s var(--ease); }
+.feature-row:hover .feature-media img { transform: scale(1.04); }
+
+/* --- Contact form ------------------------------------------------------------------------------------ */
+.form-grid { display: flex; flex-direction: column; gap: 36px; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 36px; }
+.field { display: flex; flex-direction: column; gap: 10px; }
+.field label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  transition: color 0.3s;
+}
+.field:focus-within label { color: var(--accent); }
+.field input, .field textarea, .field select {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--line-strong);
+  padding: 10px 0;
+  font-family: var(--sans);
+  font-size: 17px;
+  font-weight: 300;
+  color: var(--text);
+  border-radius: 0;
+  transition: border-color 0.3s;
+}
+.field select { appearance: none; cursor: pointer; }
+.field select option { background: var(--bg-elev); color: var(--text); }
+.field input:focus, .field textarea:focus, .field select:focus {
+  outline: none;
+  border-bottom-color: var(--accent);
+}
+.field input::placeholder, .field textarea::placeholder { color: var(--muted); }
+.field textarea { resize: vertical; min-height: 140px; }
+
+.info-list { display: flex; flex-direction: column; }
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 20px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--line);
+}
+.info-row .k {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.info-row .v { font-size: 15px; font-weight: 300; text-align: right; }
+.info-row a.v:hover { color: var(--accent); }
+
+/* --- Quote banner -------------------------------------------------------------------------------------- */
+.quote-banner {
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+  min-height: 380px;
+  display: flex;
+  align-items: flex-end;
+}
+.quote-banner img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(100%) brightness(0.5);
+}
+.quote-banner .inner {
+  position: relative;
+  padding: clamp(28px, 5vw, 56px);
+}
+.quote-banner blockquote {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 300;
+  font-size: clamp(22px, 3.2vw, 36px);
+  line-height: 1.35;
+  max-width: 22ch;
+}
+.quote-banner cite {
+  display: block;
+  margin-top: 18px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* --- CTA + Footer ---------------------------------------------------------------------------------------- */
+.cta {
+  padding: clamp(90px, 14vw, 180px) 0;
+  border-top: 1px solid var(--line);
+  text-align: left;
+}
+.cta .eyebrow { margin-bottom: 28px; }
+.cta h2 {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(40px, 7vw, 96px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  max-width: 14ch;
+}
+.cta h2 em { font-style: italic; color: var(--accent); }
+.cta .cta-actions { margin-top: clamp(32px, 5vw, 56px); display: flex; gap: 18px; flex-wrap: wrap; }
+
+footer {
+  border-top: 1px solid var(--line);
+  padding: 48px 0;
+}
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+.footer-name { font-family: var(--serif); font-size: 19px; }
+.footer-name em { font-style: italic; color: var(--accent); }
+.footer-copy { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; color: var(--muted); margin-top: 6px; }
+.footer-links { display: flex; gap: 26px; flex-wrap: wrap; }
+.footer-links a {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  transition: color 0.3s;
+}
+.footer-links a:hover { color: var(--accent); }
+
+/* --- Page hero (inner pages) -------------------------------------------------------------------------------- */
+.page-hero {
+  padding-top: clamp(150px, 20vh, 220px);
+  padding-bottom: clamp(50px, 8vw, 90px);
+}
+.page-hero h1 {
+  font-family: var(--serif);
+  font-weight: 350;
+  font-size: clamp(42px, 7vw, 92px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin-top: 26px;
+  max-width: 16ch;
+}
+.page-hero h1 em { font-style: italic; font-weight: 300; color: var(--accent); }
+.page-hero .lead { margin-top: 28px; max-width: 640px; }
+.page-hero .hero-actions { margin-top: 36px; }
+
+/* --- Reveal animations ----------------------------------------------------------------------------------------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.9s var(--ease), transform 0.9s var(--ease);
+  transition-delay: var(--d, 0s);
+}
+.reveal.in { opacity: 1; transform: translateY(0); }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+  .reveal { opacity: 1; transform: none; }
+  html { scroll-behavior: auto; }
+}
+
+/* --- Responsive --------------------------------------------------------------------------------------------------- */
+@media (max-width: 980px) {
+  .hero-grid { grid-template-columns: 1fr; }
+  .hero-portrait { max-width: 420px; }
+  .split { grid-template-columns: 1fr; }
+  .split .sticky-col { position: static; }
+  .grid-3 { grid-template-columns: repeat(2, 1fr); }
+  .feature-row { grid-template-columns: 1fr; }
+  .pub-row { grid-template-columns: 1fr; gap: 8px; }
+  .pub-arrow { display: none; }
+  .timeline-item { grid-template-columns: 1fr; gap: 8px; }
+}
+@media (max-width: 760px) {
+  .nav-links { display: none; }
+  .nav-toggle { display: flex; }
+  .grid-2, .grid-3 { grid-template-columns: 1fr; }
+  .form-row { grid-template-columns: 1fr; }
+  .scroll-hint { display: none; }
+  .stats { grid-template-columns: repeat(2, 1fr); }
+}

--- a/assets/js/premium.js
+++ b/assets/js/premium.js
@@ -1,0 +1,85 @@
+/* Shared site behaviour: nav, reveal animations, counters, scroll progress */
+(function () {
+  "use strict";
+
+  // Sticky nav state
+  var nav = document.querySelector(".nav");
+  var progress = document.querySelector(".progress-bar");
+  function onScroll() {
+    if (nav) nav.classList.toggle("scrolled", window.scrollY > 40);
+    if (progress) {
+      var h = document.documentElement.scrollHeight - window.innerHeight;
+      progress.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + "%";
+    }
+  }
+  window.addEventListener("scroll", onScroll, { passive: true });
+  onScroll();
+
+  // Mobile menu
+  var toggle = document.querySelector(".nav-toggle");
+  var menu = document.querySelector(".mobile-menu");
+  if (toggle && menu) {
+    toggle.addEventListener("click", function () {
+      var open = menu.classList.toggle("open");
+      toggle.classList.toggle("open", open);
+      document.body.style.overflow = open ? "hidden" : "";
+    });
+    menu.querySelectorAll("a").forEach(function (a) {
+      a.addEventListener("click", function () {
+        menu.classList.remove("open");
+        toggle.classList.remove("open");
+        document.body.style.overflow = "";
+      });
+    });
+  }
+
+  // Reveal on scroll (staggered via --d set inline or by sibling index)
+  var reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var revealEls = document.querySelectorAll(".reveal");
+  if (reduced || !("IntersectionObserver" in window)) {
+    revealEls.forEach(function (el) { el.classList.add("in"); });
+  } else {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in");
+          io.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.12, rootMargin: "0px 0px -5% 0px" });
+    revealEls.forEach(function (el) { io.observe(el); });
+  }
+
+  // Animated counters: <span class="count" data-target="228">0</span>
+  var counters = document.querySelectorAll(".count");
+  if (counters.length) {
+    var animate = function (el) {
+      var target = parseFloat(el.getAttribute("data-target") || "0");
+      var dur = 1600;
+      var start = null;
+      function step(ts) {
+        if (!start) start = ts;
+        var p = Math.min((ts - start) / dur, 1);
+        var eased = 1 - Math.pow(1 - p, 3);
+        el.textContent = Math.round(target * eased).toLocaleString();
+        if (p < 1) requestAnimationFrame(step);
+      }
+      if (reduced) { el.textContent = target.toLocaleString(); return; }
+      requestAnimationFrame(step);
+    };
+    var cio = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          animate(entry.target);
+          cio.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.4 });
+    counters.forEach(function (el) { cio.observe(el); });
+  }
+
+  // Footer year
+  document.querySelectorAll(".year").forEach(function (el) {
+    el.textContent = new Date().getFullYear();
+  });
+})();

--- a/blogs.html
+++ b/blogs.html
@@ -1,68 +1,15 @@
 <!DOCTYPE html>
-<html class="light" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Blogs & Writing | Dr. Yasas Sri Wickramasinghe</title>
-<meta name="description" content="Technical articles and blog posts by Dr. Yasas Sri Wickramasinghe covering AR/VR, immersive technology, software engineering, and more."/>
+<title>Writing — Dr. Yasas Sri Wickramasinghe</title>
+<meta name="description" content="Articles and essays by Dr. Yasas Sri Wickramasinghe on augmented reality, software engineering, and immersive media."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<script id="tailwind-config">
-  tailwind.config = {
-    darkMode: "class",
-    theme: {
-      extend: {
-        "colors": {
-          "primary-fixed-dim": "#b8c8dc","inverse-on-surface": "#f2f1ee","on-primary-fixed": "#0c1d2b",
-          "on-secondary-fixed": "#261900","error": "#ba1a1a","inverse-primary": "#b8c8dc",
-          "primary": "#051625","error-container": "#ffdad6","outline-variant": "#c4c6cc",
-          "background": "#faf9f6","on-background": "#1a1c1a","surface-variant": "#e3e2e0",
-          "secondary-container": "#fed488","on-tertiary-fixed": "#121e14",
-          "on-secondary-fixed-variant": "#5d4201","on-secondary": "#ffffff","on-primary": "#ffffff",
-          "surface-container": "#efeeeb","surface": "#faf9f6","on-surface-variant": "#43474c",
-          "surface-container-lowest": "#ffffff","on-surface": "#1a1c1a","surface-container-high": "#e9e8e5",
-          "on-tertiary-fixed-variant": "#3c4a3d","secondary-fixed-dim": "#e9c176",
-          "on-secondary-container": "#785a1a","secondary": "#775a19","surface-dim": "#dbdad7",
-          "tertiary": "#0c180e","tertiary-fixed-dim": "#bbcbba","surface-container-low": "#f4f3f1",
-          "on-error": "#ffffff","inverse-surface": "#2f312f","on-tertiary": "#ffffff",
-          "surface-container-highest": "#e3e2e0","on-error-container": "#93000a",
-          "primary-fixed": "#d3e4f8","secondary-fixed": "#ffdea5","primary-container": "#1b2b3a",
-          "tertiary-fixed": "#d7e7d5","tertiary-container": "#202d22","surface-tint": "#506071",
-          "on-tertiary-container": "#869586","on-primary-fixed-variant": "#384858",
-          "on-primary-container": "#8292a5","surface-bright": "#faf9f6","outline": "#74777c"
-        },
-        "borderRadius": {"DEFAULT": "0.125rem","lg": "0.25rem","xl": "0.5rem","full": "0.75rem"},
-        "spacing": {
-          "stack-sm": "12px","margin-desktop": "64px","stack-md": "24px","gutter": "24px",
-          "margin-mobile": "16px","container-max": "1140px","unit": "8px","stack-lg": "48px"
-        },
-        "fontFamily": {
-          "display-lg": ["Newsreader"],"label-md": ["Inter"],"headline-md": ["Newsreader"],
-          "display-lg-mobile": ["Newsreader"],"headline-sm": ["Newsreader"],
-          "body-lg": ["Inter"],"body-md": ["Inter"],"caption": ["Inter"]
-        },
-        "fontSize": {
-          "display-lg": ["48px", {"lineHeight": "1.1", "letterSpacing": "-0.02em", "fontWeight": "600"}],
-          "label-md": ["14px", {"lineHeight": "1.2", "letterSpacing": "0.05em", "fontWeight": "600"}],
-          "headline-md": ["32px", {"lineHeight": "1.3", "fontWeight": "500"}],
-          "display-lg-mobile": ["36px", {"lineHeight": "1.2", "fontWeight": "600"}],
-          "headline-sm": ["24px", {"lineHeight": "1.4", "fontWeight": "500"}],
-          "body-lg": ["18px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "body-md": ["16px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "caption": ["12px", {"lineHeight": "1.4", "fontWeight": "400"}]
-        }
-      }
-    }
-  }
-</script>
-<style>
-  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 24; }
-  .blog-thumb { transition: transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94); }
-  .blog-card:hover .blog-thumb { transform: scale(1.04); }
-</style>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Inter:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/premium.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -72,890 +19,317 @@
   gtag('config', 'G-N2BH0F6SNE');
 </script>
 </head>
-<body class="bg-background text-on-surface">
+<body>
 
-<!-- Navigation -->
-<nav class="w-full top-0 sticky bg-surface border-b border-outline-variant z-50">
-  <div class="flex justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-sm">
-    <a class="font-display-lg text-headline-sm text-primary tracking-tight" href="index.html">Dr. Yasas Sri Wickramasinghe</a>
-    <div class="hidden md:flex items-center gap-gutter">
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="index.html">Home</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="research.html">Research</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="teaching.html">Teaching</a>
-      <a class="font-body-md text-body-md text-primary font-bold border-b-2 border-primary pb-1" href="blogs.html">Blogs</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
-      <a href="assets/files/cv_yasas.pdf" target="_blank" class="ml-4 px-6 py-2 bg-primary text-on-primary font-label-md text-label-md rounded hover:opacity-90 transition-opacity">Curriculum Vitae</a>
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Dr. Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="research.html">Research</a>
+      <a href="teaching.html">Teaching</a>
+      <a class="active" href="blogs.html">Writing</a>
+      <a href="contact.html">Contact</a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">CV <span class="arrow">→</span></a>
     </div>
-    <button class="md:hidden text-primary" onclick="document.getElementById('mobile-menu-b').classList.toggle('hidden')">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-  </div>
-  <div class="hidden md:hidden bg-surface border-t border-outline-variant px-margin-mobile py-stack-md flex flex-col gap-stack-sm" id="mobile-menu-b">
-    <a class="font-body-md text-on-surface-variant" href="index.html">Home</a>
-    <a class="font-body-md text-on-surface-variant" href="research.html">Research</a>
-    <a class="font-body-md text-on-surface-variant" href="teaching.html">Teaching</a>
-    <a class="font-body-md text-primary font-bold" href="blogs.html">Blogs</a>
-    <a class="font-body-md text-on-surface-variant" href="contact.html">Contact</a>
-    <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 w-fit font-label-md text-label-md">Curriculum Vitae</a>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
   </div>
 </nav>
+<div class="mobile-menu">
+  <a href="index.html"><span class="idx">01</span>Home</a>
+  <a href="research.html"><span class="idx">02</span>Research</a>
+  <a href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a class="active" href="blogs.html"><span class="idx">04</span>Writing</a>
+  <a href="contact.html"><span class="idx">05</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
+</div>
 
-<main class="max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop">
-
-  <!-- Hero -->
-  <section class="py-stack-lg border-b border-outline-variant">
-    <div class="max-w-3xl">
-      <span class="font-label-md text-label-md text-secondary uppercase tracking-widest">Writing & Blogging</span>
-      <h1 class="font-display-lg text-display-lg-mobile md:text-display-lg text-primary mt-2 mb-stack-sm">Articles, Insights &amp; Ideas</h1>
-      <p class="font-body-lg text-body-lg text-on-surface-variant">
-        I write about immersive technology, augmented reality, software engineering, and the occasional travel adventure. Published across Bitsrc.io, Medium, and ReadClub.me — reaching an international research and design audience.
-      </p>
-      <div class="flex flex-wrap gap-3 mt-stack-md">
-        <a href="https://blog.bitsrc.io" target="_blank" class="flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors font-label-md text-label-md">
-          <span class="w-2 h-2 rounded-full inline-block" style="background:#f97316"></span> Bitsrc.io
-        </a>
-        <a href="https://yasassri.medium.com" target="_blank" class="flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors font-label-md text-label-md">
-          <span class="w-2 h-2 rounded-full inline-block" style="background:#22c55e"></span> Medium
-        </a>
-        <a href="https://readclub.me" target="_blank" class="flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors font-label-md text-label-md">
-          <span class="w-2 h-2 rounded-full inline-block" style="background:#3b82f6"></span> ReadClub.me
-        </a>
-      </div>
+<header class="page-hero">
+  <div class="container">
+    <span class="eyebrow reveal">Writing &amp; Blogging</span>
+    <h1 class="reveal" style="--d:.1s">Articles, insights &amp; <em>ideas</em>.</h1>
+    <p class="lead reveal" style="--d:.2s">
+      Essays on augmented reality, software engineering, computer architecture, and the occasional road trip — published on ReadClub, Medium, and Bits and Pieces.
+    </p>
+    <div class="hero-actions reveal" style="--d:.3s">
+      <a class="btn" href="https://readclub.me" target="_blank" rel="noopener">ReadClub.me <span class="arrow">↗</span></a>
+      <a class="btn" href="https://yasassri.medium.com" target="_blank" rel="noopener">Medium <span class="arrow">↗</span></a>
+      <a class="btn" href="https://blog.bitsrc.io" target="_blank" rel="noopener">Bits and Pieces <span class="arrow">↗</span></a>
     </div>
-  </section>
-
-  <!-- Stats -->
-  <div class="flex flex-wrap gap-gutter py-stack-md border-b border-outline-variant mb-stack-md">
-    <div class="flex flex-col"><span class="font-display-lg text-primary" style="font-size:28px;line-height:1">30+</span><span class="text-caption font-label-md text-on-surface-variant uppercase mt-1">Articles</span></div>
-    <div class="w-px h-8 bg-outline-variant self-center hidden md:block"></div>
-    <div class="flex flex-col"><span class="font-display-lg text-primary" style="font-size:28px;line-height:1">3</span><span class="text-caption font-label-md text-on-surface-variant uppercase mt-1">Platforms</span></div>
-    <div class="w-px h-8 bg-outline-variant self-center hidden md:block"></div>
-    <div class="flex flex-col"><span class="font-display-lg text-primary" style="font-size:28px;line-height:1">5+</span><span class="text-caption font-label-md text-on-surface-variant uppercase mt-1">Topics</span></div>
   </div>
+</header>
 
-  <!-- Blog Grid -->
-  <section class="pb-stack-lg">
-    <div class="grid grid-cols-2 md:grid-cols-12 gap-3 md:gap-gutter">
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">01</span>
+      <h2>Immersive <em>Technology</em></h2>
+    </div>
+    <div class="grid-3">
 
-      <!-- HERO CARD: AR Metaverse -->
-      <a href="https://readclub.me/design-the-real-world-metaverse-with-augmented-reality-complete-guide/" target="_blank"
-         class="blog-card col-span-2 md:col-span-12 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[320px] md:h-[400px] blog-thumb" style="background:linear-gradient(135deg,#1a0533 0%,#3b1566 50%,#5b2a9a 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 1200 400" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- perspective grid -->
-            <g opacity="0.18">
-              <line x1="600" y1="80" x2="0" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="200" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="400" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="600" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="800" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="1000" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="600" y1="80" x2="1200" y2="400" stroke="white" stroke-width="1"/>
-              <line x1="0" y1="360" x2="1200" y2="360" stroke="white" stroke-width="0.8"/>
-              <line x1="80" y1="320" x2="1120" y2="320" stroke="white" stroke-width="0.7"/>
-              <line x1="180" y1="280" x2="1020" y2="280" stroke="white" stroke-width="0.6"/>
-              <line x1="280" y1="240" x2="920" y2="240" stroke="white" stroke-width="0.5"/>
-              <line x1="370" y1="200" x2="830" y2="200" stroke="white" stroke-width="0.4"/>
-              <line x1="450" y1="160" x2="750" y2="160" stroke="white" stroke-width="0.3"/>
-            </g>
-            <!-- AR anchor markers -->
-            <circle cx="280" cy="180" r="36" stroke="white" stroke-width="1.5" opacity="0.55"/>
-            <circle cx="280" cy="180" r="4" fill="white" opacity="0.7"/>
-            <line x1="250" y1="180" x2="270" y2="180" stroke="white" stroke-width="1" opacity="0.5"/>
-            <line x1="290" y1="180" x2="310" y2="180" stroke="white" stroke-width="1" opacity="0.5"/>
-            <line x1="280" y1="150" x2="280" y2="168" stroke="white" stroke-width="1" opacity="0.5"/>
-            <line x1="280" y1="192" x2="280" y2="210" stroke="white" stroke-width="1" opacity="0.5"/>
-            <circle cx="720" cy="140" r="22" stroke="white" stroke-width="1.2" opacity="0.4"/>
-            <circle cx="720" cy="140" r="3" fill="white" opacity="0.6"/>
-            <circle cx="950" cy="220" r="28" stroke="white" stroke-width="1.2" opacity="0.35"/>
-            <circle cx="950" cy="220" r="3" fill="white" opacity="0.5"/>
-            <!-- connecting lines -->
-            <line x1="316" y1="180" x2="698" y2="140" stroke="white" stroke-width="0.8" opacity="0.2" stroke-dasharray="4 4"/>
-            <line x1="742" y1="140" x2="922" y2="220" stroke="white" stroke-width="0.8" opacity="0.2" stroke-dasharray="4 4"/>
-            <!-- corner AR brackets -->
-            <path d="M 60 30 L 60 80 L 110 80" stroke="white" stroke-width="2" opacity="0.35"/>
-            <path d="M 1140 30 L 1140 80 L 1090 80" stroke="white" stroke-width="2" opacity="0.35"/>
-            <path d="M 60 370 L 60 330 L 110 330" stroke="white" stroke-width="2" opacity="0.25"/>
-            <path d="M 1140 370 L 1140 330 L 1090 330" stroke="white" stroke-width="2" opacity="0.25"/>
-          </svg>
-          <div class="absolute inset-0 flex flex-col justify-end p-6 md:p-8" style="background:linear-gradient(to top, rgba(10,2,26,0.85) 0%, transparent 60%)">
-            <div class="flex items-center gap-3 mb-3">
-              <span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">AR / VR</span>
-              <span class="text-[10px] text-white/70 font-label-md">readclub.me</span>
-            </div>
-            <h3 class="font-display-lg text-white text-[22px] md:text-[28px] leading-tight max-w-2xl">Design the Real-World Metaverse with Augmented Reality — Complete Guide</h3>
-          </div>
-          <div class="absolute inset-0 bg-black/30 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-5 py-3 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">
-              Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span>
-            </div>
-          </div>
+      <a class="article-card reveal" href="https://readclub.me/design-the-real-world-metaverse-with-augmented-reality-complete-guide/" target="_blank" rel="noopener">
+        <div class="article-cover cov-violet" data-num="—01"><span class="cat">AR / VR</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>Design the Real-World Metaverse with Augmented Reality — Complete Guide</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- Hand Tracking AR -->
-      <a href="https://readclub.me/hand-tracking-in-augmented-reality/" target="_blank"
-         class="blog-card col-span-2 md:col-span-7 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[240px] blog-thumb" style="background:linear-gradient(135deg,#042f2e 0%,#0f766e 60%,#14b8a6 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 700 240" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- abstract hand tracking dots -->
-            <circle cx="350" cy="60" r="5" fill="white" opacity="0.5"/>
-            <circle cx="310" cy="90" r="4" fill="white" opacity="0.4"/>
-            <circle cx="390" cy="90" r="4" fill="white" opacity="0.4"/>
-            <circle cx="280" cy="130" r="5" fill="white" opacity="0.45"/>
-            <circle cx="350" cy="120" r="4" fill="white" opacity="0.4"/>
-            <circle cx="420" cy="130" r="5" fill="white" opacity="0.45"/>
-            <circle cx="300" cy="175" r="4" fill="white" opacity="0.35"/>
-            <circle cx="350" cy="170" r="4" fill="white" opacity="0.35"/>
-            <circle cx="400" cy="175" r="4" fill="white" opacity="0.35"/>
-            <circle cx="350" cy="210" r="8" fill="white" opacity="0.3"/>
-            <!-- connecting skeleton lines -->
-            <line x1="350" y1="60" x2="310" y2="90" stroke="white" stroke-width="1" opacity="0.25"/>
-            <line x1="350" y1="60" x2="390" y2="90" stroke="white" stroke-width="1" opacity="0.25"/>
-            <line x1="310" y1="90" x2="280" y2="130" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="310" y1="90" x2="350" y2="120" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="390" y1="90" x2="420" y2="130" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="280" y1="130" x2="300" y2="175" stroke="white" stroke-width="1" opacity="0.18"/>
-            <line x1="350" y1="120" x2="350" y2="170" stroke="white" stroke-width="1" opacity="0.18"/>
-            <line x1="420" y1="130" x2="400" y2="175" stroke="white" stroke-width="1" opacity="0.18"/>
-            <line x1="300" y1="175" x2="350" y2="210" stroke="white" stroke-width="1" opacity="0.15"/>
-            <line x1="400" y1="175" x2="350" y2="210" stroke="white" stroke-width="1" opacity="0.15"/>
-            <!-- tracking circles around key points -->
-            <circle cx="350" cy="60" r="14" stroke="white" stroke-width="1" opacity="0.2"/>
-            <circle cx="350" cy="210" r="18" stroke="white" stroke-width="1" opacity="0.15"/>
-            <!-- scan lines -->
-            <line x1="180" y1="120" x2="520" y2="120" stroke="white" stroke-width="0.5" opacity="0.12" stroke-dasharray="3 6"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">AR / VR</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Hand Tracking in Augmented Reality</h3>
+      <a class="article-card reveal" style="--d:.05s" href="https://readclub.me/hand-tracking-in-augmented-reality/" target="_blank" rel="noopener">
+        <div class="article-cover cov-navy" data-num="—02"><span class="cat">AR / VR</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>Hand Tracking in Augmented Reality</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- Game Dev AR -->
-      <a href="https://readclub.me/game-development-with-augmented-reality/" target="_blank"
-         class="blog-card col-span-2 md:col-span-5 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[240px] blog-thumb" style="background:linear-gradient(135deg,#431407 0%,#9a3412 60%,#ea580c 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 500 240" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- isometric cube 1 -->
-            <polygon points="250,50 310,85 310,155 250,190 190,155 190,85" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="250" y1="50" x2="250" y2="190" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="190" y1="85" x2="310" y2="85" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="190" y1="155" x2="310" y2="155" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- small cube top-right -->
-            <polygon points="390,80 420,97 420,131 390,148 360,131 360,97" stroke="white" stroke-width="1" opacity="0.25"/>
-            <line x1="390" y1="80" x2="390" y2="148" stroke="white" stroke-width="0.8" opacity="0.15"/>
-            <!-- small cube bottom-left -->
-            <polygon points="110,130 140,147 140,181 110,198 80,181 80,147" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- game controller circles (buttons) -->
-            <circle cx="390" cy="180" r="8" stroke="white" stroke-width="1.2" opacity="0.3"/>
-            <circle cx="410" cy="165" r="5" stroke="white" stroke-width="1" opacity="0.25"/>
-            <circle cx="375" cy="165" r="5" stroke="white" stroke-width="1" opacity="0.25"/>
-            <!-- scattered diamonds -->
-            <path d="M 140 60 L 155 75 L 140 90 L 125 75 Z" stroke="white" stroke-width="1" opacity="0.2"/>
-            <path d="M 450 150 L 460 160 L 450 170 L 440 160 Z" stroke="white" stroke-width="1" opacity="0.2"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">AR / Gaming</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Game Development with Augmented Reality</h3>
+      <a class="article-card reveal" style="--d:.1s" href="https://readclub.me/game-development-with-augmented-reality/" target="_blank" rel="noopener">
+        <div class="article-cover cov-plum" data-num="—03"><span class="cat">AR / Gaming</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>Game Development with Augmented Reality</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- Apple M1 -->
-      <a href="https://yasassri.medium.com/computer-architects-view-on-apple-m1-ultra-chip-821805860c42" target="_blank"
-         class="blog-card col-span-1 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#09090b 0%,#18181b 60%,#3f3f46 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- chip die blocks -->
-            <rect x="80" y="40" width="70" height="50" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="160" y="40" width="40" height="50" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="210" y="40" width="60" height="50" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="280" y="40" width="50" height="115" stroke="white" stroke-width="1" opacity="0.15"/>
-            <rect x="80" y="100" width="45" height="55" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="135" y="100" width="75" height="55" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="220" y="100" width="50" height="55" stroke="white" stroke-width="1" opacity="0.2"/>
-            <rect x="80" y="165" width="200" height="30" stroke="white" stroke-width="1" opacity="0.15"/>
-            <!-- trace lines -->
-            <line x1="115" y1="90" x2="115" y2="100" stroke="white" stroke-width="0.5" opacity="0.3"/>
-            <line x1="180" y1="90" x2="180" y2="100" stroke="white" stroke-width="0.5" opacity="0.3"/>
-            <line x1="240" y1="90" x2="240" y2="100" stroke="white" stroke-width="0.5" opacity="0.3"/>
-            <!-- M1 label ghost -->
-            <text x="130" y="145" font-family="monospace" font-size="22" fill="white" opacity="0.08" font-weight="bold">M1</text>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Architecture</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Computer Architect's View on Apple M1 Ultra Chip</h3>
+      <a class="article-card reveal" href="https://yasassri.medium.com/virtual-reality-a-secret-weapon-to-boost-efficiency-of-a-warehouse-3aa065eddea1" target="_blank" rel="noopener">
+        <div class="article-cover cov-teal" data-num="—04"><span class="cat">VR</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>Virtual Reality: A Secret Weapon to Boost Warehouse Efficiency</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- ASML Chip Manufacturing -->
-      <a href="https://readclub.me/asml-chip-manufacturing/" target="_blank"
-         class="blog-card col-span-1 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#020617 0%,#0c1a40 60%,#1e3a8a 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- EUV light beam lines converging -->
-            <line x1="60" y1="0" x2="200" y2="110" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <line x1="100" y1="0" x2="200" y2="110" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="140" y1="0" x2="200" y2="110" stroke="white" stroke-width="0.8" opacity="0.18"/>
-            <line x1="200" y1="110" x2="260" y2="220" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <line x1="200" y1="110" x2="300" y2="220" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="200" y1="110" x2="340" y2="220" stroke="white" stroke-width="0.8" opacity="0.18"/>
-            <!-- lens circles -->
-            <ellipse cx="200" cy="110" rx="45" ry="18" stroke="white" stroke-width="1.5" opacity="0.35"/>
-            <ellipse cx="200" cy="110" rx="28" ry="11" stroke="white" stroke-width="1" opacity="0.25"/>
-            <!-- wafer circle at bottom -->
-            <circle cx="290" cy="190" r="22" stroke="white" stroke-width="1" opacity="0.2"/>
-            <line x1="278" y1="178" x2="302" y2="202" stroke="white" stroke-width="0.5" opacity="0.15"/>
-            <line x1="302" y1="178" x2="278" y2="202" stroke="white" stroke-width="0.5" opacity="0.15"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Architecture</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">ASML Chip Manufacturing: EUV Lithography &amp; Computer Architecture</h3>
+      <a class="article-card reveal" style="--d:.05s" href="https://yasassri.medium.com/computer-architects-view-on-apple-m1-ultra-chip-821805860c42" target="_blank" rel="noopener">
+        <div class="article-cover cov-slate" data-num="—05"><span class="cat">Architecture</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>Computer Architect's View on Apple M1 Ultra Chip</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- VR Warehouse -->
-      <a href="https://yasassri.medium.com/virtual-reality-a-secret-weapon-to-boost-efficiency-of-a-warehouse-3aa065eddea1" target="_blank"
-         class="blog-card col-span-2 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#1e1b4b 0%,#312e81 60%,#4338ca 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- warehouse shelf lines -->
-            <line x1="60" y1="60" x2="340" y2="60" stroke="white" stroke-width="2" opacity="0.25"/>
-            <line x1="60" y1="100" x2="340" y2="100" stroke="white" stroke-width="2" opacity="0.25"/>
-            <line x1="60" y1="140" x2="340" y2="140" stroke="white" stroke-width="2" opacity="0.25"/>
-            <line x1="60" y1="180" x2="340" y2="180" stroke="white" stroke-width="2" opacity="0.2"/>
-            <!-- vertical shelf supports -->
-            <line x1="60" y1="40" x2="60" y2="195" stroke="white" stroke-width="1.5" opacity="0.2"/>
-            <line x1="200" y1="40" x2="200" y2="195" stroke="white" stroke-width="1.5" opacity="0.2"/>
-            <line x1="340" y1="40" x2="340" y2="195" stroke="white" stroke-width="1.5" opacity="0.2"/>
-            <!-- VR grid overlay (perspective) -->
-            <line x1="200" y1="30" x2="60" y2="195" stroke="white" stroke-width="0.5" opacity="0.12" stroke-dasharray="3 5"/>
-            <line x1="200" y1="30" x2="340" y2="195" stroke="white" stroke-width="0.5" opacity="0.12" stroke-dasharray="3 5"/>
-            <!-- box items on shelves -->
-            <rect x="80" y="65" width="25" height="28" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <rect x="115" y="65" width="20" height="28" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <rect x="220" y="105" width="25" height="28" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <rect x="255" y="105" width="30" height="28" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <!-- VR headset icon outline -->
-            <rect x="270" y="40" width="55" height="30" rx="8" stroke="white" stroke-width="1.2" opacity="0.3"/>
-            <line x1="282" y1="55" x2="292" y2="55" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="308" y1="55" x2="318" y2="55" stroke="white" stroke-width="1.5" opacity="0.3"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">VR</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Virtual Reality: A Secret Weapon to Boost Warehouse Efficiency</h3>
-        </div>
-      </a>
-
-      <!-- 3 Strategies Dev Costs -->
-      <a href="https://blog.bitsrc.io/3-strategies-to-reduce-software-development-costs-in-2023-e4514a110959" target="_blank"
-         class="blog-card col-span-2 md:col-span-8 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#022c22 0%,#064e3b 60%,#059669 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 800 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- descending bar chart -->
-            <rect x="120" y="40" width="70" height="140" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.08" opacity="0.5"/>
-            <rect x="220" y="70" width="70" height="110" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.07" opacity="0.45"/>
-            <rect x="320" y="100" width="70" height="80" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.06" opacity="0.4"/>
-            <rect x="420" y="125" width="70" height="55" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.35"/>
-            <rect x="520" y="145" width="70" height="35" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.04" opacity="0.3"/>
-            <!-- baseline -->
-            <line x1="100" y1="180" x2="630" y2="180" stroke="white" stroke-width="1" opacity="0.25"/>
-            <!-- downward trend arrow -->
-            <path d="M 620 60 L 680 120 L 650 120 L 700 170" stroke="white" stroke-width="2" opacity="0.35" fill="none"/>
-            <polygon points="700,170 690,152 710,152" fill="white" opacity="0.35"/>
-            <!-- cost label (abstract) -->
-            <line x1="100" y1="60" x2="115" y2="60" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="107" y1="50" x2="107" y2="70" stroke="white" stroke-width="1.5" opacity="0.3"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Software Eng</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">3 Strategies to Reduce Software Development Costs in 2023</h3>
-        </div>
-      </a>
-
-      <!-- Lazy Loading -->
-      <a href="https://blog.bitsrc.io/effects-of-too-much-lazy-loading-on-performance-4dbe8df33c37" target="_blank"
-         class="blog-card col-span-2 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#451a03 0%,#78350f 60%,#d97706 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- speedometer arc -->
-            <path d="M 80 180 A 120 120 0 0 1 320 180" stroke="white" stroke-width="2.5" opacity="0.3"/>
-            <path d="M 100 180 A 100 100 0 0 1 300 180" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- tick marks -->
-            <line x1="80" y1="180" x2="95" y2="172" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="107" y1="107" x2="118" y2="118" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="200" y1="60" x2="200" y2="75" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="293" y1="107" x2="282" y2="118" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <line x1="320" y1="180" x2="305" y2="172" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <!-- needle (pointing high - too much lazy loading = slow) -->
-            <line x1="200" y1="180" x2="130" y2="100" stroke="white" stroke-width="2.5" opacity="0.5"/>
-            <circle cx="200" cy="180" r="8" fill="white" opacity="0.35"/>
-            <!-- speed lines -->
-            <line x1="40" y1="130" x2="70" y2="130" stroke="white" stroke-width="1.2" opacity="0.2"/>
-            <line x1="30" y1="150" x2="65" y2="150" stroke="white" stroke-width="1.2" opacity="0.15"/>
-            <line x1="45" y1="170" x2="72" y2="170" stroke="white" stroke-width="1.2" opacity="0.12"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Performance</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Effects of Too Much Lazy Loading on Performance</h3>
-        </div>
-      </a>
-
-      <!-- Chrome Features -->
-      <a href="https://blog.bitsrc.io/google-chrome-experimental-features-for-developers-a9a7cc9d1b30" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#1e1b4b 0%,#3730a3 60%,#4f46e5 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- Chrome circle with segments -->
-            <circle cx="150" cy="100" r="70" stroke="white" stroke-width="1.5" opacity="0.25"/>
-            <circle cx="150" cy="100" r="28" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <!-- 3 sector lines from center -->
-            <line x1="150" y1="100" x2="150" y2="30" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <line x1="150" y1="100" x2="211" y2="161" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <line x1="150" y1="100" x2="89" y2="161" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <!-- outer ring tick marks -->
-            <circle cx="150" cy="30" r="3" fill="white" opacity="0.4"/>
-            <circle cx="211" cy="161" r="3" fill="white" opacity="0.4"/>
-            <circle cx="89" cy="161" r="3" fill="white" opacity="0.4"/>
-            <!-- small dot grid -->
-            <circle cx="80" cy="45" r="2" fill="white" opacity="0.2"/>
-            <circle cx="220" cy="45" r="2" fill="white" opacity="0.2"/>
-            <circle cx="80" cy="160" r="2" fill="white" opacity="0.15"/>
-            <circle cx="220" cy="160" r="2" fill="white" opacity="0.15"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Dev Tools</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Google Chrome Experimental Features for Developers</h3>
-        </div>
-      </a>
-
-      <!-- NPM Best Practices -->
-      <a href="https://blog.bitsrc.io/5-best-practices-when-choosing-third-party-npm-packages-2198994357f9" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#450a0a 0%,#7f1d1d 60%,#b91c1c 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- stacked package boxes -->
-            <rect x="65" y="130" width="170" height="45" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.35"/>
-            <rect x="80" y="90" width="140" height="45" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.3"/>
-            <rect x="95" y="55" width="110" height="40" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.25"/>
-            <rect x="110" y="28" width="80" height="32" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.2"/>
-            <!-- version badge dots -->
-            <circle cx="215" cy="143" r="6" stroke="white" stroke-width="1" opacity="0.3"/>
-            <circle cx="200" cy="103" r="5" stroke="white" stroke-width="1" opacity="0.25"/>
-            <circle cx="185" cy="68" r="4" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- npm abstract lines -->
-            <line x1="75" y1="152" x2="105" y2="152" stroke="white" stroke-width="2" opacity="0.25"/>
-            <line x1="90" y1="145" x2="90" y2="165" stroke="white" stroke-width="1.5" opacity="0.25"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">DevOps</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">5 Best Practices When Choosing Third-Party npm Packages</h3>
-        </div>
-      </a>
-
-      <!-- Multi-Core DevTools -->
-      <a href="https://blog.bitsrc.io/simulating-frontends-in-multi-core-devices-using-chrome-devtools-88e86e40abb2" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#111827 0%,#1f2937 60%,#374151 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- CPU core grid 2x3 -->
-            <rect x="50" y="30" width="80" height="60" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.04" opacity="0.3"/>
-            <rect x="170" y="30" width="80" height="60" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.04" opacity="0.3"/>
-            <rect x="50" y="110" width="80" height="60" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <rect x="170" y="110" width="80" height="60" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <!-- connecting data lines -->
-            <line x1="130" y1="60" x2="170" y2="60" stroke="white" stroke-width="0.8" opacity="0.3"/>
-            <line x1="130" y1="140" x2="170" y2="140" stroke="white" stroke-width="0.8" opacity="0.3"/>
-            <line x1="90" y1="90" x2="90" y2="110" stroke="white" stroke-width="0.8" opacity="0.25"/>
-            <line x1="210" y1="90" x2="210" y2="110" stroke="white" stroke-width="0.8" opacity="0.25"/>
-            <!-- activity wave inside top-left core -->
-            <path d="M 60 58 Q 70 45 80 58 Q 90 70 100 58 Q 110 45 120 58" stroke="white" stroke-width="1" opacity="0.35" fill="none"/>
-            <!-- frequency bar inside top-right core -->
-            <rect x="183" y="48" width="5" height="24" fill="white" opacity="0.2"/>
-            <rect x="193" y="55" width="5" height="17" fill="white" opacity="0.2"/>
-            <rect x="203" y="42" width="5" height="30" fill="white" opacity="0.2"/>
-            <rect x="213" y="50" width="5" height="22" fill="white" opacity="0.2"/>
-            <rect x="223" y="60" width="5" height="12" fill="white" opacity="0.2"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Dev Tools</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Simulating Frontends in Multi-Core Devices Using Chrome DevTools</h3>
-        </div>
-      </a>
-
-      <!-- Web Audio -->
-      <a href="https://blog.bitsrc.io/high-fidelity-web-audio-with-javascript-2e5fff0f071d" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#0c1445 0%,#1e3a8a 60%,#3b82f6 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- sound waves (sine curves) -->
-            <path d="M 20 60 Q 50 30 80 60 Q 110 90 140 60 Q 170 30 200 60 Q 230 90 260 60 Q 285 40 300 55" stroke="white" stroke-width="1.5" opacity="0.35" fill="none"/>
-            <path d="M 20 100 Q 55 65 90 100 Q 125 135 160 100 Q 195 65 230 100 Q 260 128 300 105" stroke="white" stroke-width="1.2" opacity="0.28" fill="none"/>
-            <path d="M 20 140 Q 60 115 100 140 Q 140 165 180 140 Q 220 115 260 140 Q 280 152 300 145" stroke="white" stroke-width="1" opacity="0.22" fill="none"/>
-            <path d="M 20 170 Q 65 155 110 170 Q 155 185 200 170 Q 245 155 290 170" stroke="white" stroke-width="0.8" opacity="0.15" fill="none"/>
-            <!-- frequency bars on left -->
-            <rect x="10" y="100" width="4" height="50" fill="white" opacity="0.2"/>
-            <rect x="16" y="85" width="4" height="65" fill="white" opacity="0.2"/>
-            <rect x="22" y="95" width="4" height="55" fill="white" opacity="0.2"/>
-            <rect x="28" y="110" width="4" height="40" fill="white" opacity="0.2"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Web Audio</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">High Fidelity Web Audio with JavaScript</h3>
-        </div>
-      </a>
-
-      <!-- Design System (large) -->
-      <a href="https://levelup.gitconnected.com/creating-a-design-system-using-react-material-ui-498e2e9d3480" target="_blank"
-         class="blog-card col-span-2 md:col-span-6 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[260px] blog-thumb" style="background:linear-gradient(135deg,#2e1065 0%,#5b21b6 60%,#a855f7 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 600 260" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- design system hierarchy -->
-            <rect x="200" y="25" width="200" height="50" stroke="white" stroke-width="1.5" fill="white" fill-opacity="0.05" opacity="0.35"/>
-            <!-- connector lines -->
-            <line x1="300" y1="75" x2="180" y2="110" stroke="white" stroke-width="1" opacity="0.25"/>
-            <line x1="300" y1="75" x2="420" y2="110" stroke="white" stroke-width="1" opacity="0.25"/>
-            <rect x="100" y="110" width="160" height="45" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.3"/>
-            <rect x="340" y="110" width="160" height="45" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.3"/>
-            <!-- lower connectors -->
-            <line x1="180" y1="155" x2="120" y2="185" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <line x1="180" y1="155" x2="220" y2="185" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <line x1="420" y1="155" x2="380" y2="185" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <line x1="420" y1="155" x2="480" y2="185" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <rect x="80" y="185" width="80" height="35" stroke="white" stroke-width="1" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <rect x="180" y="185" width="80" height="35" stroke="white" stroke-width="1" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <rect x="340" y="185" width="80" height="35" stroke="white" stroke-width="1" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <rect x="440" y="185" width="80" height="35" stroke="white" stroke-width="1" fill="white" fill-opacity="0.04" opacity="0.25"/>
-            <!-- decorative circles (component palette) -->
-            <circle cx="50" cy="50" r="20" stroke="white" stroke-width="1" opacity="0.15"/>
-            <circle cx="550" cy="50" r="14" stroke="white" stroke-width="1" opacity="0.12"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Frontend</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Level Up Coding</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Creating a Design System Using React Material UI</h3>
-        </div>
-      </a>
-
-      <!-- Map Libraries React -->
-      <a href="https://blog.bitsrc.io/top-5-map-libraries-for-react-in-2021-20a37ff5234" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[260px] blog-thumb" style="background:linear-gradient(135deg,#1c0400 0%,#78350f 60%,#b45309 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 260" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- map grid -->
-            <line x1="0" y1="65" x2="300" y2="65" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <line x1="0" y1="130" x2="300" y2="130" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <line x1="0" y1="195" x2="300" y2="195" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <line x1="75" y1="0" x2="75" y2="260" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <line x1="150" y1="0" x2="150" y2="260" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <line x1="225" y1="0" x2="225" y2="260" stroke="white" stroke-width="0.7" opacity="0.2"/>
-            <!-- map pins -->
-            <circle cx="150" cy="90" r="10" stroke="white" stroke-width="1.5" opacity="0.45"/>
-            <circle cx="150" cy="90" r="3" fill="white" opacity="0.5"/>
-            <path d="M 145 100 Q 150 120 155 100" stroke="white" stroke-width="1.5" opacity="0.4" fill="none"/>
-            <circle cx="75" cy="160" r="8" stroke="white" stroke-width="1.2" opacity="0.35"/>
-            <circle cx="75" cy="160" r="2.5" fill="white" opacity="0.4"/>
-            <path d="M 71 168 Q 75 183 79 168" stroke="white" stroke-width="1.2" opacity="0.3" fill="none"/>
-            <circle cx="230" cy="195" r="7" stroke="white" stroke-width="1.2" opacity="0.3"/>
-            <circle cx="230" cy="195" r="2" fill="white" opacity="0.35"/>
-            <path d="M 226 202 Q 230 215 234 202" stroke="white" stroke-width="1" opacity="0.25" fill="none"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Frontend</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Top 5 Map Libraries for React in 2021</h3>
-        </div>
-      </a>
-
-      <!-- Rich Text Editors React -->
-      <a href="https://blog.bitsrc.io/top-5-rich-text-editors-for-react-in-2021-628fecf0f7e0" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[260px] blog-thumb" style="background:linear-gradient(135deg,#1e1b4b 0%,#3730a3 60%,#4338ca 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 260" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- toolbar -->
-            <rect x="30" y="30" width="240" height="38" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.06" opacity="0.35"/>
-            <!-- formatting buttons: B I =list -->
-            <rect x="45" y="39" width="20" height="20" stroke="white" stroke-width="1" fill="white" fill-opacity="0.08" opacity="0.4"/>
-            <text x="51" y="54" font-family="serif" font-size="13" fill="white" opacity="0.6" font-weight="bold">B</text>
-            <rect x="75" y="39" width="20" height="20" stroke="white" stroke-width="1" fill="white" fill-opacity="0.08" opacity="0.35"/>
-            <text x="80" y="54" font-family="serif" font-size="13" fill="white" opacity="0.5" font-style="italic">I</text>
-            <rect x="105" y="39" width="20" height="20" stroke="white" stroke-width="1" fill="white" fill-opacity="0.08" opacity="0.3"/>
-            <line x1="111" y1="45" x2="119" y2="45" stroke="white" stroke-width="1.5" opacity="0.45"/>
-            <line x1="111" y1="49" x2="119" y2="49" stroke="white" stroke-width="1.5" opacity="0.45"/>
-            <line x1="111" y1="53" x2="119" y2="53" stroke="white" stroke-width="1.5" opacity="0.45"/>
-            <!-- content lines -->
-            <rect x="30" y="85" width="180" height="10" stroke="none" fill="white" fill-opacity="0.18" rx="2"/>
-            <rect x="30" y="105" width="220" height="10" stroke="none" fill="white" fill-opacity="0.15" rx="2"/>
-            <rect x="30" y="125" width="160" height="10" stroke="none" fill="white" fill-opacity="0.12" rx="2"/>
-            <rect x="30" y="155" width="200" height="10" stroke="none" fill="white" fill-opacity="0.15" rx="2"/>
-            <rect x="30" y="175" width="130" height="10" stroke="none" fill="white" fill-opacity="0.12" rx="2"/>
-            <rect x="30" y="195" width="210" height="10" stroke="none" fill="white" fill-opacity="0.1" rx="2"/>
-            <rect x="30" y="215" width="170" height="10" stroke="none" fill="white" fill-opacity="0.1" rx="2"/>
-            <!-- cursor blink -->
-            <line x1="210" y1="85" x2="210" y2="95" stroke="white" stroke-width="1.5" opacity="0.5"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Frontend</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Top 5 Rich Text Editors for React in 2021</h3>
-        </div>
-      </a>
-
-      <!-- Sri Lankan Fuel App -->
-      <a href="https://readclub.me/i-built-a-free-website-to-help-sri-lankan-drivers-save-thousands-on-fuel-heres-the-story-behind-it/" target="_blank"
-         class="blog-card col-span-2 md:col-span-5 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#1a0000 0%,#7f1d1d 60%,#ef4444 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 500 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- road lanes -->
-            <line x1="50" y1="220" x2="250" y2="0" stroke="white" stroke-width="14" opacity="0.1"/>
-            <line x1="180" y1="220" x2="380" y2="0" stroke="white" stroke-width="14" opacity="0.1"/>
-            <!-- road center dashes -->
-            <line x1="120" y1="200" x2="140" y2="155" stroke="white" stroke-width="2" opacity="0.3" stroke-dasharray="8 8"/>
-            <line x1="250" y1="200" x2="270" y2="155" stroke="white" stroke-width="2" opacity="0.3" stroke-dasharray="8 8"/>
-            <!-- fuel drop shape -->
-            <path d="M 380 60 Q 380 30 360 30 Q 330 30 330 65 Q 330 90 360 100 Q 390 90 380 60 Z" stroke="white" stroke-width="1.5" opacity="0.4" fill="white" fill-opacity="0.06"/>
-            <line x1="340" y1="100" x2="380" y2="100" stroke="white" stroke-width="1.5" opacity="0.3"/>
-            <!-- fuel percentage arc -->
-            <path d="M 340 140 A 25 25 0 0 1 390 140" stroke="white" stroke-width="2" opacity="0.25" fill="none"/>
-            <line x1="365" y1="115" x2="365" y2="140" stroke="white" stroke-width="1.5" opacity="0.25"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Innovation</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">I Built a Free Website to Help Sri Lankan Drivers Save Thousands on Fuel</h3>
-        </div>
-      </a>
-
-      <!-- Free Virtual Queue -->
-      <a href="https://yasassri.medium.com/free-virtual-queue-for-your-business-5b8eb49f1b35" target="_blank"
-         class="blog-card col-span-1 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#1c0400 0%,#9a3412 60%,#f97316 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- queue of circles (people) -->
-            <circle cx="60" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.4"/>
-            <circle cx="110" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.37"/>
-            <circle cx="160" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.33"/>
-            <circle cx="210" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.28"/>
-            <circle cx="260" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.23"/>
-            <circle cx="310" cy="110" r="18" stroke="white" stroke-width="1.5" opacity="0.18"/>
-            <!-- connecting queue line -->
-            <line x1="60" y1="140" x2="310" y2="140" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- forward arrow -->
-            <path d="M 330 110 L 360 110" stroke="white" stroke-width="2.5" opacity="0.45"/>
-            <polygon points="360,103 372,110 360,117" fill="white" opacity="0.45"/>
-            <!-- QR code pattern in corner -->
-            <rect x="30" y="30" width="8" height="8" fill="white" opacity="0.2"/>
-            <rect x="40" y="30" width="8" height="8" fill="white" opacity="0.2"/>
-            <rect x="30" y="40" width="8" height="8" fill="white" opacity="0.2"/>
-            <rect x="42" y="42" width="4" height="4" fill="white" opacity="0.15"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Innovation</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">Free Virtual Queue for Your Business</h3>
-        </div>
-      </a>
-
-      <!-- GitHub Student Pack -->
-      <a href="https://readclub.me/github-student-pack-hidden-treasure-that-most-university-students-unaware/" target="_blank"
-         class="blog-card col-span-1 md:col-span-3 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[220px] blog-thumb" style="background:linear-gradient(135deg,#030712 0%,#0c1445 60%,#1e3a8a 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 300 220" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- code brackets -->
-            <text x="20" y="130" font-family="monospace" font-size="80" fill="white" opacity="0.12">&lt;</text>
-            <text x="190" y="130" font-family="monospace" font-size="80" fill="white" opacity="0.12">&gt;</text>
-            <!-- graduation cap -->
-            <polygon points="150,55 200,75 150,95 100,75" stroke="white" stroke-width="1.5" fill="white" fill-opacity="0.08" opacity="0.4"/>
-            <rect x="135" y="95" width="30" height="35" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.05" opacity="0.3"/>
-            <line x1="200" y1="75" x2="200" y2="110" stroke="white" stroke-width="1.2" opacity="0.25"/>
-            <circle cx="200" cy="115" r="5" stroke="white" stroke-width="1.2" opacity="0.3"/>
-            <!-- tassel -->
-            <line x1="150" y1="130" x2="145" y2="155" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- stars -->
-            <circle cx="50" cy="50" r="2" fill="white" opacity="0.3"/>
-            <circle cx="250" cy="70" r="2" fill="white" opacity="0.3"/>
-            <circle cx="70" cy="180" r="1.5" fill="white" opacity="0.2"/>
-            <circle cx="240" cy="170" r="1.5" fill="white" opacity="0.2"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Education</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">GitHub Student Pack: Hidden Treasure for University Students</h3>
-        </div>
-      </a>
-
-      <!-- NZ Campervan (large) -->
-      <a href="https://readclub.me/new-zealand-campervan-road-trip/" target="_blank"
-         class="blog-card col-span-2 md:col-span-8 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[240px] blog-thumb" style="background:linear-gradient(135deg,#052e16 0%,#14532d 60%,#15803d 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 800 240" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- sky stars -->
-            <circle cx="100" cy="40" r="1.5" fill="white" opacity="0.5"/>
-            <circle cx="200" cy="25" r="1" fill="white" opacity="0.4"/>
-            <circle cx="350" cy="35" r="1.5" fill="white" opacity="0.45"/>
-            <circle cx="500" cy="20" r="1" fill="white" opacity="0.35"/>
-            <circle cx="650" cy="45" r="1.5" fill="white" opacity="0.4"/>
-            <circle cx="750" cy="30" r="1" fill="white" opacity="0.35"/>
-            <circle cx="420" cy="55" r="1" fill="white" opacity="0.3"/>
-            <circle cx="580" cy="60" r="1.5" fill="white" opacity="0.35"/>
-            <!-- mountain silhouette -->
-            <path d="M 0 180 L 120 80 L 240 150 L 350 60 L 480 140 L 570 90 L 680 130 L 800 70 L 800 240 L 0 240 Z" fill="white" fill-opacity="0.1" stroke="white" stroke-width="1" opacity="0.3"/>
-            <!-- closer mountain layer -->
-            <path d="M 0 210 L 100 150 L 200 185 L 320 130 L 440 170 L 560 145 L 680 170 L 800 150 L 800 240 L 0 240 Z" fill="white" fill-opacity="0.07" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <!-- winding road -->
-            <path d="M 400 240 Q 380 210 350 200 Q 320 190 310 175 Q 300 160 320 150 Q 340 140 350 125" stroke="white" stroke-width="3" opacity="0.3" fill="none"/>
-            <!-- road dashes -->
-            <path d="M 395 235 Q 378 207 352 197" stroke="white" stroke-width="1" opacity="0.4" stroke-dasharray="5 8" fill="none"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Travel</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">readclub.me</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">New Zealand Campervan Road Trip</h3>
-        </div>
-      </a>
-
-      <!-- Clean Code JS -->
-      <a href="https://yasassri.medium.com/how-clean-coding-helps-you-to-build-web-applications-quickly-91c5669fe097" target="_blank"
-         class="blog-card col-span-2 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[240px] blog-thumb" style="background:linear-gradient(135deg,#022c22 0%,#065f46 60%,#10b981 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 240" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- code lines of varying width -->
-            <rect x="50" y="40" width="120" height="10" fill="white" fill-opacity="0.25" rx="2"/>
-            <rect x="70" y="60" width="200" height="10" fill="white" fill-opacity="0.2" rx="2"/>
-            <rect x="70" y="80" width="160" height="10" fill="white" fill-opacity="0.2" rx="2"/>
-            <rect x="50" y="110" width="100" height="10" fill="white" fill-opacity="0.25" rx="2"/>
-            <rect x="70" y="130" width="220" height="10" fill="white" fill-opacity="0.18" rx="2"/>
-            <rect x="70" y="150" width="140" height="10" fill="white" fill-opacity="0.18" rx="2"/>
-            <rect x="50" y="180" width="90" height="10" fill="white" fill-opacity="0.22" rx="2"/>
-            <rect x="70" y="200" width="180" height="10" fill="white" fill-opacity="0.16" rx="2"/>
-            <!-- checkmarks next to clean code lines -->
-            <path d="M 285 40 L 295 52 L 315 35" stroke="white" stroke-width="2" opacity="0.45" fill="none"/>
-            <path d="M 305 110 L 315 122 L 335 105" stroke="white" stroke-width="2" opacity="0.4" fill="none"/>
-            <path d="M 255 180 L 265 192 L 285 175" stroke="white" stroke-width="2" opacity="0.35" fill="none"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Software</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[16px] leading-snug text-primary">How Clean Coding Helps You Build Web Applications Quickly</h3>
-        </div>
-      </a>
-
-      <!-- Pulumi AWS -->
-      <a href="https://blog.bitsrc.io/creating-pulumi-aws-components-with-bit-4c3691eb0adb" target="_blank"
-         class="blog-card col-span-1 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#042f2e 0%,#115e59 60%,#0d9488 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- cloud shape 1 -->
-            <path d="M 80 120 Q 80 90 110 90 Q 115 75 135 75 Q 155 60 175 75 Q 195 65 205 80 Q 225 75 230 95 Q 250 90 250 115 Q 250 130 235 130 L 95 130 Q 80 130 80 120 Z" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.06" opacity="0.35"/>
-            <!-- cloud shape 2 (smaller, above) -->
-            <path d="M 220 90 Q 220 68 245 68 Q 250 55 268 55 Q 288 45 305 58 Q 320 52 325 68 Q 340 65 340 85 Q 340 98 328 98 L 232 98 Q 220 98 220 90 Z" stroke="white" stroke-width="1" fill="white" fill-opacity="0.05" opacity="0.28"/>
-            <!-- cloud shape 3 (rightmost) -->
-            <path d="M 290 140 Q 290 118 312 118 Q 316 107 330 107 Q 348 98 363 110 Q 375 106 378 120 Q 392 117 392 135 Q 392 148 382 148 L 300 148 Q 290 148 290 140 Z" stroke="white" stroke-width="1" fill="white" fill-opacity="0.05" opacity="0.25"/>
-            <!-- connecting lines (architecture) -->
-            <line x1="165" y1="130" x2="270" y2="98" stroke="white" stroke-width="0.8" opacity="0.25" stroke-dasharray="4 4"/>
-            <line x1="250" y1="130" x2="320" y2="118" stroke="white" stroke-width="0.8" opacity="0.2" stroke-dasharray="4 4"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Cloud</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Creating Pulumi AWS Components with Bit</h3>
-        </div>
-      </a>
-
-      <!-- Ghost Blog -->
-      <a href="https://yasassri.medium.com/start-a-money-making-blog-on-ghost-497c1d2c99c7" target="_blank"
-         class="blog-card col-span-1 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#1a2000 0%,#365314 60%,#4d7c0f 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- blog layout -->
-            <rect x="50" y="30" width="220" height="28" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.08" rx="2" opacity="0.4"/>
-            <rect x="50" y="70" width="150" height="12" fill="white" fill-opacity="0.15" rx="2"/>
-            <rect x="50" y="90" width="200" height="10" fill="white" fill-opacity="0.12" rx="2"/>
-            <rect x="50" y="108" width="170" height="10" fill="white" fill-opacity="0.12" rx="2"/>
-            <rect x="50" y="126" width="190" height="10" fill="white" fill-opacity="0.1" rx="2"/>
-            <rect x="50" y="144" width="130" height="10" fill="white" fill-opacity="0.1" rx="2"/>
-            <!-- blog image placeholder -->
-            <rect x="290" y="65" width="80" height="60" stroke="white" stroke-width="1" fill="white" fill-opacity="0.05" opacity="0.3"/>
-            <!-- ghost icon circle -->
-            <circle cx="340" cy="160" r="22" stroke="white" stroke-width="1.2" opacity="0.3"/>
-            <circle cx="333" cy="156" r="3" fill="white" opacity="0.4"/>
-            <circle cx="347" cy="156" r="3" fill="white" opacity="0.4"/>
-            <path d="M 318 175 Q 328 182 340 175 Q 352 168 362 175" stroke="white" stroke-width="1" opacity="0.25" fill="none"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Blogging</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Start a Money-Making Blog on Ghost</h3>
-        </div>
-      </a>
-
-      <!-- Black Friday -->
-      <a href="https://yasassri.medium.com/black-friday-gift-ideas-for-him-or-her-in-2022-d476463b6a8f" target="_blank"
-         class="blog-card col-span-2 md:col-span-4 group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[200px] blog-thumb" style="background:linear-gradient(135deg,#1a0000 0%,#4a0404 60%,#991b1b 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 200" preserveAspectRatio="xMidYMid slice" fill="none">
-            <!-- gift box -->
-            <rect x="130" y="110" width="140" height="75" stroke="white" stroke-width="1.5" fill="white" fill-opacity="0.06" opacity="0.4"/>
-            <rect x="115" y="90" width="170" height="28" stroke="white" stroke-width="1.2" fill="white" fill-opacity="0.07" opacity="0.35"/>
-            <!-- bow (X shape) -->
-            <line x1="165" y1="65" x2="235" y2="92" stroke="white" stroke-width="2" opacity="0.4"/>
-            <line x1="235" y1="65" x2="165" y2="92" stroke="white" stroke-width="2" opacity="0.4"/>
-            <circle cx="200" cy="78" r="6" stroke="white" stroke-width="1.5" opacity="0.45"/>
-            <!-- ribbon lines down box -->
-            <line x1="200" y1="90" x2="200" y2="185" stroke="white" stroke-width="1.5" opacity="0.25"/>
-            <line x1="130" y1="104" x2="270" y2="104" stroke="white" stroke-width="1" opacity="0.2"/>
-            <!-- scattered stars -->
-            <circle cx="80" cy="50" r="2" fill="white" opacity="0.35"/>
-            <circle cx="330" cy="40" r="2" fill="white" opacity="0.3"/>
-            <circle cx="60" cy="150" r="1.5" fill="white" opacity="0.25"/>
-            <circle cx="350" cy="160" r="1.5" fill="white" opacity="0.25"/>
-            <circle cx="100" cy="170" r="1" fill="white" opacity="0.2"/>
-            <circle cx="310" cy="170" r="1" fill="white" opacity="0.2"/>
-          </svg>
-          <div class="absolute top-3 left-3"><span class="text-[10px] text-white font-bold uppercase tracking-widest bg-white/15 backdrop-blur-sm px-2 py-1 rounded-sm">Lifestyle</span></div>
-          <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center">
-            <div class="flex items-center gap-2 text-white font-label-md text-label-md bg-white/10 px-4 py-2 rounded-sm backdrop-blur-sm -translate-y-2 group-hover:translate-y-0 transition-transform duration-300">Read Article <span class="material-symbols-outlined text-sm">arrow_forward</span></div>
-          </div>
-        </div>
-        <div class="p-4 flex flex-col gap-1 flex-grow">
-          <span class="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Medium</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary">Black Friday Gift Ideas for Him or Her in 2022</h3>
+      <a class="article-card reveal" style="--d:.1s" href="https://readclub.me/asml-chip-manufacturing/" target="_blank" rel="noopener">
+        <div class="article-cover cov-ember" data-num="—06"><span class="cat">Architecture</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>ASML Chip Manufacturing: EUV Lithography &amp; Computer Architecture</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
     </div>
-  </section>
+  </div>
+</section>
 
-</main>
-
-<!-- Footer -->
-<footer class="w-full mt-stack-lg bg-surface-container-low border-t border-outline-variant">
-  <div class="flex flex-col md:flex-row justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-md">
-    <div class="mb-4 md:mb-0">
-      <span class="font-headline-sm text-headline-sm text-primary">Dr. Yasas Sri Wickramasinghe</span>
-      <p class="font-caption text-caption text-on-surface-variant mt-1 opacity-90">© 2026 Yasas Sri Wickramasinghe. All rights reserved.</p>
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>Software <em>Engineering</em></h2>
     </div>
-    <div class="flex gap-gutter">
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.linkedin.com/in/yasassri" target="_blank">LinkedIn</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://yasassri.medium.com" target="_blank">Medium</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://readclub.me" target="_blank">ReadClub</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
+    <div class="grid-3">
+
+      <a class="article-card reveal" href="https://blog.bitsrc.io/3-strategies-to-reduce-software-development-costs-in-2023-e4514a110959" target="_blank" rel="noopener">
+        <div class="article-cover cov-teal" data-num="—07"><span class="cat">Software Eng</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>3 Strategies to Reduce Software Development Costs in 2023</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://blog.bitsrc.io/effects-of-too-much-lazy-loading-on-performance-4dbe8df33c37" target="_blank" rel="noopener">
+        <div class="article-cover cov-navy" data-num="—08"><span class="cat">Performance</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Effects of Too Much Lazy Loading on Performance</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.1s" href="https://blog.bitsrc.io/google-chrome-experimental-features-for-developers-a9a7cc9d1b30" target="_blank" rel="noopener">
+        <div class="article-cover cov-slate" data-num="—09"><span class="cat">Dev Tools</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Google Chrome Experimental Features for Developers</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" href="https://blog.bitsrc.io/5-best-practices-when-choosing-third-party-npm-packages-2198994357f9" target="_blank" rel="noopener">
+        <div class="article-cover cov-forest" data-num="—10"><span class="cat">DevOps</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>5 Best Practices When Choosing Third-Party npm Packages</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://blog.bitsrc.io/simulating-frontends-in-multi-core-devices-using-chrome-devtools-88e86e40abb2" target="_blank" rel="noopener">
+        <div class="article-cover cov-plum" data-num="—11"><span class="cat">Dev Tools</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Simulating Frontends in Multi-Core Devices Using Chrome DevTools</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.1s" href="https://blog.bitsrc.io/high-fidelity-web-audio-with-javascript-2e5fff0f071d" target="_blank" rel="noopener">
+        <div class="article-cover cov-ember" data-num="—12"><span class="cat">Web Audio</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>High Fidelity Web Audio with JavaScript</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" href="https://levelup.gitconnected.com/creating-a-design-system-using-react-material-ui-498e2e9d3480" target="_blank" rel="noopener">
+        <div class="article-cover cov-violet" data-num="—13"><span class="cat">Frontend</span></div>
+        <div class="article-body">
+          <span class="src">Level Up Coding</span>
+          <h3>Creating a Design System Using React Material UI</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://blog.bitsrc.io/top-5-map-libraries-for-react-in-2021-20a37ff5234" target="_blank" rel="noopener">
+        <div class="article-cover cov-forest" data-num="—14"><span class="cat">Frontend</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Top 5 Map Libraries for React in 2021</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.1s" href="https://blog.bitsrc.io/top-5-rich-text-editors-for-react-in-2021-628fecf0f7e0" target="_blank" rel="noopener">
+        <div class="article-cover cov-navy" data-num="—15"><span class="cat">Frontend</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Top 5 Rich Text Editors for React in 2021</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" href="https://yasassri.medium.com/how-clean-coding-helps-you-to-build-web-applications-quickly-91c5669fe097" target="_blank" rel="noopener">
+        <div class="article-cover cov-slate" data-num="—16"><span class="cat">Software</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>How Clean Coding Helps You Build Web Applications Quickly</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://blog.bitsrc.io/creating-pulumi-aws-components-with-bit-4c3691eb0adb" target="_blank" rel="noopener">
+        <div class="article-cover cov-gold" data-num="—17"><span class="cat">Cloud</span></div>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>Creating Pulumi AWS Components with Bit</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">03</span>
+      <h2>Beyond the <em>Lab</em></h2>
+    </div>
+    <div class="grid-3">
+
+      <a class="article-card reveal" href="https://readclub.me/i-built-a-free-website-to-help-sri-lankan-drivers-save-thousands-on-fuel-heres-the-story-behind-it/" target="_blank" rel="noopener">
+        <div class="article-cover cov-gold" data-num="—18"><span class="cat">Innovation</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>I Built a Free Website to Help Sri Lankan Drivers Save Thousands on Fuel</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://yasassri.medium.com/free-virtual-queue-for-your-business-5b8eb49f1b35" target="_blank" rel="noopener">
+        <div class="article-cover cov-teal" data-num="—19"><span class="cat">Innovation</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>Free Virtual Queue for Your Business</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.1s" href="https://readclub.me/github-student-pack-hidden-treasure-that-most-university-students-unaware/" target="_blank" rel="noopener">
+        <div class="article-cover cov-violet" data-num="—20"><span class="cat">Education</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>GitHub Student Pack: Hidden Treasure for University Students</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" href="https://readclub.me/new-zealand-campervan-road-trip/" target="_blank" rel="noopener">
+        <div class="article-cover cov-forest" data-num="—21"><span class="cat">Travel</span></div>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>New Zealand Campervan Road Trip</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.05s" href="https://yasassri.medium.com/start-a-money-making-blog-on-ghost-497c1d2c99c7" target="_blank" rel="noopener">
+        <div class="article-cover cov-plum" data-num="—22"><span class="cat">Blogging</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>Start a Money-Making Blog on Ghost</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+      <a class="article-card reveal" style="--d:.1s" href="https://yasassri.medium.com/black-friday-gift-ideas-for-him-or-her-in-2022-d476463b6a8f" target="_blank" rel="noopener">
+        <div class="article-cover cov-ember" data-num="—23"><span class="cat">Lifestyle</span></div>
+        <div class="article-body">
+          <span class="src">Medium</span>
+          <h3>Black Friday Gift Ideas for Him or Her in 2022</h3>
+          <span class="read">Read article →</span>
+        </div>
+      </a>
+
+    </div>
+  </div>
+</section>
+
+<section class="cta">
+  <div class="container">
+    <span class="eyebrow reveal">Stay in touch</span>
+    <h2 class="reveal" style="--d:.1s">More essays on <em>immersive media</em>, every month.</h2>
+    <div class="cta-actions reveal" style="--d:.2s">
+      <a class="btn btn-solid" href="https://readclub.me" target="_blank" rel="noopener">Follow on ReadClub <span class="arrow">↗</span></a>
+      <a class="btn" href="https://yasassri.medium.com" target="_blank" rel="noopener">Follow on Medium ↗</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Dr. Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
+    </div>
+    <div class="footer-links">
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://yasassri.medium.com" target="_blank" rel="noopener">Medium</a>
+      <a href="https://readclub.me" target="_blank" rel="noopener">ReadClub</a>
+      <a href="contact.html">Contact</a>
     </div>
   </div>
 </footer>
 
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.style.opacity = '1';
-          entry.target.style.transform = 'translateY(0)';
-        }
-      });
-    }, { threshold: 0.05 });
-    document.querySelectorAll('.blog-card').forEach((el, i) => {
-      el.style.opacity = '0';
-      el.style.transform = 'translateY(20px)';
-      el.style.transition = `opacity 0.5s ease ${i * 0.05}s, transform 0.5s ease ${i * 0.05}s`;
-      observer.observe(el);
-    });
-  });
-</script>
+<script src="assets/js/premium.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,132 +1,15 @@
 <!DOCTYPE html>
-<html class="light" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Contact | Dr. Yasas Sri Wickramasinghe</title>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;500;600&family=Inter:wght@400;500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<script id="tailwind-config">
-  tailwind.config = {
-    darkMode: "class",
-    theme: {
-      extend: {
-        "colors": {
-          "primary-fixed-dim": "#b8c8dc",
-          "inverse-on-surface": "#f2f1ee",
-          "on-primary-fixed": "#0c1d2b",
-          "on-secondary-fixed": "#261900",
-          "error": "#ba1a1a",
-          "inverse-primary": "#b8c8dc",
-          "primary": "#051625",
-          "error-container": "#ffdad6",
-          "outline-variant": "#c4c6cc",
-          "background": "#faf9f6",
-          "on-background": "#1a1c1a",
-          "surface-variant": "#e3e2e0",
-          "secondary-container": "#fed488",
-          "on-tertiary-fixed": "#121e14",
-          "on-secondary-fixed-variant": "#5d4201",
-          "on-secondary": "#ffffff",
-          "on-primary": "#ffffff",
-          "surface-container": "#efeeeb",
-          "surface": "#faf9f6",
-          "on-surface-variant": "#43474c",
-          "surface-container-lowest": "#ffffff",
-          "on-surface": "#1a1c1a",
-          "surface-container-high": "#e9e8e5",
-          "on-tertiary-fixed-variant": "#3c4a3d",
-          "secondary-fixed-dim": "#e9c176",
-          "on-secondary-container": "#785a1a",
-          "secondary": "#775a19",
-          "surface-dim": "#dbdad7",
-          "tertiary": "#0c180e",
-          "tertiary-fixed-dim": "#bbcbba",
-          "surface-container-low": "#f4f3f1",
-          "on-error": "#ffffff",
-          "inverse-surface": "#2f312f",
-          "on-tertiary": "#ffffff",
-          "surface-container-highest": "#e3e2e0",
-          "on-error-container": "#93000a",
-          "primary-fixed": "#d3e4f8",
-          "secondary-fixed": "#ffdea5",
-          "primary-container": "#1b2b3a",
-          "tertiary-fixed": "#d7e7d5",
-          "tertiary-container": "#202d22",
-          "surface-tint": "#506071",
-          "on-tertiary-container": "#869586",
-          "on-primary-fixed-variant": "#384858",
-          "on-primary-container": "#8292a5",
-          "surface-bright": "#faf9f6",
-          "outline": "#74777c"
-        },
-        "borderRadius": {
-          "DEFAULT": "0.125rem",
-          "lg": "0.25rem",
-          "xl": "0.5rem",
-          "full": "0.75rem"
-        },
-        "spacing": {
-          "stack-sm": "12px",
-          "margin-desktop": "64px",
-          "stack-md": "24px",
-          "gutter": "24px",
-          "margin-mobile": "16px",
-          "container-max": "1140px",
-          "unit": "8px",
-          "stack-lg": "48px"
-        },
-        "fontFamily": {
-          "display-lg": ["Newsreader"],
-          "label-md": ["Inter"],
-          "headline-md": ["Newsreader"],
-          "display-lg-mobile": ["Newsreader"],
-          "headline-sm": ["Newsreader"],
-          "body-lg": ["Inter"],
-          "body-md": ["Inter"],
-          "caption": ["Inter"]
-        },
-        "fontSize": {
-          "display-lg": ["48px", {"lineHeight": "1.1", "letterSpacing": "-0.02em", "fontWeight": "600"}],
-          "label-md": ["14px", {"lineHeight": "1.2", "letterSpacing": "0.05em", "fontWeight": "600"}],
-          "headline-md": ["32px", {"lineHeight": "1.3", "fontWeight": "500"}],
-          "display-lg-mobile": ["36px", {"lineHeight": "1.2", "fontWeight": "600"}],
-          "headline-sm": ["24px", {"lineHeight": "1.4", "fontWeight": "500"}],
-          "body-lg": ["18px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "body-md": ["16px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "caption": ["12px", {"lineHeight": "1.4", "fontWeight": "400"}]
-        }
-      },
-    },
-  }
-</script>
-<style>
-  .material-symbols-outlined {
-    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-    display: inline-block;
-    vertical-align: middle;
-  }
-  body { background-color: #faf9f6; color: #1a1c1a; -webkit-font-smoothing: antialiased; }
-  .contact-input {
-    border: none;
-    border-bottom: 1px solid #74777c;
-    background: transparent;
-    transition: border-color 0.2s ease-in-out;
-    border-radius: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-  .contact-input:focus {
-    outline: none;
-    border-bottom: 1px solid #775a19;
-    box-shadow: none;
-  }
-  .academic-card {
-    background: #ffffff;
-    border: 1px solid #e3e2e0;
-  }
-</style>
+<title>Contact — Dr. Yasas Sri Wickramasinghe</title>
+<meta name="description" content="Contact Dr. Yasas Sri Wickramasinghe for research collaborations, speaking engagements, and academic mentorship."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Inter:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/premium.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -136,174 +19,123 @@
   gtag('config', 'G-N2BH0F6SNE');
 </script>
 </head>
-<body class="font-body-md text-body-md bg-background">
+<body>
 
-<!-- TopNavBar -->
-<nav class="w-full top-0 sticky bg-surface z-50 border-b border-outline-variant">
-  <div class="flex justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-sm">
-    <a class="font-display-lg text-headline-sm text-primary tracking-tight" href="index.html">Dr. Yasas Sri Wickramasinghe</a>
-    <div class="hidden md:flex gap-gutter items-center">
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="index.html">Home</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="research.html">Research</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="teaching.html">Teaching</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="blogs.html">Blogs</a>
-      <a class="font-body-md text-body-md text-primary font-bold border-b-2 border-primary pb-1" href="contact.html">Contact</a>
-      <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 font-label-md text-label-md hover:opacity-80 transition-opacity">Curriculum Vitae</a>
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Dr. Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="research.html">Research</a>
+      <a href="teaching.html">Teaching</a>
+      <a href="blogs.html">Writing</a>
+      <a class="active" href="contact.html">Contact</a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">CV <span class="arrow">→</span></a>
     </div>
-    <button class="md:hidden text-primary" onclick="document.getElementById('mobile-menu-c').classList.toggle('hidden')">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-  </div>
-  <div class="hidden md:hidden bg-surface border-t border-outline-variant px-margin-mobile py-stack-md flex flex-col gap-stack-sm" id="mobile-menu-c">
-    <a class="font-body-md text-on-surface-variant" href="index.html">Home</a>
-    <a class="font-body-md text-on-surface-variant" href="research.html">Research</a>
-    <a class="font-body-md text-on-surface-variant" href="teaching.html">Teaching</a>
-    <a class="font-body-md text-on-surface-variant" href="blogs.html">Blogs</a>
-    <a class="font-body-md text-primary font-bold" href="contact.html">Contact</a>
-    <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 w-fit font-label-md text-label-md">Curriculum Vitae</a>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
   </div>
 </nav>
+<div class="mobile-menu">
+  <a href="index.html"><span class="idx">01</span>Home</a>
+  <a href="research.html"><span class="idx">02</span>Research</a>
+  <a href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a href="blogs.html"><span class="idx">04</span>Writing</a>
+  <a class="active" href="contact.html"><span class="idx">05</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
+</div>
 
-<main class="max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-lg min-h-screen">
-
-  <!-- Header Section -->
-  <section class="mb-stack-lg max-w-2xl">
-    <h1 class="font-display-lg text-display-lg-mobile md:text-display-lg text-primary mb-stack-sm">Inquiries &amp; Correspondence</h1>
-    <p class="font-body-lg text-body-lg text-on-surface-variant">
+<header class="page-hero">
+  <div class="container">
+    <span class="eyebrow reveal">Contact</span>
+    <h1 class="reveal" style="--d:.1s">Inquiries &amp; <em>correspondence</em>.</h1>
+    <p class="lead reveal" style="--d:.2s">
       Whether for research collaborations, speaking engagements, tech talks, or academic mentorship — please feel free to reach out using the form below.
     </p>
-  </section>
+  </div>
+</header>
 
-  <!-- Main Grid Layout -->
-  <div class="grid grid-cols-1 lg:grid-cols-12 gap-gutter">
+<section class="section">
+  <div class="container split" style="grid-template-columns: 1.3fr 1fr;">
 
-    <!-- Contact Form Column -->
-    <div class="lg:col-span-7">
-      <form class="flex flex-col gap-stack-md" action="https://formspree.io/f/xleookvv" method="post">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-stack-md">
-          <div class="flex flex-col">
-            <label class="font-label-md text-label-md text-on-surface-variant mb-2" for="name">FULL NAME</label>
-            <input class="contact-input font-body-md" id="name" name="name" placeholder="Enter your full name" required type="text"/>
-          </div>
-          <div class="flex flex-col">
-            <label class="font-label-md text-label-md text-on-surface-variant mb-2" for="email">EMAIL ADDRESS</label>
-            <input class="contact-input font-body-md" id="email" name="email" placeholder="yourname@example.com" required type="email"/>
-          </div>
+    <form class="form-grid reveal" action="https://formspree.io/f/xleookvv" method="post">
+      <div class="form-row">
+        <div class="field">
+          <label for="name">Full Name</label>
+          <input id="name" name="name" placeholder="Enter your full name" required type="text"/>
         </div>
-        <div class="flex flex-col">
-          <label class="font-label-md text-label-md text-on-surface-variant mb-2" for="subject">SUBJECT</label>
-          <select class="contact-input font-body-md appearance-none" id="subject" name="subject">
-            <option value="research">Research Collaboration</option>
-            <option value="speaking">Tech Talk / Speaking Engagement</option>
-            <option value="teaching">Teaching &amp; Lectures</option>
-            <option value="mentoring">Project Mentoring</option>
-            <option value="other">General Inquiry</option>
-          </select>
+        <div class="field">
+          <label for="email">Email Address</label>
+          <input id="email" name="email" placeholder="yourname@example.com" required type="email"/>
         </div>
-        <div class="flex flex-col">
-          <label class="font-label-md text-label-md text-on-surface-variant mb-2" for="message">MESSAGE</label>
-          <textarea class="contact-input font-body-md resize-none" id="message" name="message" placeholder="Please type your message here..." required rows="6"></textarea>
-        </div>
-        <div class="mt-stack-sm">
-          <button class="bg-primary text-on-primary px-10 py-4 font-label-md text-label-md hover:bg-opacity-90 transition-all flex items-center gap-stack-sm group" type="submit">
-            <span>SEND MESSAGE</span>
-            <span class="material-symbols-outlined group-hover:translate-x-1 transition-transform">send</span>
-          </button>
-        </div>
-      </form>
-    </div>
+      </div>
+      <div class="field">
+        <label for="subject">Subject</label>
+        <select id="subject" name="subject">
+          <option value="research">Research Collaboration</option>
+          <option value="speaking">Tech Talk / Speaking Engagement</option>
+          <option value="teaching">Teaching &amp; Lectures</option>
+          <option value="mentoring">Project Mentoring</option>
+          <option value="other">General Inquiry</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="message">Message</label>
+        <textarea id="message" name="message" placeholder="Please type your message here..." required rows="6"></textarea>
+      </div>
+      <div>
+        <button class="btn btn-solid" type="submit">Send Message <span class="arrow">→</span></button>
+      </div>
+    </form>
 
-    <!-- Information Column -->
-    <div class="lg:col-span-5 space-y-stack-md">
+    <div style="display:flex; flex-direction:column; gap:24px;">
 
-      <!-- Office Info Card -->
-      <div class="academic-card p-stack-md">
-        <h2 class="font-headline-sm text-headline-sm text-primary mb-stack-sm flex items-center gap-2">
-          <span class="material-symbols-outlined text-secondary">location_on</span>
-          Location
-        </h2>
-        <div class="space-y-stack-sm border-t border-outline-variant pt-stack-sm">
-          <p class="font-body-md text-on-surface">
-            <strong class="text-primary">HIT Lab NZ / Yoobee Colleges</strong><br/>
-            University of Canterbury<br/>
-            Christchurch 8041<br/>
-            New Zealand
-          </p>
-          <p class="font-caption text-caption text-on-surface-variant pt-1">
-            Originally from Colombo, Sri Lanka.
-          </p>
+      <div class="card reveal" style="--d:.1s">
+        <span class="kicker">Location</span>
+        <p style="color:var(--text); font-size:16px;">
+          <strong>HIT Lab NZ / Yoobee Colleges</strong><br/>
+          University of Canterbury<br/>
+          Christchurch 8041, New Zealand
+        </p>
+        <p style="margin-top:14px; font-family:var(--mono); font-size:11px; letter-spacing:.1em; color:var(--muted);">ORIGINALLY FROM COLOMBO, SRI LANKA</p>
+        <a class="link-arrow" style="margin-top:18px;" href="https://www.google.com/maps/search/University+of+Canterbury+Christchurch" target="_blank" rel="noopener">Open Map ↗</a>
+      </div>
+
+      <div class="card reveal" style="--d:.2s">
+        <span class="kicker">Direct Contact</span>
+        <div class="info-list">
+          <div class="info-row"><span class="k">Email</span><a class="v" href="mailto:yasassriofficial@gmail.com">yasassriofficial@gmail.com</a></div>
+          <div class="info-row"><span class="k">LinkedIn</span><a class="v" href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">linkedin.com/in/yasassri</a></div>
+          <div class="info-row"><span class="k">Instagram</span><a class="v" href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">@yasassri.me</a></div>
+          <div class="info-row" style="border-bottom:none;"><span class="k">Availability</span><span class="v">Mon — Sat, 10:00 — 17:00</span></div>
         </div>
       </div>
 
-      <!-- Contact Details Card -->
-      <div class="academic-card p-stack-md">
-        <h2 class="font-headline-sm text-headline-sm text-primary mb-stack-sm flex items-center gap-2">
-          <span class="material-symbols-outlined text-secondary">contact_mail</span>
-          Direct Contact
-        </h2>
-        <div class="space-y-stack-sm border-t border-outline-variant pt-stack-sm">
-          <div class="flex justify-between items-center group">
-            <span class="font-label-md text-on-surface-variant">EMAIL</span>
-            <a class="font-body-md text-primary hover:text-secondary transition-colors" href="mailto:yasassriofficial@gmail.com">yasassriofficial@gmail.com</a>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="font-label-md text-on-surface-variant">LINKEDIN</span>
-            <a class="font-body-md text-primary hover:text-secondary transition-colors" href="https://www.linkedin.com/in/yasassri" target="_blank">linkedin.com/in/yasassri</a>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="font-label-md text-on-surface-variant">INSTAGRAM</span>
-            <a class="font-body-md text-primary hover:text-secondary transition-colors" href="https://www.instagram.com/yasassri.me" target="_blank">@yasassri.me</a>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="font-label-md text-on-surface-variant">AVAILABILITY</span>
-            <span class="font-body-md text-on-surface">Mon – Sat, 10:00 – 17:00</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Office / Campus Image -->
-      <div class="relative w-full aspect-video group overflow-hidden academic-card">
-        <img alt="Dr. Wickramasinghe at University of Canterbury" class="w-full h-full object-cover grayscale-[30%] group-hover:scale-105 transition-transform duration-700" src="assets/images/experience-img.jpg" onerror="this.src='assets/images/photography_img6.jpg'"/>
-        <div class="absolute inset-0 bg-primary/10 group-hover:bg-transparent transition-colors"></div>
-        <div class="absolute bottom-4 left-4 bg-white/90 backdrop-blur px-4 py-2 border border-outline-variant">
-          <span class="font-caption text-caption text-on-surface flex items-center gap-1">
-            <span class="material-symbols-outlined text-[14px]">info</span>
-            University of Canterbury, NZ
-          </span>
-        </div>
-        <a aria-label="Open Map" class="absolute inset-0 z-10" href="https://www.google.com/maps/search/University+of+Canterbury+Christchurch" target="_blank"></a>
+      <div class="reveal" style="--d:.3s; position:relative; border-radius:6px; overflow:hidden; border:1px solid var(--line); aspect-ratio:16/10;">
+        <img alt="Dr. Wickramasinghe at University of Canterbury" src="assets/images/experience-img.jpg" onerror="this.src='assets/images/photography_img6.jpg'" style="width:100%; height:100%; object-fit:cover; filter:grayscale(60%) brightness(.85);"/>
+        <span style="position:absolute; bottom:14px; left:14px; font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; background:rgba(11,11,13,.7); backdrop-filter:blur(8px); padding:8px 14px; border-radius:3px; color:var(--text-dim);">University of Canterbury · NZ</span>
       </div>
 
     </div>
   </div>
-</main>
+</section>
 
-<!-- Footer -->
-<footer class="w-full mt-stack-lg bg-surface-container-low border-t border-outline-variant">
-  <div class="flex flex-col md:flex-row justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-md">
-    <div class="mb-stack-sm md:mb-0">
-      <span class="font-headline-sm text-headline-sm text-primary">Dr. Yasas Sri Wickramasinghe</span>
-      <p class="font-caption text-caption text-on-surface-variant mt-1">© 2026 Yasas Sri Wickramasinghe. All rights reserved.</p>
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Dr. Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
     </div>
-    <div class="flex gap-stack-md items-center">
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.linkedin.com/in/yasassri" target="_blank">LinkedIn</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.instagram.com/yasassri.me" target="_blank">Instagram</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://twitter.com/sri_yasas" target="_blank">Twitter/X</a>
-      <a class="font-caption text-caption text-primary underline" href="contact.html">Contact</a>
+    <div class="footer-links">
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">Instagram</a>
+      <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter/X</a>
+      <a href="mailto:yasassriofficial@gmail.com">Email</a>
     </div>
   </div>
 </footer>
 
-<script>
-  const inputs = document.querySelectorAll('.contact-input');
-  inputs.forEach(input => {
-    input.addEventListener('focus', () => {
-      input.parentElement.querySelector('label').style.color = '#775a19';
-    });
-    input.addEventListener('blur', () => {
-      input.parentElement.querySelector('label').style.color = '#43474c';
-    });
-  });
-</script>
+<script src="assets/js/premium.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,115 +1,16 @@
 <!DOCTYPE html>
-<html class="light" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Dr. Yasas Sri Wickramasinghe | Academic Portfolio</title>
+<title>Dr. Yasas Sri Wickramasinghe — Augmented Reality &amp; Spatial Computing</title>
 <meta name="author" content="Yasas Sri Wickramasinghe"/>
-<meta name="description" content="Yasas Sri Wickramasinghe - Postdoctoral Researcher and Senior Lecturer specialising in Augmented Reality and Spatial Computing."/>
+<meta name="description" content="Dr. Yasas Sri Wickramasinghe — Postdoctoral Researcher at HIT Lab NZ and Senior Lecturer at Yoobee Colleges, specialising in Augmented Reality and Spatial Computing."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<script id="tailwind-config">
-  tailwind.config = {
-    darkMode: "class",
-    theme: {
-      extend: {
-        "colors": {
-          "primary-fixed-dim": "#b8c8dc",
-          "inverse-on-surface": "#f2f1ee",
-          "on-primary-fixed": "#0c1d2b",
-          "on-secondary-fixed": "#261900",
-          "error": "#ba1a1a",
-          "inverse-primary": "#b8c8dc",
-          "primary": "#051625",
-          "error-container": "#ffdad6",
-          "outline-variant": "#c4c6cc",
-          "background": "#faf9f6",
-          "on-background": "#1a1c1a",
-          "surface-variant": "#e3e2e0",
-          "secondary-container": "#fed488",
-          "on-tertiary-fixed": "#121e14",
-          "on-secondary-fixed-variant": "#5d4201",
-          "on-secondary": "#ffffff",
-          "on-primary": "#ffffff",
-          "surface-container": "#efeeeb",
-          "surface": "#faf9f6",
-          "on-surface-variant": "#43474c",
-          "surface-container-lowest": "#ffffff",
-          "on-surface": "#1a1c1a",
-          "surface-container-high": "#e9e8e5",
-          "on-tertiary-fixed-variant": "#3c4a3d",
-          "secondary-fixed-dim": "#e9c176",
-          "on-secondary-container": "#785a1a",
-          "secondary": "#775a19",
-          "surface-dim": "#dbdad7",
-          "tertiary": "#0c180e",
-          "tertiary-fixed-dim": "#bbcbba",
-          "surface-container-low": "#f4f3f1",
-          "on-error": "#ffffff",
-          "inverse-surface": "#2f312f",
-          "on-tertiary": "#ffffff",
-          "surface-container-highest": "#e3e2e0",
-          "on-error-container": "#93000a",
-          "primary-fixed": "#d3e4f8",
-          "secondary-fixed": "#ffdea5",
-          "primary-container": "#1b2b3a",
-          "tertiary-fixed": "#d7e7d5",
-          "tertiary-container": "#202d22",
-          "surface-tint": "#506071",
-          "on-tertiary-container": "#869586",
-          "on-primary-fixed-variant": "#384858",
-          "on-primary-container": "#8292a5",
-          "surface-bright": "#faf9f6",
-          "outline": "#74777c"
-        },
-        "borderRadius": {
-          "DEFAULT": "0.125rem",
-          "lg": "0.25rem",
-          "xl": "0.5rem",
-          "full": "0.75rem"
-        },
-        "spacing": {
-          "stack-sm": "12px",
-          "margin-desktop": "64px",
-          "stack-md": "24px",
-          "gutter": "24px",
-          "margin-mobile": "16px",
-          "container-max": "1140px",
-          "unit": "8px",
-          "stack-lg": "48px"
-        },
-        "fontFamily": {
-          "display-lg": ["Newsreader"],
-          "label-md": ["Inter"],
-          "headline-md": ["Newsreader"],
-          "display-lg-mobile": ["Newsreader"],
-          "headline-sm": ["Newsreader"],
-          "body-lg": ["Inter"],
-          "body-md": ["Inter"],
-          "caption": ["Inter"]
-        },
-        "fontSize": {
-          "display-lg": ["48px", {"lineHeight": "1.1", "letterSpacing": "-0.02em", "fontWeight": "600"}],
-          "label-md": ["14px", {"lineHeight": "1.2", "letterSpacing": "0.05em", "fontWeight": "600"}],
-          "headline-md": ["32px", {"lineHeight": "1.3", "fontWeight": "500"}],
-          "display-lg-mobile": ["36px", {"lineHeight": "1.2", "fontWeight": "600"}],
-          "headline-sm": ["24px", {"lineHeight": "1.4", "fontWeight": "500"}],
-          "body-lg": ["18px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "body-md": ["16px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "caption": ["12px", {"lineHeight": "1.4", "fontWeight": "400"}]
-        }
-      },
-    },
-  }
-</script>
-<style>
-  .material-symbols-outlined {
-    font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 24;
-  }
-</style>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Inter:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/premium.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -119,425 +20,274 @@
   gtag('config', 'G-N2BH0F6SNE');
 </script>
 </head>
-<body class="bg-background text-on-surface selection:bg-primary-fixed selection:text-on-primary-fixed">
+<body>
 
-<!-- Top Navigation Bar -->
-<nav class="w-full top-0 sticky bg-surface border-b border-outline-variant z-50">
-  <div class="flex justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-sm">
-    <a class="font-display-lg text-headline-sm text-primary tracking-tight" href="index.html">
-      Dr. Yasas Sri Wickramasinghe
-    </a>
-    <div class="hidden md:flex items-center gap-gutter">
-      <a class="font-body-md text-body-md text-primary font-bold border-b-2 border-primary pb-1" href="index.html">Home</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="research.html">Research</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="teaching.html">Teaching</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="blogs.html">Blogs</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
-      <a href="assets/files/cv_yasas.pdf" target="_blank" class="ml-4 px-6 py-2 bg-primary text-on-primary font-label-md text-label-md rounded hover:opacity-90 transition-opacity">
-        Curriculum Vitae
-      </a>
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Dr. Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a class="active" href="index.html">Home</a>
+      <a href="research.html">Research</a>
+      <a href="teaching.html">Teaching</a>
+      <a href="blogs.html">Writing</a>
+      <a href="contact.html">Contact</a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">CV <span class="arrow">→</span></a>
     </div>
-    <!-- Mobile Toggle -->
-    <button class="md:hidden text-primary" onclick="document.getElementById('mobile-menu').classList.toggle('hidden')">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-  </div>
-  <!-- Mobile Menu -->
-  <div class="hidden md:hidden bg-surface border-t border-outline-variant px-margin-mobile py-stack-md flex flex-col gap-stack-sm" id="mobile-menu">
-    <a class="font-body-md text-primary font-bold" href="index.html">Home</a>
-    <a class="font-body-md text-on-surface-variant" href="research.html">Research</a>
-    <a class="font-body-md text-on-surface-variant" href="teaching.html">Teaching</a>
-    <a class="font-body-md text-on-surface-variant" href="blogs.html">Blogs</a>
-    <a class="font-body-md text-on-surface-variant" href="contact.html">Contact</a>
-    <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 w-fit font-label-md text-label-md">Curriculum Vitae</a>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
   </div>
 </nav>
+<div class="mobile-menu">
+  <a class="active" href="index.html"><span class="idx">01</span>Home</a>
+  <a href="research.html"><span class="idx">02</span>Research</a>
+  <a href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a href="blogs.html"><span class="idx">04</span>Writing</a>
+  <a href="contact.html"><span class="idx">05</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
+</div>
 
-<main class="max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop">
-
-  <!-- Hero Section -->
-  <section class="py-stack-lg md:py-24 grid grid-cols-1 md:grid-cols-12 gap-gutter items-center">
-    <div class="md:col-span-7 space-y-stack-md">
-      <span class="font-label-md text-label-md text-secondary uppercase tracking-widest">Postdoctoral Researcher &amp; Senior Lecturer</span>
-      <h1 class="font-display-lg text-display-lg-mobile md:text-display-lg text-primary max-w-2xl">
-        Designing immersive systems at the frontier of augmented reality and human interaction.
-      </h1>
-      <p class="font-body-lg text-body-lg text-on-surface-variant max-w-xl">
-        Dedicated to advancing location-based AR and understanding how spatial computing reshapes human cognition and behaviour. Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) collaborating with Sony Interactive Entertainment, and Senior Lecturer at Yoobee Colleges.
+<header class="hero">
+  <div class="hero-glow"></div>
+  <div class="container hero-grid">
+    <div>
+      <span class="eyebrow reveal">Postdoctoral Researcher · Senior Lecturer</span>
+      <h1 class="reveal" style="--d:.1s">Designing immersive systems at the frontier of <em>augmented reality</em> &amp; human interaction.</h1>
+      <p class="lead hero-sub reveal" style="--d:.2s">
+        Advancing location-based AR and understanding how spatial computing reshapes human cognition and behaviour — at HIT Lab NZ (University of Canterbury) in collaboration with Sony Interactive Entertainment, and at Yoobee Colleges.
       </p>
-      <div class="flex flex-wrap gap-4 pt-stack-sm">
-        <a class="px-8 py-3 bg-primary text-on-primary font-label-md text-label-md rounded hover:opacity-90 transition-opacity inline-flex items-center gap-2" href="research.html">
-          View Research
-          <span class="material-symbols-outlined text-sm">arrow_forward</span>
-        </a>
-        <a class="px-8 py-3 border border-primary text-primary font-label-md text-label-md rounded hover:bg-surface-container-low transition-colors" href="#about">
-          About Me
-        </a>
+      <div class="hero-actions reveal" style="--d:.3s">
+        <a class="btn btn-solid" href="research.html">View Research <span class="arrow">→</span></a>
+        <a class="btn" href="#about">About Me</a>
       </div>
-      <div class="flex flex-wrap gap-4 pt-2">
-        <a href="https://www.linkedin.com/in/yasassri" target="_blank" class="flex items-center gap-2 font-caption text-caption text-on-surface-variant hover:text-primary transition-colors">
-          <span class="material-symbols-outlined text-[16px]">work</span> LinkedIn
-        </a>
-        <a href="https://www.instagram.com/yasassri.me" target="_blank" class="flex items-center gap-2 font-caption text-caption text-on-surface-variant hover:text-primary transition-colors">
-          <span class="material-symbols-outlined text-[16px]">photo_camera</span> @yasassri.me
-        </a>
-        <span class="flex items-center gap-2 font-caption text-caption text-secondary">
-          <span class="inline-block w-2 h-2 rounded-full bg-secondary animate-pulse"></span>
-          Open for Collaboration
-        </span>
+      <div class="hero-meta reveal" style="--d:.4s">
+        <span><span class="status-dot"></span>Open for collaboration</span>
+        <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn ↗</a>
+        <a href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">@yasassri.me ↗</a>
+        <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Scholar ↗</a>
       </div>
     </div>
-
-    <div class="md:col-span-5 relative mt-stack-lg md:mt-0">
-      <div class="aspect-[4/5] bg-surface-container-high rounded overflow-hidden shadow-sm border border-outline-variant">
-        <img alt="Dr. Yasas Sri Wickramasinghe" class="w-full h-full object-cover object-top grayscale hover:grayscale-0 transition-all duration-700" src="assets/images/personal_img.png" onerror="this.src='assets/images/phd-graduation.jpg'"/>
-      </div>
-      <div class="absolute -bottom-4 -left-4 w-24 h-24 border-l-2 border-b-2 border-secondary opacity-30"></div>
+    <div class="hero-portrait reveal" style="--d:.25s">
+      <img alt="Dr. Yasas Sri Wickramasinghe" src="assets/images/personal_img.png" onerror="this.src='assets/images/phd-graduation.jpg'"/>
+      <span class="frame"></span>
+      <span class="portrait-caption">Christchurch · New Zealand</span>
     </div>
-  </section>
+  </div>
+  <div class="scroll-hint">Scroll</div>
+</header>
 
-  <!-- About Section -->
-  <section class="py-stack-lg border-t border-outline-variant" id="about">
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-gutter">
-      <div class="md:col-span-4">
-        <h2 class="font-headline-md text-headline-md text-primary sticky top-24">Biography &amp;<br/>Interests</h2>
-      </div>
-      <div class="md:col-span-8 space-y-stack-md">
-        <p class="font-body-lg text-body-lg text-on-surface">
-          Dr. Yasas Sri Wickramasinghe is a Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) and Senior Lecturer at Yoobee College of Creative Innovation, where he specialises in immersive technologies and human-computer interaction. He holds a PhD in Human Interface Technology from the University of Canterbury, with a dissertation on designing multiplayer location-based AR games that connect remote players and places.
-        </p>
-        <p class="font-body-md text-body-md text-on-surface-variant">
-          His research is conducted in collaboration with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc. Earlier in his career he co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme (2015) and served as a Technical Lead at 99X Technology. He also led the development of Sri Lanka's first large-scale MOOC platform, which grew to over 150,000 registered learners. He writes regularly on immersive media and software engineering at ReadClub.me and Medium.
-        </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-stack-md pt-stack-sm">
-          <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm">
-            <h3 class="font-label-md text-label-md text-secondary uppercase mb-2">Research Focus</h3>
-            <ul class="space-y-2 font-body-md text-body-md text-on-surface">
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">check_circle</span>Location-Based Augmented Reality</li>
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">check_circle</span>XR &amp; Spatial Computing</li>
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">check_circle</span>Human Interface Technology</li>
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">check_circle</span>Player Experience &amp; HCI</li>
-            </ul>
-          </div>
-          <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm">
-            <h3 class="font-label-md text-label-md text-secondary uppercase mb-2">Education</h3>
-            <ul class="space-y-2 font-body-md text-body-md text-on-surface">
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">school</span>PhD, Human Interface Technology — University of Canterbury</li>
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">school</span>Spec. in VR — Goldsmiths, University of London</li>
-              <li class="flex items-start gap-2"><span class="material-symbols-outlined text-tertiary text-lg">school</span>BSc (Hons) IT — University of Moratuwa</li>
-            </ul>
-          </div>
+<div class="marquee" aria-hidden="true">
+  <div class="marquee-track">
+    <span>Location-Based AR</span><span>Spatial Computing</span><span>Human Interface Technology</span><span>Player Experience</span><span>XR Research</span><span>HCI</span>
+  </div>
+  <div class="marquee-track">
+    <span>Location-Based AR</span><span>Spatial Computing</span><span>Human Interface Technology</span><span>Player Experience</span><span>XR Research</span><span>HCI</span>
+  </div>
+</div>
+
+<section class="section no-line" id="about">
+  <div class="container split">
+    <div class="sticky-col reveal">
+      <span class="eyebrow">01 — Profile</span>
+      <h2>Biography &amp; <em>Interests</em></h2>
+    </div>
+    <div>
+      <p class="lead reveal">
+        Dr. Yasas Sri Wickramasinghe is a Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) and Senior Lecturer at Yoobee College of Creative Innovation, where he specialises in immersive technologies and human-computer interaction. He holds a PhD in Human Interface Technology from the University of Canterbury, with a dissertation on designing multiplayer location-based AR games that connect remote players and places.
+      </p>
+      <p class="reveal" style="--d:.1s; color: var(--text-dim); font-weight: 300; margin-top: 24px;">
+        His research is conducted in collaboration with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc. Earlier in his career he co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme (2015) and served as a Technical Lead at 99X Technology. He also led the development of Sri Lanka's first large-scale MOOC platform, which grew to over 150,000 registered learners. He writes regularly on immersive media and software engineering at ReadClub.me and Medium.
+      </p>
+      <div class="grid-2" style="margin-top: 44px;">
+        <div class="card reveal" style="--d:.15s">
+          <span class="kicker">Research Focus</span>
+          <ul style="display:flex; flex-direction:column; gap:12px;">
+            <li style="border-bottom:1px solid var(--line); padding-bottom:12px;">Location-Based Augmented Reality</li>
+            <li style="border-bottom:1px solid var(--line); padding-bottom:12px;">XR &amp; Spatial Computing</li>
+            <li style="border-bottom:1px solid var(--line); padding-bottom:12px;">Human Interface Technology</li>
+            <li>Player Experience &amp; HCI</li>
+          </ul>
+        </div>
+        <div class="card reveal" style="--d:.25s">
+          <span class="kicker">Education</span>
+          <ul style="display:flex; flex-direction:column; gap:12px;">
+            <li style="border-bottom:1px solid var(--line); padding-bottom:12px;">PhD, Human Interface Technology<br/><small style="color:var(--muted)">University of Canterbury</small></li>
+            <li style="border-bottom:1px solid var(--line); padding-bottom:12px;">Specialisation in Virtual Reality<br/><small style="color:var(--muted)">Goldsmiths, University of London</small></li>
+            <li>BSc (Hons) Information Technology<br/><small style="color:var(--muted)">University of Moratuwa</small></li>
+          </ul>
         </div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- Work Experience Timeline -->
-  <section class="py-stack-lg border-t border-outline-variant" id="experience">
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-gutter">
-      <div class="md:col-span-4">
-        <span class="font-label-md text-label-md text-secondary uppercase tracking-widest">Career</span>
-        <h2 class="font-headline-md text-headline-md text-primary mt-1 sticky top-24">Work<br/>Experience</h2>
-      </div>
-      <div class="md:col-span-8">
-        <div class="relative border-l border-outline-variant pl-8 space-y-stack-md ml-2">
+<section class="section" id="experience">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>Work <em>Experience</em></h2>
+    </div>
+    <div class="timeline">
 
-          <!-- HIT Lab NZ -->
-          <div class="relative">
-            <div class="absolute -left-[2.15rem] top-1.5 w-3 h-3 rounded-full bg-primary border-2 border-surface"></div>
-            <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm hover:border-primary transition-colors">
-              <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
-                <div>
-                  <h3 class="font-headline-sm text-headline-sm text-primary">Postdoctoral Researcher</h3>
-                  <p class="font-body-md text-body-md text-secondary font-medium">HIT Lab NZ, University of Canterbury</p>
-                </div>
-                <span class="font-caption text-caption text-on-surface-variant bg-surface-container px-3 py-1 rounded-full whitespace-nowrap">Jun 2025 – Present</span>
-              </div>
-              <p class="font-body-md text-body-md text-on-surface-variant mb-3">Design, implementation, and evaluation of VR applications in collaboration with Sony Interactive Entertainment (Japan). HCI research in immersive environments, mentoring postgraduate students, and developing multi-modal XR experimental platforms.</p>
-              <div class="flex flex-wrap gap-2">
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">Unity 3D</span>
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">Niantic Lightship</span>
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">OpenXR</span>
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-secondary-fixed text-on-secondary-fixed-variant px-2 py-0.5 rounded-sm">Sony Interactive</span>
-              </div>
-            </div>
+      <div class="timeline-item reveal">
+        <span class="timeline-date">Jun 2025 — Present</span>
+        <div class="timeline-body">
+          <h3>Postdoctoral Researcher</h3>
+          <span class="org">HIT Lab NZ · University of Canterbury</span>
+          <p>Design, implementation, and evaluation of VR applications in collaboration with Sony Interactive Entertainment (Japan). HCI research in immersive environments, mentoring postgraduate students, and developing multi-modal XR experimental platforms.</p>
+          <div class="tags">
+            <span class="tag">Unity 3D</span><span class="tag">Niantic Lightship</span><span class="tag">OpenXR</span><span class="tag gold">Sony Interactive</span>
           </div>
-
-          <!-- Yoobee -->
-          <div class="relative">
-            <div class="absolute -left-[2.15rem] top-1.5 w-3 h-3 rounded-full bg-secondary border-2 border-surface"></div>
-            <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm hover:border-primary transition-colors">
-              <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
-                <div>
-                  <h3 class="font-headline-sm text-headline-sm text-primary">Senior Lecturer</h3>
-                  <p class="font-body-md text-body-md text-secondary font-medium">Yoobee College of Creative Innovation</p>
-                </div>
-                <span class="font-caption text-caption text-on-surface-variant bg-surface-container px-3 py-1 rounded-full whitespace-nowrap">Feb 2023 – Present</span>
-              </div>
-              <p class="font-body-md text-body-md text-on-surface-variant mb-3">Teaching master's-level courses in Strategic Information Systems, Database Management, and IT Project Management. Recognised for innovative, gamified, and high-engagement teaching methods. Supervising capstone and thesis projects.</p>
-              <div class="flex flex-wrap gap-2">
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">Postgraduate Teaching</span>
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">Curriculum Design</span>
-              </div>
-            </div>
-          </div>
-
-          <!-- University of Moratuwa -->
-          <div class="relative">
-            <div class="absolute -left-[2.15rem] top-1.5 w-3 h-3 rounded-full bg-outline border-2 border-surface"></div>
-            <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm hover:border-primary transition-colors">
-              <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
-                <div>
-                  <h3 class="font-headline-sm text-headline-sm text-primary">Lecturer &amp; Platform Lead</h3>
-                  <p class="font-body-md text-body-md text-secondary font-medium">University of Moratuwa, Sri Lanka</p>
-                </div>
-                <span class="font-caption text-caption text-on-surface-variant bg-surface-container px-3 py-1 rounded-full whitespace-nowrap">2019 – 2022</span>
-              </div>
-              <p class="font-body-md text-body-md text-on-surface-variant mb-3">Taught undergraduate and postgraduate courses in HCI, Database Systems, and Software Engineering. Co-designed and launched Sri Lanka's first large-scale MOOC platform (<a href="https://open.uom.lk" target="_blank" class="underline hover:text-primary">open.uom.lk</a>), scaling to over 150,000 registered learners with fully automated course delivery.</p>
-              <div class="flex flex-wrap gap-2">
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">150,000+ Learners</span>
-                <span class="text-[10px] font-bold uppercase tracking-wider bg-tertiary-fixed text-on-tertiary-fixed-variant px-2 py-0.5 rounded-sm">MOOC Platform</span>
-              </div>
-            </div>
-          </div>
-
-          <!-- 99X Technology -->
-          <div class="relative">
-            <div class="absolute -left-[2.15rem] top-1.5 w-3 h-3 rounded-full bg-outline border-2 border-surface"></div>
-            <div class="p-stack-md bg-white border border-outline-variant rounded shadow-sm hover:border-primary transition-colors">
-              <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
-                <div>
-                  <h3 class="font-headline-sm text-headline-sm text-primary">Technical Lead / Senior Software Engineer</h3>
-                  <p class="font-body-md text-body-md text-secondary font-medium">99X Technology, Sri Lanka</p>
-                </div>
-                <span class="font-caption text-caption text-on-surface-variant bg-surface-container px-3 py-1 rounded-full whitespace-nowrap">2017 – 2021</span>
-              </div>
-              <p class="font-body-md text-body-md text-on-surface-variant">Led engineering teams building large-scale enterprise applications. Introduced AR features and Agile practices. Received three consecutive Excellence Awards and was a Top-3 Emerging Xian nominee.</p>
-            </div>
-          </div>
-
         </div>
       </div>
-    </div>
-  </section>
 
-  <!-- Featured Publications / Articles Section -->
-  <section class="py-stack-lg border-t border-outline-variant" id="publications">
-    <div class="flex justify-between items-end mb-stack-lg">
+      <div class="timeline-item reveal" style="--d:.05s">
+        <span class="timeline-date">Feb 2023 — Present</span>
+        <div class="timeline-body">
+          <h3>Senior Lecturer</h3>
+          <span class="org">Yoobee College of Creative Innovation</span>
+          <p>Teaching master's-level courses in Strategic Information Systems, Database Management, and IT Project Management. Recognised for innovative, gamified, and high-engagement teaching methods. Supervising capstone and thesis projects.</p>
+          <div class="tags">
+            <span class="tag">Postgraduate Teaching</span><span class="tag">Curriculum Design</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="timeline-item reveal" style="--d:.1s">
+        <span class="timeline-date">2019 — 2022</span>
+        <div class="timeline-body">
+          <h3>Lecturer &amp; Platform Lead</h3>
+          <span class="org">University of Moratuwa · Sri Lanka</span>
+          <p>Taught undergraduate and postgraduate courses in HCI, Database Systems, and Software Engineering. Co-designed and launched Sri Lanka's first large-scale MOOC platform (<a href="https://open.uom.lk" target="_blank" rel="noopener" style="border-bottom:1px solid var(--line-strong)">open.uom.lk</a>), scaling to over 150,000 registered learners with fully automated course delivery.</p>
+          <div class="tags">
+            <span class="tag gold">150,000+ Learners</span><span class="tag">MOOC Platform</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="timeline-item reveal" style="--d:.15s">
+        <span class="timeline-date">2017 — 2021</span>
+        <div class="timeline-body">
+          <h3>Technical Lead / Senior Software Engineer</h3>
+          <span class="org">99X Technology · Sri Lanka</span>
+          <p>Led engineering teams building large-scale enterprise applications. Introduced AR features and Agile practices. Received three consecutive Excellence Awards and was a Top-3 Emerging Xian nominee.</p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="section" id="publications">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">03</span>
+      <h2>Featured <em>Work</em></h2>
+      <a class="link-arrow head-link" href="research.html">Full publication index →</a>
+    </div>
+
+    <a class="pub-row reveal" href="https://doi.org/10.1016/j.entcom.2025.100932" target="_blank" rel="noopener">
+      <span class="pub-type">Journal · 2025</span>
       <div>
-        <span class="font-label-md text-label-md text-secondary uppercase tracking-widest">Scholarly Output</span>
-        <h2 class="font-headline-md text-headline-md text-primary">Featured Work</h2>
+        <h3 class="pub-title">Representing Remote Locations with Location-Based Augmented Reality Game Design</h3>
+        <p class="pub-venue">Entertainment Computing, 53 — Elsevier</p>
       </div>
-      <a class="hidden md:flex font-label-md text-label-md text-primary items-center gap-1 group" href="research.html">
-        Full Publication List
-        <span class="material-symbols-outlined group-hover:translate-x-1 transition-transform">arrow_right_alt</span>
-      </a>
-    </div>
-    <div class="space-y-gutter">
+      <span class="pub-arrow">↗</span>
+    </a>
 
-      <!-- Publication 1 -->
-      <div class="group p-stack-md border border-outline-variant bg-white hover:border-primary transition-all duration-300">
-        <div class="flex flex-col md:flex-row justify-between gap-stack-sm">
-          <div class="space-y-2">
-            <span class="font-caption text-caption text-secondary font-medium">Entertainment Computing, 53 — Elsevier (2025)</span>
-            <h3 class="font-headline-sm text-headline-sm text-primary">Representing Remote Locations with Location-Based Augmented Reality Game Design</h3>
-            <div class="flex flex-wrap gap-2 pt-1">
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">AR / XR</span>
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">Remote Play</span>
-            </div>
-          </div>
-          <div class="flex items-center shrink-0">
-            <a href="https://www.sciencedirect.com/science/article/pii/S1875952125000126" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">open_in_new</span>
-              Read
-            </a>
-            <span class="mx-4 h-4 w-px bg-outline-variant"></span>
-            <a href="https://doi.org/10.1016/j.entcom.2025.100932" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">cc_attribution</span>
-              DOI
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <!-- Publication 2 -->
-      <div class="group p-stack-md border border-outline-variant bg-white hover:border-primary transition-all duration-300">
-        <div class="flex flex-col md:flex-row justify-between gap-stack-sm">
-          <div class="space-y-2">
-            <span class="font-caption text-caption text-secondary font-medium">Multimodal Technologies and Interaction, 9(8) — MDPI (2025)</span>
-            <h3 class="font-headline-sm text-headline-sm text-primary">Evaluating Spatial Decision-Making and Player Experience in a Remote Multiplayer AR Hide-and-Seek Game</h3>
-            <div class="flex flex-wrap gap-2 pt-1">
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">HCI</span>
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">Player Experience</span>
-            </div>
-          </div>
-          <div class="flex items-center shrink-0">
-            <a href="https://www.mdpi.com/2414-4088/9/8/79" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">open_in_new</span>
-              Open Access
-            </a>
-            <span class="mx-4 h-4 w-px bg-outline-variant"></span>
-            <a href="https://doi.org/10.3390/mti9080079" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">cc_attribution</span>
-              DOI
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <!-- Publication 3 -->
-      <div class="group p-stack-md border border-outline-variant bg-white hover:border-primary transition-all duration-300">
-        <div class="flex flex-col md:flex-row justify-between gap-stack-sm">
-          <div class="space-y-2">
-            <span class="font-caption text-caption text-secondary font-medium">ACM Symposium on Spatial User Interaction — SUI '24 (2024)</span>
-            <h3 class="font-headline-sm text-headline-sm text-primary">Trustful Trading in Shared Augmented Reality</h3>
-            <div class="flex flex-wrap gap-2 pt-1">
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">Shared AR</span>
-              <span class="px-2 py-0.5 bg-tertiary-fixed text-on-tertiary-fixed-variant text-[10px] font-bold uppercase rounded-sm">Trust</span>
-            </div>
-          </div>
-          <div class="flex items-center shrink-0">
-            <a href="https://dl.acm.org/doi/10.1145/3677386.3682086" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">open_in_new</span>
-              ACM DL
-            </a>
-            <span class="mx-4 h-4 w-px bg-outline-variant"></span>
-            <a href="https://doi.org/10.1145/3677386.3682086" target="_blank" class="flex items-center gap-2 font-label-md text-label-md text-on-surface-variant hover:text-primary transition-colors">
-              <span class="material-symbols-outlined">cc_attribution</span>
-              DOI
-            </a>
-          </div>
-        </div>
-      </div>
-
-    </div>
-    <div class="mt-stack-md md:hidden">
-      <a class="w-full justify-center py-3 border border-primary flex font-label-md text-label-md text-primary items-center gap-2" href="research.html">
-        Full Publication List
-        <span class="material-symbols-outlined">arrow_right_alt</span>
-      </a>
-    </div>
-  </section>
-
-  <!-- Blog Preview Section -->
-  <section class="py-stack-lg border-t border-outline-variant">
-    <div class="flex justify-between items-end mb-stack-lg">
+    <a class="pub-row reveal" style="--d:.05s" href="https://doi.org/10.3390/mti9080079" target="_blank" rel="noopener">
+      <span class="pub-type">Journal · 2025</span>
       <div>
-        <span class="font-label-md text-label-md text-secondary uppercase tracking-widest">Writing</span>
-        <h2 class="font-headline-md text-headline-md text-primary">From the Blog</h2>
+        <h3 class="pub-title">Evaluating Spatial Decision-Making and Player Experience in a Remote Multiplayer AR Hide-and-Seek Game</h3>
+        <p class="pub-venue">Multimodal Technologies and Interaction, 9(8) — MDPI · Open Access</p>
       </div>
-      <a class="hidden md:flex font-label-md text-label-md text-primary items-center gap-1 group" href="blogs.html">
-        All Articles <span class="material-symbols-outlined group-hover:translate-x-1 transition-transform">arrow_right_alt</span>
-      </a>
+      <span class="pub-arrow">↗</span>
+    </a>
+
+    <a class="pub-row reveal" style="--d:.1s" href="https://doi.org/10.1145/3677386.3682086" target="_blank" rel="noopener">
+      <span class="pub-type">Conference · 2024</span>
+      <div>
+        <h3 class="pub-title">Trustful Trading in Shared Augmented Reality</h3>
+        <p class="pub-venue">ACM Symposium on Spatial User Interaction — SUI '24</p>
+      </div>
+      <span class="pub-arrow">↗</span>
+    </a>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">04</span>
+      <h2>From the <em>Blog</em></h2>
+      <a class="link-arrow head-link" href="blogs.html">All articles →</a>
     </div>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
+    <div class="grid-3">
 
-      <!-- Blog Preview 1: AR Metaverse -->
-      <a href="https://readclub.me/design-the-real-world-metaverse-with-augmented-reality-complete-guide/" target="_blank"
-         class="group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[180px]" style="background:linear-gradient(135deg,#1a0533 0%,#3b1566 50%,#5b2a9a 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 180" preserveAspectRatio="xMidYMid slice" fill="none">
-            <g opacity="0.2">
-              <line x1="200" y1="30" x2="0" y2="180" stroke="white" stroke-width="0.8"/>
-              <line x1="200" y1="30" x2="133" y2="180" stroke="white" stroke-width="0.8"/>
-              <line x1="200" y1="30" x2="267" y2="180" stroke="white" stroke-width="0.8"/>
-              <line x1="200" y1="30" x2="400" y2="180" stroke="white" stroke-width="0.8"/>
-              <line x1="0" y1="150" x2="400" y2="150" stroke="white" stroke-width="0.6"/>
-              <line x1="30" y1="120" x2="370" y2="120" stroke="white" stroke-width="0.5"/>
-            </g>
-            <circle cx="120" cy="80" r="22" stroke="white" stroke-width="1.2" opacity="0.45"/>
-            <circle cx="120" cy="80" r="3" fill="white" opacity="0.6"/>
-            <circle cx="280" cy="65" r="15" stroke="white" stroke-width="1" opacity="0.35"/>
-          </svg>
+      <a class="article-card reveal" href="https://readclub.me/design-the-real-world-metaverse-with-augmented-reality-complete-guide/" target="_blank" rel="noopener">
+        <div class="article-cover cov-violet" data-num="—01">
+          <span class="cat">AR / VR</span>
         </div>
-        <div class="p-4">
-          <span class="text-[10px] font-bold text-secondary uppercase tracking-widest">AR / VR · readclub.me</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary mt-1 group-hover:text-secondary transition-colors">Design the Real-World Metaverse with Augmented Reality</h3>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>Design the Real-World Metaverse with Augmented Reality</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- Blog Preview 2: NZ Campervan -->
-      <a href="https://readclub.me/new-zealand-campervan-road-trip/" target="_blank"
-         class="group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[180px]" style="background:linear-gradient(135deg,#052e16 0%,#14532d 60%,#15803d 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 180" preserveAspectRatio="xMidYMid slice" fill="none">
-            <circle cx="80" cy="35" r="1.5" fill="white" opacity="0.5"/>
-            <circle cx="180" cy="20" r="1" fill="white" opacity="0.4"/>
-            <circle cx="310" cy="30" r="1.5" fill="white" opacity="0.45"/>
-            <circle cx="360" cy="18" r="1" fill="white" opacity="0.35"/>
-            <path d="M 0 140 L 90 70 L 180 115 L 280 55 L 370 90 L 400 65 L 400 180 L 0 180 Z" fill="white" fill-opacity="0.1" stroke="white" stroke-width="0.8" opacity="0.3"/>
-            <path d="M 0 165 L 80 130 L 200 150 L 320 125 L 400 140 L 400 180 L 0 180 Z" fill="white" fill-opacity="0.07" stroke="white" stroke-width="0.5" opacity="0.2"/>
-            <path d="M 200 180 Q 185 160 175 148 Q 165 136 175 128 Q 185 120 190 110" stroke="white" stroke-width="2.5" opacity="0.3" fill="none"/>
-          </svg>
+      <a class="article-card reveal" style="--d:.1s" href="https://readclub.me/new-zealand-campervan-road-trip/" target="_blank" rel="noopener">
+        <div class="article-cover cov-forest" data-num="—02">
+          <span class="cat">Travel</span>
         </div>
-        <div class="p-4">
-          <span class="text-[10px] font-bold text-secondary uppercase tracking-widest">Travel · readclub.me</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary mt-1 group-hover:text-secondary transition-colors">New Zealand Campervan Road Trip</h3>
+        <div class="article-body">
+          <span class="src">readclub.me</span>
+          <h3>New Zealand Campervan Road Trip</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
-      <!-- Blog Preview 3: Dev Costs -->
-      <a href="https://blog.bitsrc.io/3-strategies-to-reduce-software-development-costs-in-2023-e4514a110959" target="_blank"
-         class="group flex flex-col bg-white border border-outline-variant overflow-hidden hover:border-primary transition-all duration-300 rounded-lg shadow-sm">
-        <div class="relative overflow-hidden h-[180px]" style="background:linear-gradient(135deg,#022c22 0%,#064e3b 60%,#059669 100%)">
-          <svg class="absolute inset-0 w-full h-full" viewBox="0 0 400 180" preserveAspectRatio="xMidYMid slice" fill="none">
-            <rect x="60" y="30" width="50" height="120" fill="white" fill-opacity="0.08" stroke="white" stroke-width="1" opacity="0.4"/>
-            <rect x="130" y="55" width="50" height="95" fill="white" fill-opacity="0.07" stroke="white" stroke-width="1" opacity="0.35"/>
-            <rect x="200" y="80" width="50" height="70" fill="white" fill-opacity="0.06" stroke="white" stroke-width="1" opacity="0.3"/>
-            <rect x="270" y="105" width="50" height="45" fill="white" fill-opacity="0.05" stroke="white" stroke-width="1" opacity="0.25"/>
-            <line x1="40" y1="150" x2="360" y2="150" stroke="white" stroke-width="0.8" opacity="0.2"/>
-            <path d="M 310 50 L 350 90" stroke="white" stroke-width="2" opacity="0.35"/>
-            <polygon points="350,90 337,80 345,70" fill="white" opacity="0.35"/>
-          </svg>
+      <a class="article-card reveal" style="--d:.2s" href="https://blog.bitsrc.io/3-strategies-to-reduce-software-development-costs-in-2023-e4514a110959" target="_blank" rel="noopener">
+        <div class="article-cover cov-teal" data-num="—03">
+          <span class="cat">Software Eng</span>
         </div>
-        <div class="p-4">
-          <span class="text-[10px] font-bold text-secondary uppercase tracking-widest">Software Eng · Bitsrc.io</span>
-          <h3 class="font-headline-sm text-[15px] leading-snug text-primary mt-1 group-hover:text-secondary transition-colors">3 Strategies to Reduce Software Development Costs in 2023</h3>
+        <div class="article-body">
+          <span class="src">Bitsrc.io</span>
+          <h3>3 Strategies to Reduce Software Development Costs</h3>
+          <span class="read">Read article →</span>
         </div>
       </a>
 
     </div>
-    <div class="mt-stack-md md:hidden">
-      <a class="w-full justify-center py-3 border border-primary flex font-label-md text-label-md text-primary items-center gap-2" href="blogs.html">
-        All Articles <span class="material-symbols-outlined">arrow_right_alt</span>
-      </a>
-    </div>
-  </section>
+  </div>
+</section>
 
-</main>
-
-<!-- Footer -->
-<footer class="w-full mt-stack-lg bg-surface-container-low border-t border-outline-variant">
-  <div class="flex flex-col md:flex-row justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-md">
-    <div class="mb-4 md:mb-0">
-      <span class="font-headline-sm text-headline-sm text-primary">Dr. Yasas Sri Wickramasinghe</span>
-      <p class="font-caption text-caption text-on-surface-variant mt-1 opacity-90">© 2026 Yasas Sri Wickramasinghe. All rights reserved.</p>
+<section class="cta">
+  <div class="container">
+    <span class="eyebrow reveal">Collaboration</span>
+    <h2 class="reveal" style="--d:.1s">Let's build the next <em>spatial</em> experience together.</h2>
+    <div class="cta-actions reveal" style="--d:.2s">
+      <a class="btn btn-solid" href="contact.html">Get in Touch <span class="arrow">→</span></a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">Curriculum Vitae</a>
     </div>
-    <div class="flex gap-gutter">
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.linkedin.com/in/yasassri" target="_blank">LinkedIn</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.instagram.com/yasassri.me" target="_blank">Instagram</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://twitter.com/sri_yasas" target="_blank">Twitter/X</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
+  </div>
+</section>
+
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Dr. Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
+    </div>
+    <div class="footer-links">
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">Instagram</a>
+      <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter/X</a>
+      <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Scholar</a>
+      <a href="contact.html">Contact</a>
     </div>
   </div>
 </footer>
 
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('opacity-100', 'translate-y-0');
-          entry.target.classList.remove('opacity-0', 'translate-y-4');
-        }
-      });
-    }, { threshold: 0.1 });
-
-    document.querySelectorAll('section, .group').forEach(el => {
-      el.classList.add('transition-all', 'duration-700', 'opacity-0', 'translate-y-4');
-      observer.observe(el);
-    });
-  });
-</script>
+<script src="assets/js/premium.js"></script>
 </body>
 </html>

--- a/research.html
+++ b/research.html
@@ -1,114 +1,15 @@
 <!DOCTYPE html>
-<html class="scroll-smooth" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Research | Dr. Yasas Sri Wickramasinghe</title>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Newsreader:ital,wght@0,500;0,600;1,500&display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<script id="tailwind-config">
-  tailwind.config = {
-    darkMode: "class",
-    theme: {
-      extend: {
-        "colors": {
-          "primary-fixed-dim": "#b8c8dc",
-          "inverse-on-surface": "#f2f1ee",
-          "on-primary-fixed": "#0c1d2b",
-          "on-secondary-fixed": "#261900",
-          "error": "#ba1a1a",
-          "inverse-primary": "#b8c8dc",
-          "primary": "#051625",
-          "error-container": "#ffdad6",
-          "outline-variant": "#c4c6cc",
-          "background": "#faf9f6",
-          "on-background": "#1a1c1a",
-          "surface-variant": "#e3e2e0",
-          "secondary-container": "#fed488",
-          "on-tertiary-fixed": "#121e14",
-          "on-secondary-fixed-variant": "#5d4201",
-          "on-secondary": "#ffffff",
-          "on-primary": "#ffffff",
-          "surface-container": "#efeeeb",
-          "surface": "#faf9f6",
-          "on-surface-variant": "#43474c",
-          "surface-container-lowest": "#ffffff",
-          "on-surface": "#1a1c1a",
-          "surface-container-high": "#e9e8e5",
-          "on-tertiary-fixed-variant": "#3c4a3d",
-          "secondary-fixed-dim": "#e9c176",
-          "on-secondary-container": "#785a1a",
-          "secondary": "#775a19",
-          "surface-dim": "#dbdad7",
-          "tertiary": "#0c180e",
-          "tertiary-fixed-dim": "#bbcbba",
-          "surface-container-low": "#f4f3f1",
-          "on-error": "#ffffff",
-          "inverse-surface": "#2f312f",
-          "on-tertiary": "#ffffff",
-          "surface-container-highest": "#e3e2e0",
-          "on-error-container": "#93000a",
-          "primary-fixed": "#d3e4f8",
-          "secondary-fixed": "#ffdea5",
-          "primary-container": "#1b2b3a",
-          "tertiary-fixed": "#d7e7d5",
-          "tertiary-container": "#202d22",
-          "surface-tint": "#506071",
-          "on-tertiary-container": "#869586",
-          "on-primary-fixed-variant": "#384858",
-          "on-primary-container": "#8292a5",
-          "surface-bright": "#faf9f6",
-          "outline": "#74777c"
-        },
-        "borderRadius": {
-          "DEFAULT": "0.125rem",
-          "lg": "0.25rem",
-          "xl": "0.5rem",
-          "full": "0.75rem"
-        },
-        "spacing": {
-          "stack-sm": "12px",
-          "margin-desktop": "64px",
-          "stack-md": "24px",
-          "gutter": "24px",
-          "margin-mobile": "16px",
-          "container-max": "1140px",
-          "unit": "8px",
-          "stack-lg": "48px"
-        },
-        "fontFamily": {
-          "display-lg": ["Newsreader"],
-          "label-md": ["Inter"],
-          "headline-md": ["Newsreader"],
-          "display-lg-mobile": ["Newsreader"],
-          "headline-sm": ["Newsreader"],
-          "body-lg": ["Inter"],
-          "body-md": ["Inter"],
-          "caption": ["Inter"]
-        },
-        "fontSize": {
-          "display-lg": ["48px", {"lineHeight": "1.1", "letterSpacing": "-0.02em", "fontWeight": "600"}],
-          "label-md": ["14px", {"lineHeight": "1.2", "letterSpacing": "0.05em", "fontWeight": "600"}],
-          "headline-md": ["32px", {"lineHeight": "1.3", "fontWeight": "500"}],
-          "display-lg-mobile": ["36px", {"lineHeight": "1.2", "fontWeight": "600"}],
-          "headline-sm": ["24px", {"lineHeight": "1.4", "fontWeight": "500"}],
-          "body-lg": ["18px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "body-md": ["16px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "caption": ["12px", {"lineHeight": "1.4", "fontWeight": "400"}]
-        }
-      },
-    },
-  }
-</script>
-<style>
-  .material-symbols-outlined {
-    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-    vertical-align: middle;
-  }
-  .pub-item { transition: transform 0.2s ease-out; }
-  .pub-item:hover { transform: translateX(4px); }
-</style>
+<title>Research — Dr. Yasas Sri Wickramasinghe</title>
+<meta name="description" content="Research and publications by Dr. Yasas Sri Wickramasinghe — location-based augmented reality, spatial computing, and human-computer interaction."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Inter:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/premium.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -118,507 +19,332 @@
   gtag('config', 'G-N2BH0F6SNE');
 </script>
 </head>
-<body class="bg-background text-on-background font-body-md antialiased">
+<body>
 
-<!-- TopNavBar -->
-<header class="w-full top-0 sticky bg-surface border-b border-outline-variant z-50">
-  <nav class="flex justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-sm">
-    <a class="font-display-lg text-headline-sm text-primary tracking-tight" href="index.html">Dr. Yasas Sri Wickramasinghe</a>
-    <div class="hidden md:flex gap-gutter items-center">
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="index.html">Home</a>
-      <a class="font-body-md text-body-md text-primary font-bold border-b-2 border-primary pb-1" href="research.html">Research</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="teaching.html">Teaching</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="blogs.html">Blogs</a>
-      <a class="font-body-md text-body-md text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
-      <a href="assets/files/cv_yasas.pdf" target="_blank" class="ml-4 px-6 py-2 bg-primary text-on-primary font-label-md text-label-md rounded-lg hover:opacity-80 transition-opacity">
-        Curriculum Vitae
-      </a>
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Dr. Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a class="active" href="research.html">Research</a>
+      <a href="teaching.html">Teaching</a>
+      <a href="blogs.html">Writing</a>
+      <a href="contact.html">Contact</a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">CV <span class="arrow">→</span></a>
     </div>
-    <button class="md:hidden text-primary" onclick="document.getElementById('mobile-menu-r').classList.toggle('hidden')">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-  </nav>
-  <div class="hidden md:hidden bg-surface border-t border-outline-variant px-margin-mobile py-stack-md flex flex-col gap-stack-sm" id="mobile-menu-r">
-    <a class="font-body-md text-on-surface-variant" href="index.html">Home</a>
-    <a class="font-body-md text-primary font-bold" href="research.html">Research</a>
-    <a class="font-body-md text-on-surface-variant" href="teaching.html">Teaching</a>
-    <a class="font-body-md text-on-surface-variant" href="blogs.html">Blogs</a>
-    <a class="font-body-md text-on-surface-variant" href="contact.html">Contact</a>
-    <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 w-fit font-label-md text-label-md">Curriculum Vitae</a>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
+  </div>
+</nav>
+<div class="mobile-menu">
+  <a href="index.html"><span class="idx">01</span>Home</a>
+  <a class="active" href="research.html"><span class="idx">02</span>Research</a>
+  <a href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a href="blogs.html"><span class="idx">04</span>Writing</a>
+  <a href="contact.html"><span class="idx">05</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
+</div>
+
+<header class="page-hero">
+  <div class="container">
+    <span class="eyebrow reveal">Research</span>
+    <h1 class="reveal" style="--d:.1s">Scientific inquiry &amp; <em>publication</em>.</h1>
+    <p class="lead reveal" style="--d:.2s">
+      My research centres on location-based augmented reality — designing, building, and evaluating systems that connect remote players through shared spatial experiences. I explore how AR can extend human interaction across distance, blending physical environments with digital layers.
+    </p>
+    <div class="hero-actions reveal" style="--d:.3s">
+      <a class="btn" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar <span class="arrow">↗</span></a>
+      <a class="btn" href="https://www.hitlabnz.org/index.php/project/location-based-ar-game-2/" target="_blank" rel="noopener">HIT Lab NZ Project <span class="arrow">↗</span></a>
+      <a class="btn" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">PhD Thesis <span class="arrow">↗</span></a>
+    </div>
   </div>
 </header>
 
-<main class="max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop">
-
-  <!-- Hero Section -->
-  <section class="py-stack-lg border-b border-outline-variant">
-    <div class="max-w-3xl">
-      <h1 class="font-display-lg text-display-lg-mobile md:text-display-lg text-primary mb-stack-sm">Scientific Inquiry &amp; Publication</h1>
-      <p class="font-body-lg text-body-lg text-on-surface-variant leading-relaxed">
-        My research centres on location-based augmented reality — designing, building, and evaluating systems that connect remote players through shared spatial experiences. I explore how AR can extend human interaction across distance, blending physical environments with digital layers.
-      </p>
-      <div class="mt-stack-md flex flex-wrap gap-4">
-        <a class="inline-flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">
-          <span class="material-symbols-outlined">school</span>
-          <span class="font-label-md text-label-md">Google Scholar</span>
-        </a>
-        <a class="inline-flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors" href="https://www.hitlabnz.org/index.php/project/location-based-ar-game-2/" target="_blank">
-          <span class="material-symbols-outlined">biotech</span>
-          <span class="font-label-md text-label-md">HIT Lab NZ Project</span>
-        </a>
-        <a class="inline-flex items-center gap-2 px-4 py-2 bg-surface-container border border-outline rounded-lg text-primary hover:bg-surface-container-high transition-colors" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank">
-          <span class="material-symbols-outlined">menu_book</span>
-          <span class="font-label-md text-label-md">PhD Thesis (UC)</span>
-        </a>
-      </div>
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">01</span>
+      <h2>Active <em>Projects</em></h2>
     </div>
-  </section>
 
-  <!-- Active Research Projects Bento Grid -->
-  <section class="py-stack-lg">
-    <div class="flex items-center justify-between mb-stack-md">
-      <h2 class="font-headline-md text-headline-md text-primary">Active Research Projects</h2>
-      <div class="h-px flex-grow bg-outline-variant ml-gutter opacity-30"></div>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-gutter">
-
-      <!-- Large card: main AR research -->
-      <div class="md:col-span-8 group bg-white border border-outline-variant rounded-lg overflow-hidden flex flex-col md:flex-row transition-all hover:border-primary">
-        <div class="md:w-1/2 h-64 md:h-auto overflow-hidden">
-          <img alt="Location-Based AR Research at HIT Lab NZ" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" src="assets/images/research-ar-map.svg"/>
-        </div>
-        <div class="md:w-1/2 p-stack-md flex flex-col justify-between">
-          <div>
-            <span class="bg-tertiary-fixed text-on-tertiary-fixed-variant font-label-md text-[10px] px-2 py-0.5 rounded-sm uppercase tracking-wider mb-2 inline-block">Principal Investigator</span>
-            <h3 class="font-headline-sm text-headline-sm text-primary mb-2">Location-Based AR Games Connecting Remote Players &amp; Places</h3>
-            <p class="font-body-md text-body-md text-on-surface-variant">Postdoctoral research at HIT Lab NZ designing, building, and evaluating multiplayer location-based AR games. Players at different physical locations share a single augmented space through custom Unity + Niantic Lightship systems.</p>
-          </div>
-          <div class="mt-4 flex gap-2 flex-wrap">
-            <span class="bg-surface-container-high px-2 py-1 rounded-sm text-caption font-label-md text-on-surface-variant">#AR_Games</span>
-            <span class="bg-surface-container-high px-2 py-1 rounded-sm text-caption font-label-md text-on-surface-variant">#Remote_Play</span>
-            <span class="bg-surface-container-high px-2 py-1 rounded-sm text-caption font-label-md text-on-surface-variant">#HCI</span>
-          </div>
-        </div>
+    <div class="feature-row reveal">
+      <div class="feature-media">
+        <img alt="Location-Based AR Research at HIT Lab NZ" src="assets/images/research-ar-map.svg"/>
       </div>
-
-      <!-- Small card: Trust in AR -->
-      <div class="md:col-span-4 bg-white border border-outline-variant rounded-lg overflow-hidden hover:border-primary transition-all flex flex-col justify-between">
-        <div class="h-48 overflow-hidden">
-          <img alt="Trust and Social Interaction in Shared Augmented Reality" class="w-full h-full object-cover" src="assets/images/research-trust-ar.svg"/>
-        </div>
-        <div class="p-stack-md">
-          <h3 class="font-headline-sm text-headline-sm text-primary mb-2">Trust in Shared Augmented Reality</h3>
-          <p class="font-body-md text-body-md text-on-surface-variant mb-3">Investigating how design choices shape trust when users exchange virtual items in shared AR environments. 36-participant study at ACM SUI 2024.</p>
-          <a class="font-label-md text-label-md text-primary flex items-center gap-1 group/link" href="https://dl.acm.org/doi/10.1145/3677386.3682086" target="_blank">
-            ACM DL Paper <span class="material-symbols-outlined text-sm group-hover/link:translate-x-1 transition-transform">open_in_new</span>
-          </a>
-        </div>
-      </div>
-
-      <!-- Medium card: Early AR work -->
-      <div class="md:col-span-4 bg-surface-container-low border border-outline-variant rounded-lg p-stack-md hover:border-primary transition-all">
-        <div class="w-10 h-10 rounded-lg bg-secondary-fixed flex items-center justify-center mb-4">
-          <span class="material-symbols-outlined text-on-secondary-fixed">rocket_launch</span>
-        </div>
-        <h3 class="font-headline-sm text-headline-sm text-primary mb-2">NavitaZ VR Labs</h3>
-        <p class="font-body-md text-body-md text-on-surface-variant mb-4">Co-founded AR/VR startup under the MIT Global Startup Labs programme (2015–2019). Built mobile AR apps and VR web applications in Sri Lanka — Microsoft Imagine Cup Runner-Up 2015.</p>
-        <div class="flex flex-wrap gap-2">
-          <span class="bg-white border border-outline-variant px-2 py-1 rounded-sm text-caption font-label-md">#Startup</span>
-          <span class="bg-white border border-outline-variant px-2 py-1 rounded-sm text-caption font-label-md">#MIT_GSL</span>
-        </div>
-      </div>
-
-      <!-- Medium card: Remote multiplayer stats -->
-      <div class="md:col-span-8 bg-white border border-outline-variant rounded-lg overflow-hidden flex flex-col md:flex-row-reverse transition-all hover:border-primary">
-        <div class="md:w-2/5 h-48 md:h-auto overflow-hidden">
-          <img alt="VR and AR Workshop" class="w-full h-full object-cover transition-transform duration-500 hover:scale-105" src="assets/images/photography_img13.jpg"/>
-        </div>
-        <div class="md:w-3/5 p-stack-md">
-          <h3 class="font-headline-sm text-headline-sm text-primary mb-2">Multiplayer AR — Player Experience &amp; Spatial Decision-Making</h3>
-          <p class="font-body-md text-body-md text-on-surface-variant mb-4">60-participant empirical study comparing AR hide-and-seek against traditional gameplay. Published in IEEE VR 2025 and Multimodal Technologies &amp; Interaction (MDPI).</p>
-          <div class="flex gap-4 flex-wrap">
-            <div class="flex flex-col">
-              <span class="font-display-lg text-primary text-[28px] leading-none">60</span>
-              <span class="text-caption font-label-md text-on-surface-variant uppercase">Participants</span>
-            </div>
-            <div class="w-px h-8 bg-outline-variant self-center"></div>
-            <div class="flex flex-col">
-              <span class="font-display-lg text-primary text-[28px] leading-none">12</span>
-              <span class="text-caption font-label-md text-on-surface-variant uppercase">Publications</span>
-            </div>
-            <div class="w-px h-8 bg-outline-variant self-center"></div>
-            <div class="flex flex-col">
-              <span class="font-display-lg text-primary text-[28px] leading-none">5</span>
-              <span class="text-caption font-label-md text-on-surface-variant uppercase">Venues 2025</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-    </div>
-  </section>
-
-  <!-- Publications Section -->
-  <section class="py-stack-lg" id="publications">
-    <div class="flex items-center justify-between mb-stack-md">
-      <h2 class="font-headline-md text-headline-md text-primary">Publications</h2>
-      <div class="flex gap-2">
-        <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" class="px-4 py-1 text-label-md font-label-md rounded-full bg-primary text-on-primary flex items-center gap-1">
-          <span class="material-symbols-outlined text-sm">school</span> Google Scholar
-        </a>
+      <div>
+        <span class="eyebrow">Principal Investigator</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Location-Based AR Games Connecting Remote Players &amp; Places</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Postdoctoral research at HIT Lab NZ designing, building, and evaluating multiplayer location-based AR games. Players at different physical locations share a single augmented space through custom Unity + Niantic Lightship systems.</p>
+        <div class="tags"><span class="tag">AR Games</span><span class="tag">Remote Play</span><span class="tag">HCI</span></div>
       </div>
     </div>
 
-    <div class="space-y-stack-lg">
-
-      <!-- 2025 -->
+    <div class="feature-row reveal">
       <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2025</h3>
-        <ul class="space-y-stack-md">
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Journal</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. (2025). "Evaluating Spatial Decision-Making and Player Experience in a Remote Multiplayer Augmented Reality Hide-and-Seek Game."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  Multimodal Technologies and Interaction, 9(8), 79. MDPI.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://www.mdpi.com/2414-4088/9/8/79" target="_blank">Open Access ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://doi.org/10.3390/mti9080079" target="_blank">DOI: 10.3390/mti9080079</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, Y.S., Lukosch, H., Everett, J., &amp; Lukosch, S. (2025). "On the Impact of Augmented Reality Game Mechanics on the Player Experience in Remote Multiplayer Gameplay."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  37th Australian Conference on Human-Computer Interaction (OzCHI '25). ACM.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://dl.acm.org/doi/10.1145/3764687.3764699" target="_blank">ACM DL ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://doi.org/10.1145/3764687.3764699" target="_blank">DOI: 10.1145/3764687.3764699</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, Y.S., Lukosch, H., Everett, J., &amp; Lukosch, S. (2025). "Augmented Hide-And-Seek: Evaluating Spatial Decision-Making and Player Experience in a Multiplayer Location-Based Game."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  2025 IEEE Conference on Virtual Reality and 3D User Interfaces (IEEE VR '25). IEEE.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://ieeexplore.ieee.org/document/10973019" target="_blank">IEEE Xplore ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://www.researchgate.net/publication/391122985" target="_blank">ResearchGate ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Journal</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. (2025). "Representing Remote Locations with Location-Based Augmented Reality Game Design."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  Entertainment Computing, 53, 100932. Elsevier. <span class="not-italic text-secondary font-medium">1 citation</span>
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://www.sciencedirect.com/science/article/pii/S1875952125000126" target="_blank">ScienceDirect ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://doi.org/10.1016/j.entcom.2025.100932" target="_blank">DOI: 10.1016/j.entcom.2025.100932</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Thesis</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, W.A.U.Y.S. (2025). "Designing Multiplayer Location-Based Augmented Reality Games that Connect Remote Players and Places."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  PhD Thesis. University of Canterbury, Christchurch, New Zealand.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank">UC Repository ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="Wickramasinghe.pdf" target="_blank">PDF ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-        </ul>
+        <span class="eyebrow">ACM SUI 2024</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Trust in Shared Augmented Reality</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Investigating how design choices shape trust when users exchange virtual items in shared AR environments. A 36-participant study presented at the ACM Symposium on Spatial User Interaction 2024.</p>
+        <a class="link-arrow" style="margin-top:22px;" href="https://dl.acm.org/doi/10.1145/3677386.3682086" target="_blank" rel="noopener">ACM DL Paper ↗</a>
       </div>
-
-      <!-- 2024 -->
-      <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2024</h3>
-        <ul class="space-y-stack-md">
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Ritter, M., Liew, K., Wickramasinghe, Y.S., &amp; Lukosch, S. (2024). "Trustful Trading in Shared Augmented Reality."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  Proceedings of the 2024 ACM Symposium on Spatial User Interaction (SUI '24). ACM.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://dl.acm.org/doi/10.1145/3677386.3682086" target="_blank">ACM DL ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://doi.org/10.1145/3677386.3682086" target="_blank">DOI: 10.1145/3677386.3682086</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Tech Report</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Ritter, M., Lukosch, S., Liew, K., &amp; Wickramasinghe, Y. (2024). "Trust and Trustworthiness While Exchanging Virtual Items in Shared Augmented Reality."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  HIT Lab NZ, University of Canterbury. <span class="not-italic text-secondary font-medium">1 citation</span>
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">Google Scholar ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-        </ul>
+      <div class="feature-media">
+        <img alt="Trust and Social Interaction in Shared Augmented Reality" src="assets/images/research-trust-ar.svg"/>
       </div>
-
-      <!-- 2023 -->
-      <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2023</h3>
-        <ul class="space-y-stack-md">
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, Y.S., Lukosch, S., &amp; Lukosch, H. (2023). "Designing Immersive Multiplayer Location-Based Augmented Reality Games with Remotely Shared Spaces."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  54th Conference of the International Simulation and Gaming Association (ISAGA 2023), pp. 204–214.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://shs.hal.science/halshs-04209935" target="_blank">HAL Science ↗</a>
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="ISAGA2023Proceedings.pdf" target="_blank">Proceedings PDF ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <!-- 2022 -->
-      <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2022</h3>
-        <ul class="space-y-stack-md">
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Journal</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, W.A.U.Y.S., De Saram, P.S.R.S., Liyanage, C.P., &amp; Rangika, L.N.R. (2022). "Generating Dynamic Indoor Environments with Virtual Reality Markups."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  Journal of Software Engineering &amp; Software Testing, 6(3), 34–75. ManTech Publications.
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">Google Scholar ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Inparajah, J., &amp; Wickramasinghe, W. (2022). "A Review on Reimagining Medical Education with Virtual Reality in Emerging Medical Disciplines."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  15th International Research Conference, p. 36. <span class="not-italic text-secondary font-medium">1 citation</span>
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">Google Scholar ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-
-        </ul>
-      </div>
-
-      <!-- 2017 -->
-      <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2017</h3>
-        <ul class="space-y-stack-md">
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, W., De Saram, P., Liyanage, C.P., Rangika, L.N.R., et al. (2017). "Virtual Reality Markup Framework for Generating Interactive Indoor Environment."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  2017 IEEE 3rd International Conference on Engineering Technologies and Social Sciences (ICETSS). IEEE. <span class="not-italic text-secondary font-medium">4 citations</span>
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="https://ieeexplore.ieee.org/document/8324175" target="_blank">IEEE Xplore ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <!-- 2015 -->
-      <div>
-        <h3 class="font-label-md text-label-md text-secondary border-b border-outline-variant pb-2 mb-stack-md uppercase tracking-widest">2015</h3>
-        <ul class="space-y-stack-md">
-          <li class="pub-item group">
-            <div class="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-gutter">
-              <span class="text-caption font-label-md text-on-surface-variant uppercase md:w-24 shrink-0">Conference</span>
-              <div class="flex-grow">
-                <p class="font-body-lg text-body-lg text-primary leading-tight mb-1 group-hover:text-secondary transition-colors">
-                  Wickramasinghe, W., &amp; Gunasekara, E.H.D.A. (2015). "A Mobile Application with Augmented Reality to Enhance Sinhala Learning Experience for Children."
-                </p>
-                <p class="font-body-md text-body-md text-on-surface-variant italic">
-                  Research Symposium of the Information Technology Research Unit (ITRU 2015). University of Moratuwa, Sri Lanka. <span class="not-italic text-secondary font-medium">1 citation</span>
-                </p>
-                <div class="mt-2 flex gap-4 flex-wrap">
-                  <a class="text-caption font-label-md text-primary underline hover:text-secondary transition-colors" href="http://dl.lib.uom.lk/handle/123/12494" target="_blank">UoM Repository ↗</a>
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-
     </div>
 
-    <div class="mt-stack-lg text-center">
-      <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" class="inline-flex items-center gap-2 px-8 py-3 border border-primary text-primary font-label-md text-label-md rounded-lg hover:bg-primary hover:text-on-primary transition-all">
-        <span class="material-symbols-outlined">school</span>
-        View Full Profile on Google Scholar
+    <div class="feature-row reveal">
+      <div class="feature-media">
+        <img alt="VR and AR Workshop" src="assets/images/photography_img13.jpg"/>
+      </div>
+      <div>
+        <span class="eyebrow">IEEE VR 2025 · MDPI</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Multiplayer AR — Player Experience &amp; Spatial Decision-Making</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">A 60-participant empirical study comparing AR hide-and-seek against traditional gameplay. Published in IEEE VR 2025 and Multimodal Technologies &amp; Interaction (MDPI).</p>
+        <div class="tags"><span class="tag gold">60 Participants</span><span class="tag">12 Publications</span><span class="tag">5 Venues in 2025</span></div>
+      </div>
+    </div>
+
+    <div class="feature-row reveal" style="border-bottom:none;">
+      <div>
+        <span class="eyebrow">2015 — 2019</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">NavitaZ VR Labs</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Co-founded AR/VR startup under the MIT Global Startup Labs programme. Built mobile AR apps and VR web applications in Sri Lanka — Microsoft Imagine Cup Runner-Up 2015.</p>
+        <div class="tags"><span class="tag">Startup</span><span class="tag">MIT GSL</span></div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center; min-height:240px;">
+        <span class="kicker">Citation Metrics — Google Scholar, 2026</span>
+        <div class="info-list">
+          <div class="info-row"><span class="k">Publications</span><span class="v">12</span></div>
+          <div class="info-row"><span class="k">Citations</span><span class="v">7</span></div>
+          <div class="info-row"><span class="k">Since 2021</span><span class="v">6</span></div>
+          <div class="info-row"><span class="k">h-index</span><span class="v">1</span></div>
+          <div class="info-row" style="border-bottom:none;"><span class="k">Active Years</span><span class="v">2015 — 2025</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="publications">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>Publication <em>Index</em></h2>
+      <a class="link-arrow head-link" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar ↗</a>
+    </div>
+
+    <span class="pub-year reveal">2025</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Journal</span>
+      <div>
+        <h3 class="pub-title">Evaluating Spatial Decision-Making and Player Experience in a Remote Multiplayer Augmented Reality Hide-and-Seek Game</h3>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. — Multimodal Technologies and Interaction, 9(8), 79. MDPI.</p>
+        <div class="pub-links">
+          <a href="https://www.mdpi.com/2414-4088/9/8/79" target="_blank" rel="noopener">Open Access</a>
+          <a href="https://doi.org/10.3390/mti9080079" target="_blank" rel="noopener">DOI: 10.3390/mti9080079</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">On the Impact of Augmented Reality Game Mechanics on the Player Experience in Remote Multiplayer Gameplay</h3>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H., Everett, J., &amp; Lukosch, S. — 37th Australian Conference on Human-Computer Interaction (OzCHI '25). ACM.</p>
+        <div class="pub-links">
+          <a href="https://dl.acm.org/doi/10.1145/3764687.3764699" target="_blank" rel="noopener">ACM DL</a>
+          <a href="https://doi.org/10.1145/3764687.3764699" target="_blank" rel="noopener">DOI: 10.1145/3764687.3764699</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">Augmented Hide-And-Seek: Evaluating Spatial Decision-Making and Player Experience in a Multiplayer Location-Based Game</h3>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H., Everett, J., &amp; Lukosch, S. — 2025 IEEE Conference on Virtual Reality and 3D User Interfaces (IEEE VR '25). IEEE.</p>
+        <div class="pub-links">
+          <a href="https://ieeexplore.ieee.org/document/10973019" target="_blank" rel="noopener">IEEE Xplore</a>
+          <a href="https://www.researchgate.net/publication/391122985" target="_blank" rel="noopener">ResearchGate</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Journal</span>
+      <div>
+        <h3 class="pub-title">Representing Remote Locations with Location-Based Augmented Reality Game Design</h3>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. — Entertainment Computing, 53, 100932. Elsevier. <span class="cite">1 citation</span></p>
+        <div class="pub-links">
+          <a href="https://www.sciencedirect.com/science/article/pii/S1875952125000126" target="_blank" rel="noopener">ScienceDirect</a>
+          <a href="https://doi.org/10.1016/j.entcom.2025.100932" target="_blank" rel="noopener">DOI: 10.1016/j.entcom.2025.100932</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Thesis</span>
+      <div>
+        <h3 class="pub-title">Designing Multiplayer Location-Based Augmented Reality Games that Connect Remote Players and Places</h3>
+        <p class="pub-venue">Wickramasinghe, W.A.U.Y.S. — PhD Thesis. University of Canterbury, Christchurch, New Zealand.</p>
+        <div class="pub-links">
+          <a href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">UC Repository</a>
+          <a href="Wickramasinghe.pdf" target="_blank">PDF</a>
+        </div>
+      </div>
+    </div>
+
+    <span class="pub-year reveal">2024</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">Trustful Trading in Shared Augmented Reality</h3>
+        <p class="pub-venue">Ritter, M., Liew, K., Wickramasinghe, Y.S., &amp; Lukosch, S. — Proceedings of the 2024 ACM Symposium on Spatial User Interaction (SUI '24). ACM.</p>
+        <div class="pub-links">
+          <a href="https://dl.acm.org/doi/10.1145/3677386.3682086" target="_blank" rel="noopener">ACM DL</a>
+          <a href="https://doi.org/10.1145/3677386.3682086" target="_blank" rel="noopener">DOI: 10.1145/3677386.3682086</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Tech Report</span>
+      <div>
+        <h3 class="pub-title">Trust and Trustworthiness While Exchanging Virtual Items in Shared Augmented Reality</h3>
+        <p class="pub-venue">Ritter, M., Lukosch, S., Liew, K., &amp; Wickramasinghe, Y. — HIT Lab NZ, University of Canterbury. <span class="cite">1 citation</span></p>
+        <div class="pub-links">
+          <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+        </div>
+      </div>
+    </div>
+
+    <span class="pub-year reveal">2023</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">Designing Immersive Multiplayer Location-Based Augmented Reality Games with Remotely Shared Spaces</h3>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, S., &amp; Lukosch, H. — 54th Conference of the International Simulation and Gaming Association (ISAGA 2023), pp. 204–214.</p>
+        <div class="pub-links">
+          <a href="https://shs.hal.science/halshs-04209935" target="_blank" rel="noopener">HAL Science</a>
+          <a href="ISAGA2023Proceedings.pdf" target="_blank">Proceedings PDF</a>
+        </div>
+      </div>
+    </div>
+
+    <span class="pub-year reveal">2022</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Journal</span>
+      <div>
+        <h3 class="pub-title">Generating Dynamic Indoor Environments with Virtual Reality Markups</h3>
+        <p class="pub-venue">Wickramasinghe, W.A.U.Y.S., De Saram, P.S.R.S., Liyanage, C.P., &amp; Rangika, L.N.R. — Journal of Software Engineering &amp; Software Testing, 6(3), 34–75. ManTech Publications.</p>
+        <div class="pub-links">
+          <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">A Review on Reimagining Medical Education with Virtual Reality in Emerging Medical Disciplines</h3>
+        <p class="pub-venue">Inparajah, J., &amp; Wickramasinghe, W. — 15th International Research Conference, p. 36. <span class="cite">1 citation</span></p>
+        <div class="pub-links">
+          <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
+        </div>
+      </div>
+    </div>
+
+    <span class="pub-year reveal">2017</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">Virtual Reality Markup Framework for Generating Interactive Indoor Environment</h3>
+        <p class="pub-venue">Wickramasinghe, W., De Saram, P., Liyanage, C.P., Rangika, L.N.R., et al. — 2017 IEEE 3rd International Conference on Engineering Technologies and Social Sciences (ICETSS). IEEE. <span class="cite">4 citations</span></p>
+        <div class="pub-links">
+          <a href="https://ieeexplore.ieee.org/document/8324175" target="_blank" rel="noopener">IEEE Xplore</a>
+        </div>
+      </div>
+    </div>
+
+    <span class="pub-year reveal">2015</span>
+
+    <div class="pub-row reveal">
+      <span class="pub-type">Conference</span>
+      <div>
+        <h3 class="pub-title">A Mobile Application with Augmented Reality to Enhance Sinhala Learning Experience for Children</h3>
+        <p class="pub-venue">Wickramasinghe, W., &amp; Gunasekara, E.H.D.A. — Research Symposium of the Information Technology Research Unit (ITRU 2015). University of Moratuwa, Sri Lanka. <span class="cite">1 citation</span></p>
+        <div class="pub-links">
+          <a href="http://dl.lib.uom.lk/handle/123/12494" target="_blank" rel="noopener">UoM Repository</a>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<section class="section">
+  <div class="container split">
+    <div class="sticky-col reveal">
+      <span class="eyebrow">03 — Network</span>
+      <h2>Collaborators &amp; <em>Links</em></h2>
+      <p style="color:var(--text-dim); font-weight:300; margin-top:20px; font-size:15px;">Co-authoring with researchers at HIT Lab NZ, University of Moratuwa, and Niantic Aotearoa.</p>
+    </div>
+    <div class="grid-2">
+      <a class="card reveal" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">
+        <span class="kicker">Profile</span>
+        <h3>Google Scholar</h3>
+        <p>Full citation record and publication history.</p>
+      </a>
+      <a class="card reveal" style="--d:.05s" href="https://www.hitlabnz.org/index.php/project/location-based-ar-game-2/" target="_blank" rel="noopener">
+        <span class="kicker">Lab</span>
+        <h3>HIT Lab NZ — AR Games Project</h3>
+        <p>The location-based AR games research project page.</p>
+      </a>
+      <a class="card reveal" style="--d:.1s" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">
+        <span class="kicker">Thesis</span>
+        <h3>PhD Thesis — UC Repository</h3>
+        <p>Full dissertation at the University of Canterbury.</p>
+      </a>
+      <a class="card reveal" style="--d:.15s" href="https://www.yoobee.ac.nz/our-research-profile/yasas-sri-wickramasinghe" target="_blank" rel="noopener">
+        <span class="kicker">Profile</span>
+        <h3>Yoobee Research Profile</h3>
+        <p>Institutional research profile at Yoobee Colleges.</p>
       </a>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- Citation Metrics / External Links -->
-  <section class="py-stack-lg bg-surface-container-lowest rounded-xl border border-outline-variant p-stack-md mb-stack-lg">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-stack-lg">
-      <div>
-        <h3 class="font-headline-sm text-headline-sm text-primary mb-stack-sm">Citation Metrics</h3>
-        <p class="font-caption text-caption text-on-surface-variant mb-4 italic">Source: Google Scholar · Updated 2026</p>
-        <div class="space-y-3">
-          <div class="flex justify-between items-center font-body-md text-body-md border-b border-outline-variant pb-2">
-            <span class="text-on-surface-variant">Total Publications</span>
-            <span class="font-bold text-primary">12</span>
-          </div>
-          <div class="flex justify-between items-center font-body-md text-body-md border-b border-outline-variant pb-2">
-            <span class="text-on-surface-variant">Total Citations</span>
-            <span class="font-bold text-primary">7</span>
-          </div>
-          <div class="flex justify-between items-center font-body-md text-body-md border-b border-outline-variant pb-2">
-            <span class="text-on-surface-variant">Citations since 2021</span>
-            <span class="font-bold text-primary">6</span>
-          </div>
-          <div class="flex justify-between items-center font-body-md text-body-md border-b border-outline-variant pb-2">
-            <span class="text-on-surface-variant">h-index</span>
-            <span class="font-bold text-primary">1</span>
-          </div>
-          <div class="flex justify-between items-center font-body-md text-body-md">
-            <span class="text-on-surface-variant">Active Publishing Years</span>
-            <span class="font-bold text-primary">2015 – 2025</span>
-          </div>
-        </div>
-      </div>
-      <div>
-        <h3 class="font-headline-sm text-headline-sm text-primary mb-stack-sm">Key Collaborators &amp; Links</h3>
-        <p class="font-body-md text-body-md text-on-surface-variant mb-4">Co-authoring with researchers at HIT Lab NZ, University of Moratuwa, and Niantic Aotearoa.</p>
-        <div class="flex flex-col gap-2">
-          <a class="group flex items-center justify-between p-3 border border-outline-variant rounded hover:border-primary transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">
-            <span class="font-label-md text-label-md">Google Scholar Profile</span>
-            <span class="material-symbols-outlined text-outline group-hover:text-primary">open_in_new</span>
-          </a>
-          <a class="group flex items-center justify-between p-3 border border-outline-variant rounded hover:border-primary transition-colors" href="https://www.hitlabnz.org/index.php/project/location-based-ar-game-2/" target="_blank">
-            <span class="font-label-md text-label-md">HIT Lab NZ — AR Games Project</span>
-            <span class="material-symbols-outlined text-outline group-hover:text-primary">open_in_new</span>
-          </a>
-          <a class="group flex items-center justify-between p-3 border border-outline-variant rounded hover:border-primary transition-colors" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank">
-            <span class="font-label-md text-label-md">PhD Thesis — UC Repository</span>
-            <span class="material-symbols-outlined text-outline group-hover:text-primary">open_in_new</span>
-          </a>
-          <a class="group flex items-center justify-between p-3 border border-outline-variant rounded hover:border-primary transition-colors" href="https://www.yoobee.ac.nz/our-research-profile/yasas-sri-wickramasinghe" target="_blank">
-            <span class="font-label-md text-label-md">Yoobee Research Profile</span>
-            <span class="material-symbols-outlined text-outline group-hover:text-primary">open_in_new</span>
-          </a>
-        </div>
-      </div>
+<section class="cta">
+  <div class="container">
+    <span class="eyebrow reveal">Collaboration</span>
+    <h2 class="reveal" style="--d:.1s">Interested in <em>collaborating</em> on XR research?</h2>
+    <div class="cta-actions reveal" style="--d:.2s">
+      <a class="btn btn-solid" href="contact.html">Get in Touch <span class="arrow">→</span></a>
+      <a class="btn" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar ↗</a>
     </div>
-  </section>
+  </div>
+</section>
 
-</main>
-
-<!-- Footer -->
-<footer class="w-full mt-stack-lg bg-surface-container-low border-t border-outline-variant">
-  <div class="flex flex-col md:flex-row justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-md">
-    <div class="mb-stack-sm md:mb-0">
-      <span class="font-headline-sm text-headline-sm text-primary">Dr. Yasas Sri Wickramasinghe</span>
-      <p class="font-caption text-caption text-on-surface-variant mt-1">© 2026 Yasas Sri Wickramasinghe. All rights reserved.</p>
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Dr. Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
     </div>
-    <div class="flex gap-gutter">
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank">Google Scholar</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://www.linkedin.com/in/yasassri" target="_blank">LinkedIn</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="https://twitter.com/sri_yasas" target="_blank">Twitter/X</a>
-      <a class="font-caption text-caption text-on-surface-variant hover:text-primary transition-colors" href="contact.html">Contact</a>
+    <div class="footer-links">
+      <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Scholar</a>
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter/X</a>
+      <a href="contact.html">Contact</a>
     </div>
   </div>
 </footer>
 
-<script>
-  window.addEventListener('scroll', () => {
-    const header = document.querySelector('header');
-    if (window.scrollY > 50) {
-      header.classList.add('shadow-sm');
-      header.style.backgroundColor = 'rgba(250, 249, 246, 0.95)';
-      header.style.backdropFilter = 'blur(8px)';
-    } else {
-      header.classList.remove('shadow-sm');
-      header.style.backgroundColor = '#faf9f6';
-      header.style.backdropFilter = 'none';
-    }
-  });
-</script>
+<script src="assets/js/premium.js"></script>
 </body>
 </html>

--- a/teaching.html
+++ b/teaching.html
@@ -1,146 +1,15 @@
 <!DOCTYPE html>
-<html class="light" lang="en">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Teaching | Dr. Yasas Sri Wickramasinghe</title>
-<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;500;600&family=Inter:wght@400;500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-<script id="tailwind-config">
-  tailwind.config = {
-    darkMode: "class",
-    theme: {
-      extend: {
-        "colors": {
-          "primary-fixed-dim": "#b8c8dc",
-          "inverse-on-surface": "#f2f1ee",
-          "on-primary-fixed": "#0c1d2b",
-          "on-secondary-fixed": "#261900",
-          "error": "#ba1a1a",
-          "inverse-primary": "#b8c8dc",
-          "primary": "#051625",
-          "error-container": "#ffdad6",
-          "outline-variant": "#c4c6cc",
-          "background": "#faf9f6",
-          "on-background": "#1a1c1a",
-          "surface-variant": "#e3e2e0",
-          "secondary-container": "#fed488",
-          "on-tertiary-fixed": "#121e14",
-          "on-secondary-fixed-variant": "#5d4201",
-          "on-secondary": "#ffffff",
-          "on-primary": "#ffffff",
-          "surface-container": "#efeeeb",
-          "surface": "#faf9f6",
-          "on-surface-variant": "#43474c",
-          "surface-container-lowest": "#ffffff",
-          "on-surface": "#1a1c1a",
-          "surface-container-high": "#e9e8e5",
-          "on-tertiary-fixed-variant": "#3c4a3d",
-          "secondary-fixed-dim": "#e9c176",
-          "on-secondary-container": "#785a1a",
-          "secondary": "#775a19",
-          "surface-dim": "#dbdad7",
-          "tertiary": "#0c180e",
-          "tertiary-fixed-dim": "#bbcbba",
-          "surface-container-low": "#f4f3f1",
-          "on-error": "#ffffff",
-          "inverse-surface": "#2f312f",
-          "on-tertiary": "#ffffff",
-          "surface-container-highest": "#e3e2e0",
-          "on-error-container": "#93000a",
-          "primary-fixed": "#d3e4f8",
-          "secondary-fixed": "#ffdea5",
-          "primary-container": "#1b2b3a",
-          "tertiary-fixed": "#d7e7d5",
-          "tertiary-container": "#202d22",
-          "surface-tint": "#506071",
-          "on-tertiary-container": "#869586",
-          "on-primary-fixed-variant": "#384858",
-          "on-primary-container": "#8292a5",
-          "surface-bright": "#faf9f6",
-          "outline": "#74777c"
-        },
-        "borderRadius": {
-          "DEFAULT": "0.125rem",
-          "lg": "0.25rem",
-          "xl": "0.5rem",
-          "full": "0.75rem"
-        },
-        "spacing": {
-          "stack-sm": "12px",
-          "margin-desktop": "64px",
-          "stack-md": "24px",
-          "gutter": "24px",
-          "margin-mobile": "16px",
-          "container-max": "1140px",
-          "unit": "8px",
-          "stack-lg": "48px"
-        },
-        "fontFamily": {
-          "display-lg": ["Newsreader"],
-          "label-md": ["Inter"],
-          "headline-md": ["Newsreader"],
-          "display-lg-mobile": ["Newsreader"],
-          "headline-sm": ["Newsreader"],
-          "body-lg": ["Inter"],
-          "body-md": ["Inter"],
-          "caption": ["Inter"]
-        },
-        "fontSize": {
-          "display-lg": ["48px", {"lineHeight": "1.1", "letterSpacing": "-0.02em", "fontWeight": "600"}],
-          "label-md": ["14px", {"lineHeight": "1.2", "letterSpacing": "0.05em", "fontWeight": "600"}],
-          "headline-md": ["32px", {"lineHeight": "1.3", "fontWeight": "500"}],
-          "display-lg-mobile": ["36px", {"lineHeight": "1.2", "fontWeight": "600"}],
-          "headline-sm": ["24px", {"lineHeight": "1.4", "fontWeight": "500"}],
-          "body-lg": ["18px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "body-md": ["16px", {"lineHeight": "1.6", "fontWeight": "400"}],
-          "caption": ["12px", {"lineHeight": "1.4", "fontWeight": "400"}]
-        }
-      },
-    },
-  }
-</script>
-<style>
-  .material-symbols-outlined {
-    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-    display: inline-block;
-    vertical-align: middle;
-    line-height: 1;
-  }
-  body { background-color: #faf9f6; color: #1a1c1a; -webkit-font-smoothing: antialiased; }
-  .content-card {
-    background-color: #ffffff;
-    border: 1px solid #e3e2e0;
-    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  }
-  .content-card:hover { border-color: #051625; }
-  .feature-card {
-    background-color: #ffffff;
-    border: 1px solid #e3e2e0;
-    transition: transform 0.2s ease-out, border-color 0.2s ease-in-out;
-  }
-  .feature-card:hover { transform: translateY(-2px); border-color: #051625; }
-  .course-card {
-    background-color: #ffffff;
-    border: 1px solid #e3e2e0;
-    border-top: 3px solid #051625;
-    transition: border-color 0.2s ease-in-out;
-  }
-  .course-card.gold { border-top-color: #775a19; }
-  .tech-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 8px;
-    background-color: #efeeeb;
-    border: 1px solid #c4c6cc;
-    font-size: 11px;
-    font-family: Inter, sans-serif;
-    color: #43474c;
-    letter-spacing: 0.04em;
-  }
-</style>
+<title>Teaching — Dr. Yasas Sri Wickramasinghe</title>
+<meta name="description" content="Teaching practice and the YooBees learning platform — Dr. Yasas Sri Wickramasinghe, Senior Lecturer at Yoobee Colleges."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=Inter:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/premium.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -150,500 +19,293 @@
   gtag('config', 'G-N2BH0F6SNE');
 </script>
 </head>
-<body class="font-body-md text-body-md bg-background">
+<body>
 
-<!-- TopNavBar -->
-<nav class="w-full top-0 sticky z-50 bg-surface border-b border-outline-variant">
-  <div class="flex justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-sm">
-    <a class="font-display-lg text-headline-sm text-primary tracking-tight" href="index.html">Dr. Yasas Sri Wickramasinghe</a>
-    <div class="hidden md:flex items-center gap-gutter">
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-body-md text-body-md" href="index.html">Home</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-body-md text-body-md" href="research.html">Research</a>
-      <a class="text-primary font-bold border-b-2 border-primary pb-1 font-body-md text-body-md" href="teaching.html">Teaching</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-body-md text-body-md" href="blogs.html">Blogs</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-body-md text-body-md" href="contact.html">Contact</a>
-      <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 font-label-md text-label-md hover:opacity-80 transition-opacity">Curriculum Vitae</a>
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Dr. Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="research.html">Research</a>
+      <a class="active" href="teaching.html">Teaching</a>
+      <a href="blogs.html">Writing</a>
+      <a href="contact.html">Contact</a>
+      <a class="btn" href="assets/files/cv_yasas.pdf" target="_blank">CV <span class="arrow">→</span></a>
     </div>
-    <button class="md:hidden text-primary" onclick="document.getElementById('mobile-menu-t').classList.toggle('hidden')">
-      <span class="material-symbols-outlined">menu</span>
-    </button>
-  </div>
-  <div class="hidden md:hidden bg-surface border-t border-outline-variant px-margin-mobile py-stack-md flex flex-col gap-stack-sm" id="mobile-menu-t">
-    <a class="font-body-md text-on-surface-variant" href="index.html">Home</a>
-    <a class="font-body-md text-on-surface-variant" href="research.html">Research</a>
-    <a class="font-body-md text-primary font-bold" href="teaching.html">Teaching</a>
-    <a class="font-body-md text-on-surface-variant" href="blogs.html">Blogs</a>
-    <a class="font-body-md text-on-surface-variant" href="contact.html">Contact</a>
-    <a href="assets/files/cv_yasas.pdf" target="_blank" class="bg-primary text-on-primary px-6 py-2 w-fit font-label-md text-label-md">Curriculum Vitae</a>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
   </div>
 </nav>
+<div class="mobile-menu">
+  <a href="index.html"><span class="idx">01</span>Home</a>
+  <a href="research.html"><span class="idx">02</span>Research</a>
+  <a class="active" href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a href="blogs.html"><span class="idx">04</span>Writing</a>
+  <a href="contact.html"><span class="idx">05</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
+</div>
 
-<main class="max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-lg">
+<header class="page-hero">
+  <div class="container">
+    <span class="eyebrow reveal">Teaching &amp; EdTech</span>
+    <h1 class="reveal" style="--d:.1s">Building the future of <em>learning</em>.</h1>
+    <p class="lead reveal" style="--d:.2s">
+      I design experiential, technology-forward classrooms — and build the platforms that power them. My teaching practice at Yoobee Colleges is inseparable from YooBees, a real-time learning platform I created to bring attendance, live coding, competitive SQL, and AI-assisted reasoning into every session.
+    </p>
+  </div>
+</header>
 
-  <!-- Header Section -->
-  <header class="mb-stack-lg max-w-3xl">
-    <p class="font-label-md text-label-md text-secondary mb-stack-sm tracking-widest">TEACHING &amp; EDTECH</p>
-    <h1 class="font-display-lg text-display-lg-mobile md:text-display-lg text-primary mb-stack-sm">Building the Future<br/>of Learning</h1>
-    <p class="font-body-lg text-body-lg text-on-surface-variant">I design experiential, technology-forward classrooms — and build the platforms that power them. My teaching practice at Yoobee Colleges is inseparable from YooBees, a real-time learning platform I created to bring attendance, live coding, competitive SQL, and AI-assisted reasoning into every session.</p>
-  </header>
-
-  <!-- =========================================================
-       YOOBEES PLATFORM SECTION
-  ========================================================= -->
-  <section class="mb-stack-lg">
-    <div class="flex items-center gap-2 mb-stack-md border-b border-outline-variant pb-2">
-      <span class="material-symbols-outlined text-secondary">deployed_code</span>
-      <h2 class="font-headline-md text-headline-md text-primary">YooBees — The Platform I Built</h2>
+<section class="section" id="yoobees">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">01</span>
+      <h2>YooBees — The Platform <em>I Built</em></h2>
     </div>
 
-    <!-- Platform overview: image + description -->
-    <div class="grid grid-cols-1 lg:grid-cols-12 gap-gutter mb-stack-md">
-
-      <!-- Dashboard graphic -->
-      <div class="lg:col-span-7 content-card overflow-hidden">
-        <img src="assets/images/teaching-yoobees-dashboard.svg" alt="YooBees Lecturer Dashboard" class="w-full h-auto"/>
+    <div class="feature-row reveal" style="border-bottom:none; padding-top:0;">
+      <div class="feature-media">
+        <img alt="YooBees Lecturer Dashboard" src="assets/images/teaching-yoobees-dashboard.svg"/>
       </div>
-
-      <!-- Description + tech stack -->
-      <div class="lg:col-span-5 flex flex-col gap-stack-md">
-        <div class="content-card p-stack-md flex-1">
-          <h3 class="font-headline-sm text-headline-sm text-primary mb-stack-sm">A Real-Time Learning Platform</h3>
-          <p class="text-on-surface-variant leading-relaxed mb-stack-sm">
-            YooBees is a full-stack web application I designed and built from scratch to serve the Masters of Business Informatics (MBI) programme at Yoobee Colleges. It replaces static slide decks and paper registers with a live, interactive, data-driven classroom experience.
-          </p>
-          <p class="text-on-surface-variant leading-relaxed">
-            Every feature was shaped by a real classroom problem — from fraudulent attendance submissions caught by three detection algorithms, to students competing on SQL queries in real time.
-          </p>
+      <div>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25;">A Real-Time Learning Platform</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">YooBees is a full-stack web application I designed and built from scratch to serve the Masters of Business Informatics (MBI) programme at Yoobee Colleges. It replaces static slide decks and paper registers with a live, interactive, data-driven classroom experience.</p>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:14px;">Every feature was shaped by a real classroom problem — from fraudulent attendance submissions caught by three detection algorithms, to students competing on SQL queries in real time.</p>
+        <div class="tags">
+          <span class="tag">React 18</span><span class="tag">TypeScript 5</span><span class="tag">Vite 5</span><span class="tag">Tailwind CSS 3</span><span class="tag gold">Firebase Auth</span><span class="tag gold">Firestore</span><span class="tag gold">Firebase Storage</span>
         </div>
-
-        <!-- Tech stack card -->
-        <div class="bg-primary p-stack-md">
-          <p class="font-label-md text-label-md text-primary-fixed-dim mb-stack-sm tracking-widest">TECH STACK</p>
-          <div class="flex flex-wrap gap-2">
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#b8c8dc;">React 18</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#b8c8dc;">TypeScript 5</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#b8c8dc;">Vite 5</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#b8c8dc;">Tailwind CSS 3</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#e9c176;">Firebase Auth</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#e9c176;">Firestore</span>
-            <span class="tech-badge" style="background:#1b2b3a;border-color:#384858;color:#e9c176;">Firebase Storage</span>
-          </div>
-          <p class="font-caption text-caption mt-stack-sm" style="color:#8292a5;">Open-source · github.com/ureshan2011/YooBees</p>
-        </div>
+        <p style="font-family:var(--mono); font-size:11px; letter-spacing:.1em; color:var(--muted); margin-top:18px;">OPEN-SOURCE · GITHUB.COM/URESHAN2011/YOOBEES</p>
       </div>
     </div>
 
-    <!-- Platform stats row -->
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-gutter mb-stack-md">
-      <div class="content-card p-stack-md text-center">
-        <p class="font-display-lg text-headline-md md:text-display-lg-mobile text-primary font-bold">228</p>
-        <p class="font-label-md text-label-md text-on-surface-variant mt-1 tracking-widest">STUDENTS</p>
-        <p class="font-caption text-caption text-on-surface-variant">enrolled across 3 courses</p>
+    <div class="stats reveal">
+      <div class="stat">
+        <div class="stat-value"><span class="count" data-target="228">0</span></div>
+        <span class="stat-label">Students — across 3 courses</span>
       </div>
-      <div class="content-card p-stack-md text-center" style="border-top:3px solid #775a19;">
-        <p class="font-display-lg text-headline-md md:text-display-lg-mobile text-secondary font-bold">24</p>
-        <p class="font-label-md text-label-md text-on-surface-variant mt-1 tracking-widest">COUNTRIES</p>
-        <p class="font-caption text-caption text-on-surface-variant">represented in cohorts</p>
+      <div class="stat">
+        <div class="stat-value"><span class="count" data-target="24">0</span></div>
+        <span class="stat-label">Countries in cohorts</span>
       </div>
-      <div class="content-card p-stack-md text-center">
-        <p class="font-display-lg text-headline-md md:text-display-lg-mobile text-primary font-bold">2,500+</p>
-        <p class="font-label-md text-label-md text-on-surface-variant mt-1 tracking-widest">SESSIONS</p>
-        <p class="font-caption text-caption text-on-surface-variant">attendance records logged</p>
+      <div class="stat">
+        <div class="stat-value"><span class="count" data-target="2500">0</span><span class="suffix">+</span></div>
+        <span class="stat-label">Attendance records logged</span>
       </div>
-      <div class="content-card p-stack-md text-center">
-        <p class="font-display-lg text-headline-md md:text-display-lg-mobile text-primary font-bold">100+</p>
-        <p class="font-label-md text-label-md text-on-surface-variant mt-1 tracking-widest">QUIZ MCQs</p>
-        <p class="font-caption text-caption text-on-surface-variant">+ 16 lecture videos</p>
+      <div class="stat">
+        <div class="stat-value"><span class="count" data-target="100">0</span><span class="suffix">+</span></div>
+        <span class="stat-label">Quiz MCQs · 16 lecture videos</span>
       </div>
     </div>
 
-    <!-- Feature cards bento grid -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-gutter">
+    <div class="grid-3" style="margin-top: 56px;">
 
-      <!-- One-tap Attendance + Fraud Detection -->
-      <div class="feature-card p-stack-md">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-            <span class="material-symbols-outlined text-primary">fingerprint</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] text-primary font-bold leading-tight">One-tap Attendance</h3>
-            <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-0.5">+ FRAUD DETECTION</p>
-          </div>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm mb-stack-sm">Students check in with a single tap. Three detection algorithms run in real time to flag dishonest submissions:</p>
-        <ul class="space-y-1.5">
-          <li class="flex items-start gap-2 text-sm text-on-surface-variant">
-            <span class="text-error font-bold mt-0.5">⚑</span>
-            <span><strong class="text-primary">Shared-IP clustering</strong> — detects multiple students submitting from one device</span>
-          </li>
-          <li class="flex items-start gap-2 text-sm text-on-surface-variant">
-            <span class="text-error font-bold mt-0.5">⚑</span>
-            <span><strong class="text-primary">GPS outlier detection</strong> — flags GPS coordinates &gt;500 m from campus</span>
-          </li>
-          <li class="flex items-start gap-2 text-sm text-on-surface-variant">
-            <span class="text-error font-bold mt-0.5">⚑</span>
-            <span><strong class="text-primary">Rapid-submission window</strong> — catches submissions within 30 s of session open</span>
-          </li>
-        </ul>
+      <div class="card reveal">
+        <span class="kicker">+ Fraud Detection</span>
+        <h3>One-tap Attendance</h3>
+        <p>Students check in with a single tap. Three detection algorithms run in real time to flag dishonest submissions: shared-IP clustering (multiple students on one device), GPS outlier detection (coordinates &gt;500&nbsp;m from campus), and a rapid-submission window (check-ins within 30&nbsp;s of session open).</p>
       </div>
 
-      <!-- Live Playground -->
-      <div class="feature-card p-stack-md bg-primary" style="border-color:#384858;">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 flex items-center justify-center" style="background:#1b2b3a;">
-            <span class="material-symbols-outlined" style="color:#b8c8dc;">terminal</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] font-bold leading-tight" style="color:#d3e4f8;">Live Playground</h3>
-            <p class="font-caption text-caption font-semibold tracking-wider mt-0.5" style="color:#775a19;">IN-CLASS CODING</p>
-          </div>
-        </div>
-        <p class="leading-relaxed text-sm mb-stack-sm" style="color:#8292a5;">An in-browser code execution environment embedded directly in lectures. Students write and run SQL, Python snippets, and pseudocode without leaving the platform — and I can see their output live.</p>
-        <div class="p-3 font-mono text-xs" style="background:#0c180e;color:#869586;border-radius:2px;">
-          <span style="color:#775a19;">SELECT</span> dept, <span style="color:#b8c8dc;">AVG</span>(salary)<br/>
-          <span style="color:#775a19;">FROM</span> employees<br/>
-          <span style="color:#775a19;">GROUP BY</span> dept<br/>
-          <span style="color:#869586;opacity:0.6;">→ 12 rows returned ✓</span>
+      <div class="card reveal" style="--d:.05s">
+        <span class="kicker">In-class Coding</span>
+        <h3>Live Playground</h3>
+        <p>An in-browser code execution environment embedded directly in lectures. Students write and run SQL, Python snippets, and pseudocode without leaving the platform — and I can see their output live.</p>
+        <div style="margin-top:18px; padding:16px; border:1px solid var(--line); border-radius:4px; font-family:var(--mono); font-size:12px; line-height:1.8; color:var(--text-dim); background:rgba(0,0,0,.3);">
+          <span style="color:var(--accent)">SELECT</span> dept, AVG(salary)<br/>
+          <span style="color:var(--accent)">FROM</span> employees<br/>
+          <span style="color:var(--accent)">GROUP BY</span> dept<br/>
+          <span style="color:var(--muted)">→ 12 rows returned ✓</span>
         </div>
       </div>
 
-      <!-- SQL Race -->
-      <div class="feature-card p-stack-md" style="border-top:3px solid #775a19;">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 bg-secondary-fixed flex items-center justify-center">
-            <span class="material-symbols-outlined text-secondary">sprint</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] text-primary font-bold leading-tight">SQL Race</h3>
-            <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-0.5">COMPETITIVE LEARNING</p>
-          </div>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm">Students race around a virtual track by solving SQL challenges in sequence — SELECT → WHERE → JOIN → GROUP BY → ORDER BY → HAVING. A live leaderboard drives friendly competition and keeps engagement high across 228 students.</p>
+      <div class="card reveal" style="--d:.1s">
+        <span class="kicker">Competitive Learning</span>
+        <h3>SQL Race</h3>
+        <p>Students race around a virtual track by solving SQL challenges in sequence — SELECT → WHERE → JOIN → GROUP BY → ORDER BY → HAVING. A live leaderboard drives friendly competition and keeps engagement high across 228 students.</p>
       </div>
 
-      <!-- Quiz Badges -->
-      <div class="feature-card p-stack-md">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-            <span class="material-symbols-outlined text-secondary">military_tech</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] text-primary font-bold leading-tight">Quiz Badges</h3>
-            <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-0.5">GAMIFIED ASSESSMENT</p>
-          </div>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm mb-stack-sm">Over 100 MCQ questions across all three MBI courses. Students earn badge tiers as they progress, with instant feedback and explanations. Results feed directly into the lecturer analytics dashboard.</p>
-        <div class="flex gap-2 mt-2">
-          <span class="text-2xl" title="Bronze">🏅</span>
-          <span class="text-2xl" title="Silver">⭐</span>
-          <span class="text-2xl opacity-40" title="Gold — locked">🏆</span>
-        </div>
+      <div class="card reveal">
+        <span class="kicker">Gamified Assessment</span>
+        <h3>Quiz Badges</h3>
+        <p>Over 100 MCQ questions across all three MBI courses. Students earn badge tiers as they progress, with instant feedback and explanations. Results feed directly into the lecturer analytics dashboard.</p>
       </div>
 
-      <!-- Daily Match -->
-      <div class="feature-card p-stack-md">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 bg-tertiary-fixed flex items-center justify-center">
-            <span class="material-symbols-outlined text-primary">groups</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] text-primary font-bold leading-tight">Daily Match</h3>
-            <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-0.5">PEER COLLABORATION</p>
-          </div>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm">A daily collaborative challenge pairs students across cohorts to solve a shared problem together. Designed to build cross-cultural communication skills in an international classroom spanning 24 countries.</p>
+      <div class="card reveal" style="--d:.05s">
+        <span class="kicker">Peer Collaboration</span>
+        <h3>Daily Match</h3>
+        <p>A daily collaborative challenge pairs students across cohorts to solve a shared problem together. Designed to build cross-cultural communication skills in an international classroom spanning 24 countries.</p>
       </div>
 
-      <!-- Cohort Analytics -->
-      <div class="feature-card p-stack-md">
-        <div class="flex items-start gap-3 mb-stack-sm">
-          <div class="w-10 h-10 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-            <span class="material-symbols-outlined text-primary">analytics</span>
-          </div>
-          <div>
-            <h3 class="font-headline-sm text-[18px] text-primary font-bold leading-tight">Cohort Analytics</h3>
-            <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-0.5">REAL-TIME INSIGHTS</p>
-          </div>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm">A lecturer-only dashboard surfaces attendance trends, quiz completion rates, country-level engagement, and fraud alert history — giving me a full picture of each cohort without manual data wrangling.</p>
+      <div class="card reveal" style="--d:.1s">
+        <span class="kicker">Real-time Insights</span>
+        <h3>Cohort Analytics</h3>
+        <p>A lecturer-only dashboard surfaces attendance trends, quiz completion rates, country-level engagement, and fraud alert history — giving me a full picture of each cohort without manual data wrangling.</p>
       </div>
 
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- =========================================================
-       SQL RACE SPOTLIGHT
-  ========================================================= -->
-  <section class="mb-stack-lg">
-    <div class="flex items-center gap-2 mb-stack-md border-b border-outline-variant pb-2">
-      <span class="material-symbols-outlined text-secondary">sprint</span>
-      <h2 class="font-headline-md text-headline-md text-primary">SQL Race — Feature Spotlight</h2>
+<section class="section" id="sql-race">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>SQL Race — Feature <em>Spotlight</em></h2>
     </div>
-    <div class="grid grid-cols-1 lg:grid-cols-12 gap-gutter items-center">
-      <div class="lg:col-span-7 content-card overflow-hidden">
-        <img src="assets/images/teaching-sql-race.svg" alt="SQL Race game track visualization" class="w-full h-auto"/>
+    <div class="feature-row reveal" style="border:none; padding:0;">
+      <div class="feature-media">
+        <img alt="SQL Race game track visualization" src="assets/images/teaching-sql-race.svg"/>
       </div>
-      <div class="lg:col-span-5 space-y-stack-md">
-        <div class="content-card p-stack-md">
-          <h3 class="font-headline-sm text-headline-sm text-primary mb-stack-sm">Why a Race?</h3>
-          <p class="text-on-surface-variant leading-relaxed text-sm mb-3">SQL Race transforms database exercises into a live, multiplayer competition. Each checkpoint on the track corresponds to a core SQL clause. Students only advance by writing a correct query — keeping the learning rigorous while the format keeps energy high.</p>
-          <p class="text-on-surface-variant leading-relaxed text-sm">It was born out of a simple observation: students who were bored by textbook drills became intensely focused the moment there was a leaderboard.</p>
-        </div>
-        <div class="content-card p-stack-md">
-          <p class="font-label-md text-label-md text-secondary mb-stack-sm tracking-widest">CHECKPOINTS</p>
-          <div class="space-y-2">
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-primary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">1</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">SELECT</code> — basic column retrieval</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-secondary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">2</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">WHERE</code> — row-level filtering</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-primary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">3</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">JOIN</code> — multi-table relationships</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-primary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">4</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">GROUP BY</code> — aggregation logic</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-secondary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">5</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">ORDER BY</code> — result sorting</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-6 h-6 bg-primary flex items-center justify-center text-xs text-white font-bold flex-shrink-0">6</span>
-              <span class="text-sm text-on-surface"><code class="bg-surface-container px-1 py-0.5 text-primary font-mono text-xs">HAVING</code> — post-aggregation filter</span>
-            </div>
-          </div>
+      <div>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25;">Why a Race?</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">SQL Race transforms database exercises into a live, multiplayer competition. Each checkpoint on the track corresponds to a core SQL clause. Students only advance by writing a correct query — keeping the learning rigorous while the format keeps energy high.</p>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:14px;">It was born out of a simple observation: students who were bored by textbook drills became intensely focused the moment there was a leaderboard.</p>
+        <div class="info-list" style="margin-top:24px;">
+          <div class="info-row"><span class="k">01 · Select</span><span class="v">Basic column retrieval</span></div>
+          <div class="info-row"><span class="k">02 · Where</span><span class="v">Row-level filtering</span></div>
+          <div class="info-row"><span class="k">03 · Join</span><span class="v">Multi-table relationships</span></div>
+          <div class="info-row"><span class="k">04 · Group By</span><span class="v">Aggregation logic</span></div>
+          <div class="info-row"><span class="k">05 · Order By</span><span class="v">Result sorting</span></div>
+          <div class="info-row" style="border-bottom:none;"><span class="k">06 · Having</span><span class="v">Post-aggregation filter</span></div>
         </div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- =========================================================
-       MBI COURSE CATALOG
-  ========================================================= -->
-  <section class="mb-stack-lg">
-    <div class="flex items-center justify-between mb-stack-md border-b border-outline-variant pb-2">
-      <div class="flex items-center gap-2">
-        <span class="material-symbols-outlined text-secondary">menu_book</span>
-        <h2 class="font-headline-md text-headline-md text-primary">MBI Course Catalog</h2>
-      </div>
-      <span class="font-caption text-caption text-on-surface-variant italic">Masters of Business Informatics · Yoobee Colleges NZ</span>
+<section class="section" id="courses">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">03</span>
+      <h2>MBI Course <em>Catalog</em></h2>
+      <span class="head-link" style="font-family:var(--mono); font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--muted);">Masters of Business Informatics · Yoobee Colleges NZ</span>
     </div>
+    <div class="grid-3">
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-gutter">
-
-      <!-- MBI800 -->
-      <div class="course-card p-stack-md flex flex-col">
-        <div class="mb-stack-sm">
-          <span class="font-label-md text-label-md text-on-surface-variant tracking-widest">MBI800</span>
-          <h3 class="font-headline-sm text-headline-sm text-primary mt-1 leading-tight">Business Information Systems</h3>
-          <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-1">STRATEGY &amp; SYSTEMS PLANNING</p>
+      <div class="card reveal">
+        <span class="kicker">MBI800 · Strategy &amp; Systems Planning</span>
+        <h3>Business Information Systems</h3>
+        <p>Covers the strategic role of information systems in organisations — from IS alignment and SISP (Strategic Information Systems Planning) to digital transformation frameworks and Porter's competitive models.</p>
+        <div class="tags">
+          <span class="tag">IS Strategy</span><span class="tag">SISP</span><span class="tag">Porter's Models</span><span class="tag">Digital Transformation</span><span class="tag">Value Chain</span>
         </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm flex-1 mb-stack-sm">Covers the strategic role of information systems in organisations — from IS alignment and SISP (Strategic Information Systems Planning) to digital transformation frameworks and Porter's competitive models.</p>
-        <div class="border-t border-outline-variant pt-stack-sm">
-          <p class="font-label-md text-label-md text-on-surface-variant mb-2 tracking-widest">KEY TOPICS</p>
-          <div class="flex flex-wrap gap-1.5 mb-stack-sm">
-            <span class="tech-badge">IS Strategy</span>
-            <span class="tech-badge">SISP</span>
-            <span class="tech-badge">Porter's Models</span>
-            <span class="tech-badge">Digital Transformation</span>
-            <span class="tech-badge">Value Chain Analysis</span>
-          </div>
-        </div>
-        <div class="bg-surface-container-low p-3 border border-outline-variant">
-          <p class="font-label-md text-label-md text-secondary mb-1 tracking-wider">✦ PLATFORM FEATURE</p>
-          <p class="text-sm text-on-surface-variant"><strong class="text-primary">SISP Prompt Lab</strong> — an AI-assisted tool embedded in YooBees that walks students through strategic IS planning exercises using guided prompts and real case data.</p>
-        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ PLATFORM FEATURE</span><br/><strong style="color:var(--text)">SISP Prompt Lab</strong> — an AI-assisted tool embedded in YooBees that walks students through strategic IS planning exercises using guided prompts and real case data.</p>
       </div>
 
-      <!-- MBI802 -->
-      <div class="course-card gold p-stack-md flex flex-col">
-        <div class="mb-stack-sm">
-          <span class="font-label-md text-label-md text-on-surface-variant tracking-widest">MBI802</span>
-          <h3 class="font-headline-sm text-headline-sm text-primary mt-1 leading-tight">Database Management Systems</h3>
-          <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-1">SQL · ER MODELLING · NOSQL</p>
+      <div class="card reveal" style="--d:.08s">
+        <span class="kicker">MBI802 · SQL · ER Modelling · NoSQL</span>
+        <h3>Database Management Systems</h3>
+        <p>A hands-on deep-dive into relational database design, SQL from basics to advanced joins and stored procedures, ER diagram methodology, normalisation theory, and an introduction to NoSQL paradigms.</p>
+        <div class="tags">
+          <span class="tag">ER Diagrams</span><span class="tag">SQL Joins</span><span class="tag">Normalisation</span><span class="tag">Stored Procedures</span><span class="tag">NoSQL</span><span class="tag">Transactions</span>
         </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm flex-1 mb-stack-sm">A hands-on deep-dive into relational database design, SQL from basics to advanced joins and stored procedures, ER diagram methodology, normalisation theory, and an introduction to NoSQL paradigms.</p>
-        <div class="border-t border-outline-variant pt-stack-sm">
-          <p class="font-label-md text-label-md text-on-surface-variant mb-2 tracking-widest">KEY TOPICS</p>
-          <div class="flex flex-wrap gap-1.5 mb-stack-sm">
-            <span class="tech-badge">ER Diagrams</span>
-            <span class="tech-badge">SQL Joins</span>
-            <span class="tech-badge">Normalisation</span>
-            <span class="tech-badge">Stored Procedures</span>
-            <span class="tech-badge">NoSQL</span>
-            <span class="tech-badge">Transactions</span>
-          </div>
-        </div>
-        <div class="bg-secondary-fixed p-3 border border-secondary-fixed-dim">
-          <p class="font-label-md text-label-md text-secondary mb-1 tracking-wider">✦ PLATFORM FEATURES</p>
-          <p class="text-sm text-on-surface-variant"><strong class="text-primary">SQL Race</strong> — competitive live query challenges. <strong class="text-primary">Live Playground</strong> — in-browser SQL execution environment for practice and demonstrations.</p>
-        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ PLATFORM FEATURES</span><br/><strong style="color:var(--text)">SQL Race</strong> — competitive live query challenges. <strong style="color:var(--text)">Live Playground</strong> — in-browser SQL execution environment for practice and demonstrations.</p>
       </div>
 
-      <!-- MBI804 -->
-      <div class="course-card p-stack-md flex flex-col">
-        <div class="mb-stack-sm">
-          <span class="font-label-md text-label-md text-on-surface-variant tracking-widest">MBI804</span>
-          <h3 class="font-headline-sm text-headline-sm text-primary mt-1 leading-tight">IT Project Management</h3>
-          <p class="font-caption text-caption text-secondary font-semibold tracking-wider mt-1">AGILE · SCRUM · RISK MANAGEMENT</p>
+      <div class="card reveal" style="--d:.16s">
+        <span class="kicker">MBI804 · Agile · Scrum · Risk</span>
+        <h3>IT Project Management</h3>
+        <p>Covers the full project lifecycle — initiation, planning, execution, monitoring, and closure — with a strong practical emphasis on Agile methodologies, Scrum ceremonies, stakeholder management, and risk frameworks.</p>
+        <div class="tags">
+          <span class="tag">Agile &amp; Scrum</span><span class="tag">Project Charter</span><span class="tag">Risk Management</span><span class="tag">Stakeholder Comms</span><span class="tag">Gantt &amp; WBS</span>
         </div>
-        <p class="text-on-surface-variant leading-relaxed text-sm flex-1 mb-stack-sm">Covers the full project lifecycle — initiation, planning, execution, monitoring, and closure — with a strong practical emphasis on Agile methodologies, Scrum ceremonies, stakeholder management, and risk frameworks.</p>
-        <div class="border-t border-outline-variant pt-stack-sm">
-          <p class="font-label-md text-label-md text-on-surface-variant mb-2 tracking-widest">KEY TOPICS</p>
-          <div class="flex flex-wrap gap-1.5 mb-stack-sm">
-            <span class="tech-badge">Agile &amp; Scrum</span>
-            <span class="tech-badge">Project Charter</span>
-            <span class="tech-badge">Risk Management</span>
-            <span class="tech-badge">Stakeholder Comms</span>
-            <span class="tech-badge">Gantt &amp; WBS</span>
-          </div>
-        </div>
-        <div class="bg-surface-container-low p-3 border border-outline-variant">
-          <p class="font-label-md text-label-md text-secondary mb-1 tracking-wider">✦ PLATFORM FEATURE</p>
-          <p class="text-sm text-on-surface-variant"><strong class="text-primary">Case Study Labs</strong> — students manage a simulated IT project via YooBees, tracking sprints, updating risk registers, and submitting deliverables with structured peer review.</p>
-        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ PLATFORM FEATURE</span><br/><strong style="color:var(--text)">Case Study Labs</strong> — students manage a simulated IT project via YooBees, tracking sprints, updating risk registers, and submitting deliverables with structured peer review.</p>
       </div>
 
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- =========================================================
-       PHILOSOPHY + AVAILABILITY
-  ========================================================= -->
-  <section class="mb-stack-lg">
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
-
-      <!-- Teaching Philosophy -->
-      <div class="md:col-span-2 content-card p-stack-md">
-        <div class="flex items-center gap-2 mb-stack-sm">
-          <span class="material-symbols-outlined text-secondary">history_edu</span>
-          <h2 class="font-headline-sm text-headline-sm text-primary">Philosophy</h2>
+<section class="section" id="philosophy">
+  <div class="container split">
+    <div class="sticky-col reveal">
+      <span class="eyebrow">04 — Approach</span>
+      <h2>Teaching <em>Philosophy</em></h2>
+    </div>
+    <div>
+      <p class="lead reveal">My approach to education is grounded in experiential and constructivist learning — I believe students learn best by building, failing, iterating, and reflecting. Every feature in YooBees was designed around this principle: the Live Playground lowers the barrier to trying, SQL Race makes failure feel like just one more lap, and badge tiers reward persistence over perfection.</p>
+      <p class="reveal" style="--d:.1s; color:var(--text-dim); font-weight:300; margin-top:24px;">I prioritise purpose-driven education: helping students not just acquire technical skills, but develop the vision and initiative to use them meaningfully. In a classroom spanning 24 countries, that also means building cultural fluency and collaborative communication into every assignment — not just technical competence.</p>
+      <blockquote class="reveal" style="--d:.15s; font-family:var(--serif); font-style:italic; font-weight:300; font-size:clamp(20px,2.6vw,28px); line-height:1.5; border-left:1px solid var(--accent); padding-left:28px; margin-top:36px; color:var(--text);">
+        "If we can change the way we see the world, we can change the world we see."
+      </blockquote>
+      <div class="card reveal" style="--d:.2s; margin-top:40px;">
+        <span class="kicker">Availability</span>
+        <div class="info-list">
+          <div class="info-row"><span class="k">Mon — Sat</span><span class="v">10:00 — 17:00 (In-person / Virtual)</span></div>
+          <div class="info-row"><span class="k">Location</span><span class="v">Yoobee Colleges, Christchurch, NZ</span></div>
+          <div class="info-row" style="border-bottom:none;"><span class="k">For</span><span class="v">Mentoring · Supervision · Industry talks</span></div>
         </div>
-        <div class="space-y-4 text-on-surface-variant leading-relaxed">
-          <p>My approach to education is grounded in experiential and constructivist learning — I believe students learn best by building, failing, iterating, and reflecting. Every feature in YooBees was designed around this principle: the Live Playground lowers the barrier to trying, SQL Race makes failure feel like just one more lap, and badge tiers reward persistence over perfection.</p>
-          <p>I prioritise purpose-driven education: helping students not just acquire technical skills, but develop the vision and initiative to use them meaningfully. In a classroom spanning 24 countries, that also means building cultural fluency and collaborative communication into every assignment — not just technical competence.</p>
-          <p class="italic text-on-surface border-l-2 border-secondary pl-4">"If we can change the way we see the world, we can change the world we see."</p>
+        <a class="btn" style="margin-top:24px;" href="contact.html">Get in Touch <span class="arrow">→</span></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="previous">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">05</span>
+      <h2>Previous <em>Teaching</em></h2>
+    </div>
+    <div class="timeline">
+      <div class="timeline-item reveal">
+        <span class="timeline-date">2021 — 2022</span>
+        <div class="timeline-body">
+          <h3>Computer Architecture &amp; Enterprise Software</h3>
+          <span class="org">University of Moratuwa · Sri Lanka</span>
         </div>
       </div>
-
-      <!-- Availability -->
-      <div class="content-card p-stack-md bg-surface-container-low border-none">
-        <div class="flex items-center gap-2 mb-stack-sm">
-          <span class="material-symbols-outlined text-secondary">event_available</span>
-          <h2 class="font-headline-sm text-headline-sm text-primary">Availability</h2>
+      <div class="timeline-item reveal" style="--d:.05s">
+        <span class="timeline-date">2018 — 2021</span>
+        <div class="timeline-body">
+          <h3>Database Management Systems</h3>
+          <span class="org">SLIIT &amp; University of Moratuwa · Sri Lanka</span>
         </div>
-        <div class="space-y-stack-sm">
-          <div>
-            <p class="font-label-md text-label-md text-primary">MON – SAT</p>
-            <p class="text-on-surface-variant">10:00 — 17:00 (In-person / Virtual)</p>
-          </div>
-          <div>
-            <p class="font-label-md text-label-md text-primary">LOCATION</p>
-            <p class="text-on-surface-variant">Yoobee Colleges, Christchurch, NZ</p>
-          </div>
-          <div class="pt-stack-sm border-t border-outline-variant">
-            <p class="font-label-md text-label-md text-primary mb-2">CONTACT</p>
-            <p class="text-on-surface-variant text-sm mb-stack-sm">For mentoring, project supervision, industry talks, or academic inquiries.</p>
-            <a href="contact.html" class="block w-full py-2 text-center border border-primary text-primary font-label-md text-label-md hover:bg-primary hover:text-white transition-all">Get in Touch</a>
-          </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.1s">
+        <span class="timeline-date">2018 — 2022</span>
+        <div class="timeline-body">
+          <h3>Human-Computer Interaction</h3>
+          <span class="org">University of Moratuwa &amp; SLIIT · Sri Lanka</span>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.15s">
+        <span class="timeline-date">2018 — 2022</span>
+        <div class="timeline-body">
+          <h3>Project Management &amp; Enterprise App Development</h3>
+          <span class="org">SLIIT · Sri Lanka</span>
         </div>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-  <!-- =========================================================
-       PREVIOUS TEACHING EXPERIENCE
-  ========================================================= -->
-  <section class="mb-stack-lg">
-    <div class="flex items-center gap-2 mb-stack-md border-b border-outline-variant pb-2">
-      <span class="material-symbols-outlined text-secondary">school</span>
-      <h2 class="font-headline-md text-headline-md text-primary">Previous Teaching</h2>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-gutter">
-
-      <div class="content-card p-stack-sm flex items-start gap-4">
-        <div class="w-12 h-12 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-          <span class="material-symbols-outlined text-outline">computer</span>
-        </div>
-        <div>
-          <p class="font-label-md text-label-md text-outline-variant">2021 – 2022</p>
-          <h4 class="font-body-lg text-primary font-bold">Computer Architecture &amp; Enterprise Software</h4>
-          <p class="text-caption font-caption text-on-surface-variant">University of Moratuwa, Sri Lanka</p>
-        </div>
-      </div>
-
-      <div class="content-card p-stack-sm flex items-start gap-4">
-        <div class="w-12 h-12 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-          <span class="material-symbols-outlined text-outline">storage</span>
-        </div>
-        <div>
-          <p class="font-label-md text-label-md text-outline-variant">2018 – 2021</p>
-          <h4 class="font-body-lg text-primary font-bold">Database Management Systems</h4>
-          <p class="text-caption font-caption text-on-surface-variant">SLIIT &amp; University of Moratuwa, Sri Lanka</p>
-        </div>
-      </div>
-
-      <div class="content-card p-stack-sm flex items-start gap-4">
-        <div class="w-12 h-12 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-          <span class="material-symbols-outlined text-outline">touch_app</span>
-        </div>
-        <div>
-          <p class="font-label-md text-label-md text-outline-variant">2018 – 2022</p>
-          <h4 class="font-body-lg text-primary font-bold">Human-Computer Interaction</h4>
-          <p class="text-caption font-caption text-on-surface-variant">University of Moratuwa &amp; SLIIT, Sri Lanka</p>
-        </div>
-      </div>
-
-      <div class="content-card p-stack-sm flex items-start gap-4">
-        <div class="w-12 h-12 flex-shrink-0 bg-surface-container-highest flex items-center justify-center">
-          <span class="material-symbols-outlined text-outline">work_history</span>
-        </div>
-        <div>
-          <p class="font-label-md text-label-md text-outline-variant">2018 – 2022</p>
-          <h4 class="font-body-lg text-primary font-bold">Project Management &amp; Enterprise App Dev</h4>
-          <p class="text-caption font-caption text-on-surface-variant">SLIIT, Sri Lanka</p>
-        </div>
-      </div>
-
-    </div>
-  </section>
-
-  <!-- Quote Banner -->
-  <section class="mb-stack-lg">
-    <div class="relative w-full aspect-[21/9] overflow-hidden">
-      <img alt="Dr. Yasas Sri Wickramasinghe teaching" class="w-full h-full object-cover grayscale opacity-80" src="assets/images/photography_img7.jpg"/>
-      <div class="absolute inset-0 bg-gradient-to-t from-primary/70 to-transparent flex items-end p-stack-md">
-        <div>
-          <p class="text-white font-display-lg text-headline-sm md:text-headline-md italic max-w-2xl">"The classroom is not a place where knowledge is delivered — it's a space where thinking is provoked."</p>
-          <p class="font-caption text-caption mt-2" style="color:#b8c8dc;">Dr. Yasas Sri Wickramasinghe · Lecturer, MBI · Yoobee Colleges NZ</p>
-        </div>
+<section class="section">
+  <div class="container">
+    <div class="quote-banner reveal">
+      <img alt="Dr. Yasas Sri Wickramasinghe teaching" src="assets/images/photography_img7.jpg"/>
+      <div class="inner">
+        <blockquote>"The classroom is not a place where knowledge is delivered — it's a space where thinking is provoked."</blockquote>
+        <cite>Dr. Yasas Sri Wickramasinghe · Lecturer, MBI · Yoobee Colleges NZ</cite>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
-</main>
-
-<!-- Footer -->
-<footer class="w-full bg-surface-container-low border-t border-outline-variant">
-  <div class="flex flex-col md:flex-row justify-between items-center max-w-container-max mx-auto px-margin-mobile md:px-margin-desktop py-stack-md">
-    <div class="mb-stack-sm md:mb-0">
-      <span class="font-headline-sm text-headline-sm text-primary">Dr. Yasas Sri Wickramasinghe</span>
-      <p class="font-caption text-caption text-on-surface-variant mt-1">© 2026 Yasas Sri Wickramasinghe. All rights reserved.</p>
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Dr. Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
     </div>
-    <div class="flex gap-gutter">
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-caption text-caption" href="https://www.linkedin.com/in/yasassri" target="_blank">LinkedIn</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-caption text-caption" href="https://www.instagram.com/yasassri.me" target="_blank">Instagram</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-caption text-caption" href="https://twitter.com/sri_yasas" target="_blank">Twitter/X</a>
-      <a class="text-on-surface-variant hover:text-primary transition-colors font-caption text-caption underline" href="contact.html">Contact</a>
+    <div class="footer-links">
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">Instagram</a>
+      <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter/X</a>
+      <a href="contact.html">Contact</a>
     </div>
   </div>
 </footer>
 
+<script src="assets/js/premium.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Rebuild all five pages (home, research, teaching, blogs, contact) on a shared hand-crafted design system, replacing the per-page Tailwind CDN setup:

- New dark cinematic aesthetic: Fraunces serif display type, IBM Plex Mono labels, gold accent, film-grain overlay
- Shared assets/css/premium.css + assets/js/premium.js (scroll reveals, animated counters, scroll progress bar, blurred sticky nav, full-screen mobile menu, reduced-motion support)
- Hero with oversized typography, portrait treatment, and keyword marquee; numbered editorial sections throughout
- Publication index redesigned as an elegant year-grouped list
- All content, links, DOIs, Formspree form, and Google Analytics preserved