### PR TITLE
Add interactive Student Voices globe as homepage hero

### DIFF
--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -542,6 +542,159 @@ footer { background: var(--bg-soft); border-top: 1px solid var(--line); }
 .quote-banner blockquote { font-size: clamp(20px, 3vw, 32px); font-weight: 600; letter-spacing: -0.02em; line-height: 1.35; color: #fff; max-width: 820px; }
 .quote-banner cite { display: block; margin-top: 18px; font-style: normal; font-size: 14px; color: rgba(255,255,255,.75); }
 
+/* ==========================================================================
+   Hero — Student Voices Globe (dark, full-bleed)
+   ========================================================================== */
+.hero-voices {
+  position: relative; isolation: isolate; overflow: hidden;
+  color: #fff;
+  background:
+    radial-gradient(120% 110% at 78% 18%, #14306a 0%, #0a1736 42%, #060d1f 100%);
+  min-height: clamp(600px, 90svh, 960px);
+  display: flex; align-items: center;
+  padding: clamp(40px, 7vw, 90px) 0 clamp(56px, 8vw, 96px);
+}
+/* faint dot grid + aura, echoing the light hero */
+.hv-aura { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
+.hv-aura::before {
+  content: ""; position: absolute; right: 4%; top: 50%; transform: translateY(-50%);
+  width: min(640px, 56vw); aspect-ratio: 1; border-radius: 50%;
+  background: radial-gradient(circle, rgba(47,107,255,.34), rgba(47,107,255,0) 62%);
+  filter: blur(8px);
+}
+.hv-aura::after {
+  content: ""; position: absolute; inset: 0; opacity: .5;
+  background-image: radial-gradient(rgba(255,255,255,.05) 1px, transparent 1px);
+  background-size: 26px 26px;
+  -webkit-mask-image: radial-gradient(ellipse 90% 80% at 60% 40%, #000 30%, transparent 78%);
+  mask-image: radial-gradient(ellipse 90% 80% at 60% 40%, #000 30%, transparent 78%);
+}
+.hv-inner {
+  position: relative; z-index: 1; width: 100%;
+  display: grid; grid-template-columns: 1.05fr 1fr;
+  gap: clamp(28px, 5vw, 72px); align-items: center;
+}
+.hv-kicker {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-size: clamp(11px, 1.1vw, 13px); font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: rgba(255,255,255,.62); margin-bottom: 18px;
+}
+.hv-kicker::before { content: ""; width: 22px; height: 1px; background: #6ea0ff; }
+.hv-eyebrow { color: #6ea0ff; margin-bottom: 18px; }
+.hv-eyebrow::before { background: #6ea0ff; }
+.hv-title {
+  color: #fff; font-weight: 800; letter-spacing: -0.035em; line-height: 1.04;
+  font-size: clamp(34px, 5.2vw, 62px);
+}
+.hv-title em { color: #6ea0ff; font-style: normal; }
+.hv-sub {
+  color: rgba(255,255,255,.66); margin-top: 18px; max-width: 48ch;
+  font-size: clamp(15px, 1.5vw, 17.5px);
+}
+
+/* dynamic quote card */
+.hv-quote {
+  position: relative; margin-top: 28px;
+  background: rgba(255,255,255,.055);
+  border: 1px solid rgba(255,255,255,.13); border-radius: var(--radius);
+  padding: 26px 28px; backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+  min-height: 168px; max-width: 540px;
+  transition: opacity .45s var(--ease), transform .45s var(--ease);
+}
+.hv-quote.is-swapping { opacity: 0; transform: translateY(12px); }
+.hv-quote .vq-mark {
+  position: absolute; top: 8px; right: 22px; font-size: 64px; line-height: 1;
+  color: rgba(110,160,255,.22); font-weight: 800; pointer-events: none;
+}
+.hv-quote blockquote {
+  font-size: clamp(16px, 1.9vw, 21px); font-weight: 500; line-height: 1.5;
+  color: #fff; letter-spacing: -0.01em;
+}
+.vq-meta { display: flex; align-items: center; gap: 14px; margin-top: 22px; }
+.vq-avatar {
+  width: 46px; height: 46px; border-radius: 50%; flex-shrink: 0;
+  display: grid; place-items: center; font-weight: 700; font-size: 15px; color: #fff;
+  background: linear-gradient(135deg, #2f6bff, #6ea0ff);
+  box-shadow: 0 6px 18px -6px rgba(47,107,255,.7);
+}
+.vq-who { display: flex; flex-direction: column; line-height: 1.3; }
+.vq-who strong { font-size: 15px; color: #fff; }
+.vq-who small { color: rgba(255,255,255,.6); font-size: 13px; }
+.vq-flag { margin-left: auto; text-align: right; }
+.vq-stars { display: block; color: #ffc861; font-size: 13px; letter-spacing: 2px; }
+.vq-country { font-size: 11px; color: rgba(255,255,255,.55); text-transform: uppercase; letter-spacing: 0.12em; }
+
+/* controls */
+.hv-controls { display: flex; align-items: center; gap: 14px; margin-top: 24px; flex-wrap: wrap; }
+.hv-filters { display: flex; gap: 8px; flex-wrap: wrap; }
+.vfilter {
+  padding: 7px 15px; border-radius: 999px; font-family: inherit;
+  border: 1px solid rgba(255,255,255,.18); background: rgba(255,255,255,.04);
+  color: rgba(255,255,255,.74); font-size: 12.5px; font-weight: 600;
+  cursor: pointer; transition: all .25s var(--ease);
+}
+.vfilter:hover { border-color: #6ea0ff; color: #fff; }
+.vfilter.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.hv-nav { display: flex; gap: 8px; margin-left: auto; }
+.vnav-btn {
+  width: 42px; height: 42px; border-radius: 50%; cursor: pointer;
+  border: 1px solid rgba(255,255,255,.2); background: rgba(255,255,255,.05);
+  color: #fff; display: grid; place-items: center; font-size: 16px;
+  transition: all .25s var(--ease);
+}
+.vnav-btn:hover { background: var(--accent); border-color: var(--accent); transform: translateY(-2px); }
+
+/* stats + CTAs */
+.hv-stats { display: flex; gap: clamp(24px, 4vw, 44px); margin-top: 30px; }
+.hv-stats > div { display: flex; flex-direction: column; gap: 2px; }
+.hv-stats b { font-size: clamp(24px, 3vw, 34px); font-weight: 800; color: #6ea0ff; letter-spacing: -0.02em; line-height: 1.05; }
+.hv-stats > div > span { font-size: 13px; color: rgba(255,255,255,.58); }
+.hv-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 30px; }
+.hv-actions .btn { color: #fff; border-color: rgba(255,255,255,.28); background: transparent; }
+.hv-actions .btn:hover { border-color: #fff; }
+.hv-actions .btn-solid { background: var(--accent); border-color: var(--accent); }
+.hv-actions .btn-solid:hover { background: var(--accent-dark); border-color: var(--accent-dark); }
+
+/* globe stage */
+.hv-stage { position: relative; width: 100%; max-width: 560px; margin-inline: auto; aspect-ratio: 1; }
+.voices-globe { width: 100%; height: 100%; display: block; cursor: grab; touch-action: pan-y; }
+.voices-globe:active { cursor: grabbing; }
+.voices-tooltip {
+  position: absolute; pointer-events: none; transform: translate(-50%, -135%);
+  background: rgba(6,13,31,.92); border: 1px solid rgba(110,160,255,.45);
+  color: #fff; font-size: 12px; font-weight: 600; padding: 6px 11px; border-radius: 8px;
+  white-space: nowrap; opacity: 0; transition: opacity .2s; z-index: 5;
+  box-shadow: 0 10px 30px -10px rgba(0,0,0,.6);
+}
+.voices-tooltip.show { opacity: 1; }
+
+/* dark scroll hint */
+.hv-scroll {
+  position: absolute; left: 50%; bottom: clamp(18px, 3vw, 30px); transform: translateX(-50%);
+  z-index: 2; display: flex; align-items: center; gap: 10px;
+  font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(255,255,255,.5);
+}
+.hv-scroll span { width: 22px; height: 22px; border-radius: 50%; border: 1px solid rgba(255,255,255,.25); display: inline-grid; place-items: center; }
+.hv-scroll span::after { content: "↓"; animation: bob 1.6s var(--ease) infinite; }
+
+/* screen-reader-only testimonial list (a11y + SEO) */
+.voices-srlist { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+
+@media (max-width: 940px) {
+  .hv-inner { grid-template-columns: 1fr; gap: 8px; text-align: center; }
+  .hv-stage { order: -1; max-width: 340px; }
+  .hv-kicker, .hv-eyebrow { justify-content: center; }
+  .hv-sub { margin-inline: auto; }
+  .hv-quote { margin-inline: auto; text-align: left; }
+  .hv-controls, .hv-stats, .hv-actions { justify-content: center; }
+  .hv-nav { margin-left: 0; }
+  .hv-scroll { display: none; }
+}
+@media (max-width: 560px) {
+  .hv-stats { gap: 28px; }
+  .vq-mark { display: none; }
+}
+
 /* ---------- Lenis smooth scroll ---------- */
 html.lenis, html.lenis body { height: auto; }
 .lenis.lenis-smooth { scroll-behavior: auto !important; }

--- a/assets/js/globe-voices.js
+++ b/assets/js/globe-voices.js
@@ -1,0 +1,430 @@
+/* ==========================================================================
+   Student Voices Globe
+   A dependency-free, dotted point-cloud globe rendered on <canvas>.
+   - Slowly auto-rotates, seeks the active student's country to face front
+   - Drag to spin, hover markers for a tooltip, click a marker to select
+   - Region filter pills + prev/next, animated quote card, live stats
+   - Respects prefers-reduced-motion (static render, no auto motion)
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  var DATA = window.STUDENT_VOICES || [];
+  var canvas = document.getElementById("voicesGlobe");
+  if (!canvas || !DATA.length) return;
+
+  var ctx = canvas.getContext("2d");
+  var reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // ---- DOM refs ----
+  var quoteEl   = document.getElementById("voicesQuote");
+  var textEl    = document.getElementById("vqText");
+  var nameEl    = document.getElementById("vqName");
+  var roleEl    = document.getElementById("vqRole");
+  var countryEl = document.getElementById("vqCountry");
+  var starsEl   = document.getElementById("vqStars");
+  var avatarEl  = document.getElementById("vqAvatar");
+  var filtersEl = document.getElementById("voicesFilters");
+  var tooltipEl = document.getElementById("voicesTooltip");
+  var srListEl  = document.getElementById("voicesSrList");
+  var prevBtn   = document.getElementById("vPrev");
+  var nextBtn   = document.getElementById("vNext");
+
+  // ---- palette ----
+  var DOT = "110,160,255";          // base globe dots
+  var MARK = "120,170,255";         // resting marker
+  var ACTIVE = "47,107,255";        // active marker / brand accent
+  var REGION_TINT = {
+    "Asia":        ["#2f6bff", "#6ea0ff"],
+    "Oceania":     ["#13b4a0", "#5fe0c8"],
+    "Europe":      ["#7b5bff", "#b39bff"],
+    "Americas":    ["#ff7d54", "#ffb38a"],
+    "Africa":      ["#f5a623", "#ffce6b"],
+    "Middle East": ["#e7568a", "#ff9bbf"]
+  };
+
+  // ---- geometry / view state ----
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var W = 0, H = 0, cx = 0, cy = 0, R = 0;
+  var rotation = 0, tilt = 0.35;          // current orientation (radians)
+  var targetRot = 0, targetTilt = 0.35;   // where we're easing toward
+  var seeking = false;                     // currently spinning to a country
+  var dragging = false, dragDist = 0;
+  var lastX = 0, lastY = 0, lastInteract = -1e9, lastActivate = 0;
+  var running = false, rafId = 0, lastTs = 0;
+
+  var DRIFT = 0.13;        // idle rotation speed (rad/s)
+  var DWELL = 4800;        // ms a country stays centered before auto-advance
+  var RESUME = 9000;       // ms after a user interaction before auto motion resumes
+  var EASE = 0.09;         // seek easing per frame
+
+  // ---- build the dotted sphere (Fibonacci distribution) ----
+  var N = 1500;
+  var bx = new Float32Array(N), by = new Float32Array(N), bz = new Float32Array(N);
+  (function buildSphere() {
+    var golden = Math.PI * (3 - Math.sqrt(5));
+    for (var i = 0; i < N; i++) {
+      var y = 1 - (i / (N - 1)) * 2;
+      var r = Math.sqrt(Math.max(0, 1 - y * y));
+      var th = i * golden;
+      bx[i] = Math.cos(th) * r;
+      by[i] = y;
+      bz[i] = Math.sin(th) * r;
+    }
+  })();
+
+  // ---- group testimonials into country markers ----
+  var countries = [];
+  var byCode = {};
+  DATA.forEach(function (d, idx) {
+    var c = byCode[d.code];
+    if (!c) {
+      c = byCode[d.code] = {
+        code: d.code, name: d.country, region: d.region,
+        lat: d.lat, lng: d.lng, indices: []
+      };
+      countries.push(c);
+    }
+    c.indices.push(idx);
+  });
+
+  // ---- regions + filter pool ----
+  var regions = [];
+  DATA.forEach(function (d) { if (regions.indexOf(d.region) === -1) regions.push(d.region); });
+  var activeFilter = "all";
+  var pool = DATA.map(function (_, i) { return i; });
+  var activeIndex = 0;
+
+  function rebuildPool() {
+    pool = DATA.map(function (_, i) { return i; }).filter(function (i) {
+      return activeFilter === "all" || DATA[i].region === activeFilter;
+    });
+    if (pool.indexOf(activeIndex) === -1 && pool.length) activate(pool[0]);
+  }
+
+  // ---- math: rotate a unit vector and project (orthographic) ----
+  var cr = 1, sr = 0, cti = Math.cos(tilt), sti = Math.sin(tilt);
+  function refreshTrig() { cr = Math.cos(rotation); sr = Math.sin(rotation); cti = Math.cos(tilt); sti = Math.sin(tilt); }
+
+  function vec(lat, lng) {
+    var phi = lat * Math.PI / 180, th = lng * Math.PI / 180;
+    return [Math.cos(phi) * Math.sin(th), Math.sin(phi), Math.cos(phi) * Math.cos(th)];
+  }
+  function rot3(x, y, z) {
+    var x1 = x * cr + z * sr;
+    var z1 = -x * sr + z * cr;
+    var y2 = y * cti - z1 * sti;
+    var z2 = y * sti + z1 * cti;
+    return [x1, y2, z2]; // camera at +z; z2>0 => front facing
+  }
+
+  // ---- sizing ----
+  function resize() {
+    var rect = canvas.getBoundingClientRect();
+    W = Math.max(1, rect.width); H = Math.max(1, rect.height);
+    canvas.width = Math.round(W * dpr);
+    canvas.height = Math.round(H * dpr);
+    cx = W / 2; cy = H / 2;
+    R = Math.min(W, H) / 2 * 0.82;
+    draw(performance.now());
+  }
+
+  // ---- render ----
+  function draw(now) {
+    refreshTrig();
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+
+    // atmosphere glow
+    var atmo = ctx.createRadialGradient(cx, cy, R * 0.7, cx, cy, R * 1.32);
+    atmo.addColorStop(0, "rgba(" + DOT + ",0.18)");
+    atmo.addColorStop(1, "rgba(" + DOT + ",0)");
+    ctx.fillStyle = atmo;
+    ctx.beginPath(); ctx.arc(cx, cy, R * 1.32, 0, 6.2832); ctx.fill();
+
+    // sphere body
+    var body = ctx.createRadialGradient(cx - R * 0.32, cy - R * 0.34, R * 0.15, cx, cy, R);
+    body.addColorStop(0, "rgba(34,68,140,0.55)");
+    body.addColorStop(0.7, "rgba(13,28,66,0.7)");
+    body.addColorStop(1, "rgba(6,13,31,0.92)");
+    ctx.fillStyle = body;
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832); ctx.fill();
+
+    // dotted surface
+    for (var i = 0; i < N; i++) {
+      var p = rot3(bx[i], by[i], bz[i]);
+      var depth = (p[2] + 1) / 2;                 // 0 back .. 1 front
+      var a = 0.10 + depth * depth * 0.55;
+      var s = 0.5 + depth * 1.5;
+      ctx.globalAlpha = a;
+      ctx.fillStyle = "rgb(" + DOT + ")";
+      ctx.fillRect(cx + p[0] * R - s / 2, cy - p[1] * R - s / 2, s, s);
+    }
+    ctx.globalAlpha = 1;
+
+    // country markers
+    var active = DATA[activeIndex];
+    for (var m = 0; m < countries.length; m++) {
+      var c = countries[m];
+      var v = vec(c.lat, c.lng);
+      var pp = rot3(v[0], v[1], v[2]);
+      if (pp[2] <= 0.02) continue;                 // back of globe
+      var sx = cx + pp[0] * R, sy = cy - pp[1] * R;
+      var isActive = active && c.code === active.code;
+      var depth = (pp[2] + 1) / 2;
+      var size = (isActive ? 4.2 : 2.6) * (0.7 + depth * 0.5);
+      var tint = REGION_TINT[c.region] || [ "#2f6bff", "#6ea0ff" ];
+
+      // halo
+      var halo = ctx.createRadialGradient(sx, sy, 0, sx, sy, size * 4.5);
+      halo.addColorStop(0, hexA(tint[1], isActive ? 0.7 : 0.4));
+      halo.addColorStop(1, hexA(tint[1], 0));
+      ctx.fillStyle = halo;
+      ctx.beginPath(); ctx.arc(sx, sy, size * 4.5, 0, 6.2832); ctx.fill();
+
+      // pulsing ring on active (skip when reduced motion)
+      if (isActive && !reduced) {
+        var t = (now % 1600) / 1600;
+        ctx.globalAlpha = (1 - t) * 0.8;
+        ctx.strokeStyle = tint[1];
+        ctx.lineWidth = 1.4;
+        ctx.beginPath(); ctx.arc(sx, sy, size + t * 22, 0, 6.2832); ctx.stroke();
+        ctx.globalAlpha = 1;
+      }
+
+      // core
+      ctx.fillStyle = isActive ? tint[0] : hexA(tint[1], 0.9);
+      ctx.beginPath(); ctx.arc(sx, sy, size, 0, 6.2832); ctx.fill();
+      ctx.strokeStyle = "rgba(255,255,255,0.9)";
+      ctx.lineWidth = isActive ? 1.6 : 0.8;
+      ctx.stroke();
+
+      c._sx = sx; c._sy = sy; c._front = true;     // cache for hit-testing
+    }
+    // mark off-screen markers as not hittable
+    for (var k = 0; k < countries.length; k++) {
+      var cc = countries[k];
+      var vv = rot3.apply(null, vec(cc.lat, cc.lng));
+      cc._front = vv[2] > 0.02;
+    }
+  }
+
+  function hexA(hex, a) {
+    var n = parseInt(hex.slice(1), 16);
+    return "rgba(" + (n >> 16 & 255) + "," + (n >> 8 & 255) + "," + (n & 255) + "," + a + ")";
+  }
+
+  // ---- animation loop ----
+  function angDiff(a, b) {
+    var d = (a - b) % (Math.PI * 2);
+    if (d > Math.PI) d -= Math.PI * 2;
+    if (d < -Math.PI) d += Math.PI * 2;
+    return d;
+  }
+
+  function frame(ts) {
+    if (!running) return;
+    var dt = Math.min(0.05, (ts - lastTs) / 1000 || 0);
+    lastTs = ts;
+
+    if (!dragging) {
+      if (seeking) {
+        rotation += angDiff(targetRot, rotation) * EASE;
+        if (Math.abs(angDiff(targetRot, rotation)) < 0.01) { rotation = targetRot; seeking = false; }
+      } else if (!reduced && (ts - lastInteract) > RESUME) {
+        rotation += DRIFT * dt;          // idle drift
+        targetRot = rotation;
+      }
+      tilt += (targetTilt - tilt) * EASE;
+    }
+
+    // auto-advance to the next student once a country has dwelled
+    if (!reduced && !seeking && !dragging &&
+        (ts - lastInteract) > RESUME && (ts - lastActivate) > DWELL) {
+      next(true);
+    }
+
+    draw(ts);
+    rafId = requestAnimationFrame(frame);
+  }
+
+  function start() {
+    if (running || reduced) { draw(performance.now()); return; }
+    running = true; lastTs = performance.now();
+    rafId = requestAnimationFrame(frame);
+  }
+  function stop() { running = false; if (rafId) cancelAnimationFrame(rafId); }
+
+  // ---- selection / quote card ----
+  function initials(name) {
+    return name.split(/\s+/).slice(0, 2).map(function (s) { return s[0]; }).join("").toUpperCase();
+  }
+  function stars(rating) {
+    var full = Math.floor(rating), half = rating - full >= 0.5;
+    var s = "";
+    for (var i = 0; i < 5; i++) s += (i < full ? "★" : (i === full && half ? "★" : "☆"));
+    return s;
+  }
+
+  function paint() {
+    var d = DATA[activeIndex];
+    var tint = REGION_TINT[d.region] || [ "#2f6bff", "#6ea0ff" ];
+    textEl.textContent = "“" + d.quote + "”";
+    nameEl.textContent = d.name;
+    roleEl.textContent = d.program;
+    countryEl.textContent = d.country;
+    starsEl.textContent = stars(d.rating);
+    avatarEl.textContent = initials(d.name);
+    avatarEl.style.background = "linear-gradient(135deg," + tint[0] + "," + tint[1] + ")";
+    canvas.setAttribute("aria-label",
+      "Globe showing " + countries.length + " countries. Currently: " + d.name + " from " + d.country);
+  }
+
+  function activate(index, isAuto) {
+    activeIndex = index;
+    lastActivate = performance.now();
+    var d = DATA[index];
+    targetRot = -d.lng * Math.PI / 180;
+    targetTilt = Math.max(-0.6, Math.min(0.6, d.lat * Math.PI / 180));
+    if (reduced) { rotation = targetRot; tilt = targetTilt; seeking = false; }
+    else { seeking = true; }
+
+    // animated card swap
+    if (quoteEl) {
+      quoteEl.classList.add("is-swapping");
+      setTimeout(function () { paint(); quoteEl.classList.remove("is-swapping"); }, 240);
+    } else { paint(); }
+
+    if (reduced) draw(performance.now());
+  }
+
+  function next(isAuto) {
+    var pos = pool.indexOf(activeIndex);
+    activate(pool[(pos + 1) % pool.length], isAuto);
+  }
+  function prev() {
+    var pos = pool.indexOf(activeIndex);
+    activate(pool[(pos - 1 + pool.length) % pool.length]);
+  }
+
+  // ---- build filter pills ----
+  function buildFilters() {
+    if (!filtersEl) return;
+    var mk = function (label, value) {
+      var b = document.createElement("button");
+      b.className = "vfilter" + (value === activeFilter ? " active" : "");
+      b.type = "button";
+      b.textContent = label;
+      b.setAttribute("data-filter", value);
+      b.addEventListener("click", function () {
+        activeFilter = value;
+        filtersEl.querySelectorAll(".vfilter").forEach(function (el) {
+          el.classList.toggle("active", el.getAttribute("data-filter") === value);
+        });
+        lastInteract = performance.now();
+        rebuildPool();
+      });
+      return b;
+    };
+    filtersEl.appendChild(mk("All", "all"));
+    regions.forEach(function (r) { filtersEl.appendChild(mk(r, r)); });
+  }
+
+  // ---- screen-reader / no-JS list ----
+  function buildSrList() {
+    if (!srListEl) return;
+    DATA.forEach(function (d) {
+      var li = document.createElement("li");
+      li.textContent = "“" + d.quote + "” — " + d.name + ", " + d.program + " (" + d.country + ")";
+      srListEl.appendChild(li);
+    });
+  }
+
+  // ---- pointer interaction ----
+  function pickMarker(px, py) {
+    var best = null, bestD = 18 * 18;
+    for (var i = 0; i < countries.length; i++) {
+      var c = countries[i];
+      if (!c._front || c._sx == null) continue;
+      var dx = px - c._sx, dy = py - c._sy, dd = dx * dx + dy * dy;
+      if (dd < bestD) { bestD = dd; best = c; }
+    }
+    return best;
+  }
+
+  function onMove(e) {
+    var rect = canvas.getBoundingClientRect();
+    var px = e.clientX - rect.left, py = e.clientY - rect.top;
+    if (dragging) {
+      var dx = e.clientX - lastX, dy = e.clientY - lastY;
+      dragDist += Math.abs(dx) + Math.abs(dy);
+      rotation += dx * 0.006;
+      tilt = Math.max(-0.9, Math.min(0.9, tilt + dy * 0.005));
+      targetRot = rotation; targetTilt = tilt; seeking = false;
+      lastX = e.clientX; lastY = e.clientY; lastInteract = performance.now();
+      if (reduced) draw(performance.now());
+      return;
+    }
+    var hit = pickMarker(px, py);
+    if (hit && tooltipEl) {
+      tooltipEl.textContent = hit.name + " · " + hit.indices.length + (hit.indices.length > 1 ? " students" : " student");
+      tooltipEl.style.left = hit._sx + "px";
+      tooltipEl.style.top = hit._sy + "px";
+      tooltipEl.classList.add("show");
+      canvas.style.cursor = "pointer";
+    } else if (tooltipEl) {
+      tooltipEl.classList.remove("show");
+      canvas.style.cursor = "grab";
+    }
+  }
+
+  function onDown(e) {
+    dragging = true; dragDist = 0;
+    lastX = e.clientX; lastY = e.clientY; lastInteract = performance.now();
+    seeking = false;
+    canvas.setPointerCapture && canvas.setPointerCapture(e.pointerId);
+  }
+  function onUp(e) {
+    if (!dragging) return;
+    dragging = false; lastInteract = performance.now();
+    if (dragDist < 6) {                          // treat as a click
+      var rect = canvas.getBoundingClientRect();
+      var hit = pickMarker(e.clientX - rect.left, e.clientY - rect.top);
+      if (hit) {
+        var pos = hit.indices.indexOf(activeIndex);
+        activate(hit.indices[(pos + 1) % hit.indices.length]);  // cycle within country
+      }
+    }
+  }
+
+  // ---- wire up ----
+  buildFilters();
+  buildSrList();
+  activate(0);
+  paint();
+  resize();
+
+  if (prevBtn) prevBtn.addEventListener("click", function () { lastInteract = performance.now(); prev(); });
+  if (nextBtn) nextBtn.addEventListener("click", function () { lastInteract = performance.now(); next(); });
+
+  canvas.addEventListener("pointerdown", onDown);
+  canvas.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+  canvas.addEventListener("pointerleave", function () { if (tooltipEl) tooltipEl.classList.remove("show"); });
+
+  if ("ResizeObserver" in window) { new ResizeObserver(resize).observe(canvas); }
+  else { window.addEventListener("resize", resize); }
+
+  // start/stop with visibility to save battery
+  if ("IntersectionObserver" in window && !reduced) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) { if (en.isIntersecting) start(); else stop(); });
+    }, { threshold: 0.05 });
+    io.observe(canvas);
+  } else {
+    start();
+  }
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) stop(); else if (!reduced) start();
+  });
+})();

--- a/assets/js/testimonials.js
+++ b/assets/js/testimonials.js
@@ -1,0 +1,113 @@
+/* ==========================================================================
+   Student Voices — mock testimonial data for the hero globe.
+   Replace these entries with real student feedback when ready.
+   Each entry:
+     name    – student name (or initials for privacy)
+     program – course / context
+     country – display name
+     code    – short label shown on the globe
+     region  – used for the filter pills + avatar tint
+     lat,lng – map coordinates (decimal degrees) for the globe marker
+     rating  – 1–5 (drives the star row + sentiment)
+     quote   – the testimonial text
+   ========================================================================== */
+window.STUDENT_VOICES = [
+  {
+    name: "Priya Madhavan",
+    program: "MSc Information Systems · Yoobee College",
+    country: "Sri Lanka", code: "LK", region: "Asia",
+    lat: 6.9271, lng: 79.8612, rating: 5,
+    quote: "He made the hardest systems concepts finally click. Every lecture felt like a game I actually wanted to win."
+  },
+  {
+    name: "Liam Carter",
+    program: "Capstone supervisee · University of Canterbury",
+    country: "New Zealand", code: "NZ", region: "Oceania",
+    lat: -43.5321, lng: 172.6362, rating: 5,
+    quote: "Yasas pushed my AR project further than I thought I could take it — rigorous feedback, always delivered with kindness."
+  },
+  {
+    name: "Aarav Sharma",
+    program: "Project Management cohort",
+    country: "India", code: "IN", region: "Asia",
+    lat: 12.9716, lng: 77.5946, rating: 5,
+    quote: "The most engaging lecturer I've had. He turns dense theory into stories you remember months later."
+  },
+  {
+    name: "Yuki Tanaka",
+    program: "XR Design workshop",
+    country: "Japan", code: "JP", region: "Asia",
+    lat: 35.6762, lng: 139.6503, rating: 4.5,
+    quote: "His spatial-computing session reshaped how our whole studio thinks about immersive interaction."
+  },
+  {
+    name: "Maya Robinson",
+    program: "Online MOOC — AR Fundamentals",
+    country: "United States", code: "US", region: "Americas",
+    lat: 40.7128, lng: -74.0060, rating: 5,
+    quote: "I took his free course on a whim and ended up changing my career into HCI. That's the kind of teacher he is."
+  },
+  {
+    name: "Oliver Bennett",
+    program: "Guest lecture series",
+    country: "United Kingdom", code: "GB", region: "Europe",
+    lat: 51.5074, lng: -0.1278, rating: 5,
+    quote: "Clear, generous, and genuinely current. He connects research to real products better than anyone I've studied under."
+  },
+  {
+    name: "Lena Hoffmann",
+    program: "Research methods seminar",
+    country: "Germany", code: "DE", region: "Europe",
+    lat: 52.5200, lng: 13.4050, rating: 4.5,
+    quote: "Structured, patient, and deeply knowledgeable. My thesis design improved dramatically after his guidance."
+  },
+  {
+    name: "Charlotte Nguyen",
+    program: "Information Systems elective",
+    country: "Australia", code: "AU", region: "Oceania",
+    lat: -33.8688, lng: 151.2093, rating: 5,
+    quote: "He cares whether you actually understand — not whether you pass. Rare and unforgettable."
+  },
+  {
+    name: "Lucas Almeida",
+    program: "MOOC learner — Immersive Media",
+    country: "Brazil", code: "BR", region: "Americas",
+    lat: -23.5505, lng: -46.6333, rating: 5,
+    quote: "From São Paulo, his course felt like sitting in the front row of a world-class lab. Inspiring from start to finish."
+  },
+  {
+    name: "Sophie Tremblay",
+    program: "Thesis supervisee",
+    country: "Canada", code: "CA", region: "Americas",
+    lat: 43.6532, lng: -79.3832, rating: 5,
+    quote: "He believed in my idea before I did, then gave me the tools to prove it. I defended with confidence."
+  },
+  {
+    name: "Wei Lin Tan",
+    program: "Project Management cohort",
+    country: "Singapore", code: "SG", region: "Asia",
+    lat: 1.3521, lng: 103.8198, rating: 5,
+    quote: "Gamified, practical, and demanding in the best way. Easily the highlight of my postgrad year."
+  },
+  {
+    name: "Adaeze Okonkwo",
+    program: "Online MOOC — AR Fundamentals",
+    country: "Nigeria", code: "NG", region: "Africa",
+    lat: 6.5244, lng: 3.3792, rating: 5,
+    quote: "Access to teaching this good, for free, from Lagos — it genuinely opened a door for me into XR."
+  },
+  {
+    name: "Omar Al-Farsi",
+    program: "Spatial computing workshop",
+    country: "United Arab Emirates", code: "AE", region: "Middle East",
+    lat: 25.2048, lng: 55.2708, rating: 4.5,
+    quote: "He balances academic depth with industry pragmatism — exactly what our innovation team needed."
+  },
+  {
+    name: "Sanne de Vries",
+    program: "HCI guest seminar",
+    country: "Netherlands", code: "NL", region: "Europe",
+    lat: 52.3676, lng: 4.9041, rating: 5,
+    quote: "Warm, sharp, and endlessly curious. You leave his sessions thinking differently about technology and people."
+  }
+];

--- a/index.html
+++ b/index.html
@@ -141,35 +141,59 @@
   <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">06</span>Curriculum Vitae</a>
 </div>
 
-<!-- HERO -->
-<header class="hero" id="top">
-  <div class="hero-bg" aria-hidden="true"></div>
-  <div class="container">
-    <span class="hero-eyebrow">Postdoctoral Researcher · Senior Lecturer</span>
-    <div class="hero-stage">
-      <h1 class="hero-name" aria-label="Yasas Sri Wickramasinghe">
-        <span class="l1" data-parallax data-speed="0.16">Yasas</span>
-        <span class="l2" data-parallax data-speed="0.10">Wickramasinghe</span>
-      </h1>
-      <img class="hero-cutout" src="assets/images/hero-cutout.png" alt="Dr. Yasas Sri Wickramasinghe, augmented reality researcher and lecturer" data-parallax data-speed="-0.05"/>
-      <div class="hero-float hero-float-l" data-parallax data-speed="-0.10">
-        <div class="hero-card">
-          <h3>Let's Build Immersive Futures</h3>
-          <p>Location-based AR &amp; spatial computing research — turned into things people can actually use.</p>
-          <a class="btn" href="research.html">Explore Research <span class="arrow">→</span></a>
+<!-- HERO — Student Voices Globe -->
+<header class="hero-voices" id="top">
+  <div class="hv-aura" aria-hidden="true"></div>
+  <div class="container hv-inner">
+    <div class="hv-copy">
+      <span class="hv-kicker">Dr. Yasas Sri Wickramasinghe · AR Researcher &amp; Lecturer</span>
+      <span class="eyebrow hv-eyebrow">Voices From My Classroom</span>
+      <h1 class="hv-title">What My Students Say,<br/><em>All Around the World</em></h1>
+      <p class="hv-sub">From Colombo to Christchurch — feedback from learners I've taught across universities, MOOCs, and immersive-technology workshops.</p>
+
+      <figure class="hv-quote" id="voicesQuote">
+        <span class="vq-mark" aria-hidden="true">&ldquo;</span>
+        <blockquote id="vqText">&hellip;</blockquote>
+        <figcaption class="vq-meta">
+          <span class="vq-avatar" id="vqAvatar" aria-hidden="true"></span>
+          <span class="vq-who">
+            <strong id="vqName">&hellip;</strong>
+            <small id="vqRole">&hellip;</small>
+          </span>
+          <span class="vq-flag">
+            <span class="vq-stars" id="vqStars"></span>
+            <span class="vq-country" id="vqCountry"></span>
+          </span>
+        </figcaption>
+      </figure>
+
+      <div class="hv-controls">
+        <div class="hv-filters" id="voicesFilters" role="group" aria-label="Filter testimonials by region"></div>
+        <div class="hv-nav">
+          <button class="vnav-btn" id="vPrev" type="button" aria-label="Previous student">←</button>
+          <button class="vnav-btn" id="vNext" type="button" aria-label="Next student">→</button>
         </div>
       </div>
-      <div class="hero-float hero-float-r" data-parallax data-speed="-0.10">
-        <div class="hero-stat-card">
-          <span class="num">150K+ <span class="up">↗</span></span>
-          <span class="lbl">learners reached through platforms I helped build</span>
-          <hr/>
-          <p class="role">AR · XR · HCI research at HIT Lab NZ in collaboration with Sony Interactive Entertainment.</p>
-        </div>
+
+      <div class="hv-stats">
+        <div><b><span class="count" data-target="14">0</span></b><span>countries represented</span></div>
+        <div><b><span class="count" data-target="80">0</span>+</b><span>students &amp; learners taught</span></div>
+      </div>
+
+      <div class="hv-actions">
+        <a class="btn btn-solid" href="teaching.html">Explore Teaching <span class="arrow">→</span></a>
+        <a class="btn" href="contact.html">Get in Touch</a>
       </div>
     </div>
+
+    <div class="hv-stage">
+      <canvas id="voicesGlobe" class="voices-globe" role="img" aria-label="Rotating globe showing the locations of students who left feedback"></canvas>
+      <div class="voices-tooltip" id="voicesTooltip" aria-hidden="true"></div>
+    </div>
   </div>
-  <a class="scroll-hint" href="#about">Scroll <span></span></a>
+
+  <a class="hv-scroll" href="#about">Scroll <span></span></a>
+  <ul class="voices-srlist" id="voicesSrList"></ul>
 </header>
 
 <!-- MARQUEE -->
@@ -392,5 +416,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1.3.23/dist/lenis.min.js"></script>
 <script src="assets/js/premium.js"></script>
+<script src="assets/js/testimonials.js"></script>
+<script src="assets/js/globe-voices.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Replace the name/cutout hero on index.html with a full-bleed dark hero built around a rotating, interactive globe of student testimonials — inspired by Anthropic's "81k interviews" feature.

- assets/js/globe-voices.js: dependency-free dotted point-cloud globe on <canvas>; auto-rotates, seeks the active student's country to face front, supports drag-to-spin, hover tooltips, click-to-select, region filter pills, prev/next, animated quote card, and live stats. Lazy-starts via IntersectionObserver and fully honours prefers-reduced-motion.
- assets/js/testimonials.js: editable mock testimonial data (14 countries) with coordinates, region, rating and quote.
- redesign.css: new .hero-voices dark hero styles reusing existing tokens.
- index.html: new hero markup + script includes; name/role kept as kicker.


Claude-Session: https://claude.ai/code/session_01Px6t6kPoMYJxm2fWuouLDg