### PR TITLE
Reframe Student Voices globe as Anthropic-styled section below hero

### DIFF
--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -542,6 +542,104 @@ footer { background: var(--bg-soft); border-top: 1px solid var(--line); }
 .quote-banner blockquote { font-size: clamp(20px, 3vw, 32px); font-weight: 600; letter-spacing: -0.02em; line-height: 1.35; color: #fff; max-width: 820px; }
 .quote-banner cite { display: block; margin-top: 18px; font-style: normal; font-size: 14px; color: rgba(255,255,255,.75); }
 
+/* ==========================================================================
+   Student Voices — interactive globe (Anthropic-inspired editorial section)
+   Palette: ivory #faf9f5 · ink #141413 · border #e8e6dc · coral #d97757
+            sage #788c5d (loved it) · sky #6a9bcc (positive)
+   ========================================================================== */
+.avoices {
+  position: relative; overflow: hidden;
+  background: #faf9f5; color: #141413;
+  padding: clamp(64px, 9vw, 120px) 0;
+  border-top: 1px solid #ece9e0; border-bottom: 1px solid #ece9e0;
+}
+.av-inner { position: relative; z-index: 1; }
+.av-head { max-width: 760px; margin: 0 auto clamp(34px, 5vw, 60px); text-align: center; }
+.av-eyebrow {
+  display: inline-block; font-family: var(--sans);
+  font-size: 13px; font-weight: 500; letter-spacing: 0.01em; color: #d97757; margin-bottom: 16px;
+}
+.av-title {
+  font-family: "Newsreader", Georgia, "Times New Roman", serif;
+  font-weight: 400; letter-spacing: -0.015em; line-height: 1.08;
+  font-size: clamp(31px, 5vw, 56px); color: #141413;
+}
+.av-sub { margin: 18px auto 0; max-width: 60ch; color: #5c5a52; font-size: clamp(15px, 1.5vw, 18px); line-height: 1.62; }
+
+.av-grid { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: clamp(28px, 5vw, 64px); align-items: center; }
+
+/* globe stage */
+.av-stage { position: relative; width: 100%; max-width: 560px; margin-inline: auto; aspect-ratio: 1; }
+.voices-globe { width: 100%; height: 100%; display: block; cursor: grab; touch-action: pan-y; }
+.voices-globe:active { cursor: grabbing; }
+.voices-tooltip {
+  position: absolute; pointer-events: none; transform: translate(-50%, -135%);
+  background: #141413; color: #faf9f5; font-size: 12px; font-weight: 500;
+  padding: 6px 11px; border-radius: 8px; white-space: nowrap;
+  opacity: 0; transition: opacity .2s; z-index: 5; box-shadow: 0 12px 30px -12px rgba(20,20,19,.45);
+}
+.voices-tooltip.show { opacity: 1; }
+
+/* quote panel */
+.av-panel { max-width: 520px; }
+.av-quote { position: relative; min-height: 188px; transition: opacity .45s var(--ease), transform .45s var(--ease); }
+.av-quote.is-swapping { opacity: 0; transform: translateY(12px); }
+.av-quote blockquote {
+  font-family: "Newsreader", Georgia, serif; font-weight: 400;
+  font-size: clamp(20px, 2.6vw, 30px); line-height: 1.35; letter-spacing: -0.01em; color: #141413;
+}
+.av-cite { display: flex; align-items: center; gap: 12px; margin-top: 26px; padding-top: 22px; border-top: 1px solid #e8e6dc; }
+.av-dot { width: 12px; height: 12px; border-radius: 50%; background: #788c5d; flex-shrink: 0; transition: background .3s, box-shadow .3s; }
+.av-who { display: flex; flex-direction: column; line-height: 1.35; }
+.av-who strong { font-size: 15px; font-weight: 600; color: #141413; }
+.av-who span { font-size: 13.5px; color: #807d74; }
+.av-loc { margin-left: auto; text-align: right; }
+.av-country { display: block; font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: #57554e; }
+.av-sentiment { display: block; font-size: 12px; font-weight: 500; margin-top: 3px; color: #788c5d; }
+
+/* controls */
+.av-controls { display: flex; align-items: center; gap: 14px; margin-top: 30px; flex-wrap: wrap; }
+.av-filters { display: flex; gap: 8px; flex-wrap: wrap; }
+.vfilter {
+  padding: 7px 14px; border-radius: 999px; font-family: var(--sans);
+  border: 1px solid #ddd9cd; background: transparent; color: #57554e;
+  font-size: 12.5px; font-weight: 500; cursor: pointer; transition: all .25s var(--ease);
+}
+.vfilter:hover { border-color: #d97757; color: #141413; }
+.vfilter.active { background: #141413; border-color: #141413; color: #faf9f5; }
+.av-nav { display: flex; gap: 8px; margin-left: auto; }
+.av-navbtn {
+  width: 40px; height: 40px; border-radius: 50%; cursor: pointer;
+  border: 1px solid #ddd9cd; background: transparent; color: #141413;
+  display: grid; place-items: center; font-size: 16px; transition: all .25s var(--ease);
+}
+.av-navbtn:hover { background: #141413; border-color: #141413; color: #faf9f5; transform: translateY(-2px); }
+
+/* legend + stats */
+.av-foot { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-top: 30px; flex-wrap: wrap; }
+.av-legend { display: flex; gap: 18px; }
+.av-legend span { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: #807d74; }
+.av-li { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.av-li-pos { background: #788c5d; }
+.av-li-neu { background: #6a9bcc; }
+.av-stats { display: flex; gap: 22px; }
+.av-stats span { font-size: 13px; color: #807d74; }
+.av-stats b { font-family: "Newsreader", Georgia, serif; font-weight: 500; font-size: 22px; color: #141413; margin-right: 5px; }
+
+/* screen-reader-only testimonial list (a11y + SEO) */
+.voices-srlist { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+
+@media (max-width: 940px) {
+  .av-grid { grid-template-columns: 1fr; gap: 14px; }
+  .av-stage { order: -1; max-width: 360px; }
+  .av-panel { max-width: 560px; margin-inline: auto; }
+}
+@media (max-width: 560px) {
+  .av-foot { gap: 14px; }
+  .av-cite { flex-wrap: wrap; }
+  .av-loc { margin-left: 0; text-align: left; width: 100%; }
+}
+
 /* ---------- Lenis smooth scroll ---------- */
 html.lenis, html.lenis body { height: auto; }
 .lenis.lenis-smooth { scroll-behavior: auto !important; }

--- a/assets/js/globe-voices.js
+++ b/assets/js/globe-voices.js
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Student Voices Globe  —  Anthropic-inspired editorial styling
+   A dependency-free, dotted point-cloud globe rendered on <canvas>.
+   - Slowly auto-rotates; seeks the active voice's country to face front
+   - Drag to spin, hover markers for a tooltip, click a marker to select
+   - Region filter pills + prev/next, animated quote card, live stats
+   - Markers sized by number of respondents, coloured by sentiment
+       sage  #788c5d  = "Loved it"  (avg rating >= 4.75)
+       sky   #6a9bcc  = "Positive"  (avg rating <  4.75)
+     the active country is ringed in coral #d97757
+   - Respects prefers-reduced-motion (static render, no auto motion)
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  var DATA = window.STUDENT_VOICES || [];
+  var canvas = document.getElementById("voicesGlobe");
+  if (!canvas || !DATA.length) return;
+
+  var ctx = canvas.getContext("2d");
+  var reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // ---- DOM refs ----
+  var quoteEl   = document.getElementById("voicesQuote");
+  var textEl    = document.getElementById("vqText");
+  var nameEl    = document.getElementById("vqName");
+  var roleEl    = document.getElementById("vqRole");
+  var countryEl = document.getElementById("vqCountry");
+  var labelEl   = document.getElementById("vqStars");   // repurposed: sentiment label
+  var dotEl     = document.getElementById("vqAvatar");  // repurposed: sentiment dot
+  var filtersEl = document.getElementById("voicesFilters");
+  var tooltipEl = document.getElementById("voicesTooltip");
+  var srListEl  = document.getElementById("voicesSrList");
+  var prevBtn   = document.getElementById("vPrev");
+  var nextBtn   = document.getElementById("vNext");
+
+  // ---- palette (Anthropic) ----
+  var DOT = "20,20,19";        // ink dots on ivory
+  var SENT_POS = "#788c5d";    // sage  — loved it
+  var SENT_NEU = "#6a9bcc";    // sky   — positive
+  var CORAL = "#d97757";       // active highlight
+  function sentiment(r) { return r >= 5 ? { label: "Loved it", color: SENT_POS } : { label: "Positive", color: SENT_NEU }; }
+
+  // ---- view state ----
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var W = 0, H = 0, cx = 0, cy = 0, R = 0;
+  var rotation = 0, tilt = 0.32;
+  var targetRot = 0, targetTilt = 0.32;
+  var seeking = false, dragging = false, dragDist = 0;
+  var lastX = 0, lastY = 0, lastInteract = -1e9, lastActivate = 0;
+  var running = false, rafId = 0, lastTs = 0;
+
+  var DRIFT = 0.12, DWELL = 4800, RESUME = 9000, EASE = 0.09;
+
+  // ---- dotted sphere (Fibonacci distribution) ----
+  var N = 1500;
+  var bx = new Float32Array(N), by = new Float32Array(N), bz = new Float32Array(N);
+  (function () {
+    var golden = Math.PI * (3 - Math.sqrt(5));
+    for (var i = 0; i < N; i++) {
+      var y = 1 - (i / (N - 1)) * 2;
+      var r = Math.sqrt(Math.max(0, 1 - y * y));
+      var th = i * golden;
+      bx[i] = Math.cos(th) * r; by[i] = y; bz[i] = Math.sin(th) * r;
+    }
+  })();
+
+  // ---- group testimonials into country markers ----
+  var countries = [], byCode = {};
+  DATA.forEach(function (d, idx) {
+    var c = byCode[d.code];
+    if (!c) { c = byCode[d.code] = { code: d.code, name: d.country, region: d.region, lat: d.lat, lng: d.lng, indices: [], sum: 0 }; countries.push(c); }
+    c.indices.push(idx); c.sum += d.rating;
+  });
+  countries.forEach(function (c) {
+    c.count = c.indices.length;
+    c.avg = c.sum / c.count;
+    c.color = c.avg >= 4.75 ? SENT_POS : SENT_NEU;
+  });
+
+  // ---- regions + pool ----
+  var regions = [];
+  DATA.forEach(function (d) { if (regions.indexOf(d.region) === -1) regions.push(d.region); });
+  var activeFilter = "all";
+  var pool = DATA.map(function (_, i) { return i; });
+  var activeIndex = 0;
+
+  function rebuildPool() {
+    pool = DATA.map(function (_, i) { return i; }).filter(function (i) {
+      return activeFilter === "all" || DATA[i].region === activeFilter;
+    });
+    if (pool.indexOf(activeIndex) === -1 && pool.length) activate(pool[0]);
+  }
+
+  // ---- math ----
+  var cr = 1, sr = 0, cti = Math.cos(tilt), sti = Math.sin(tilt);
+  function refreshTrig() { cr = Math.cos(rotation); sr = Math.sin(rotation); cti = Math.cos(tilt); sti = Math.sin(tilt); }
+  function vec(lat, lng) {
+    var phi = lat * Math.PI / 180, th = lng * Math.PI / 180;
+    return [Math.cos(phi) * Math.sin(th), Math.sin(phi), Math.cos(phi) * Math.cos(th)];
+  }
+  function rot3(x, y, z) {
+    var x1 = x * cr + z * sr, z1 = -x * sr + z * cr;
+    var y2 = y * cti - z1 * sti, z2 = y * sti + z1 * cti;
+    return [x1, y2, z2];
+  }
+  function hexA(hex, a) {
+    var n = parseInt(hex.slice(1), 16);
+    return "rgba(" + (n >> 16 & 255) + "," + (n >> 8 & 255) + "," + (n & 255) + "," + a + ")";
+  }
+  function angDiff(a, b) {
+    var d = (a - b) % (Math.PI * 2);
+    if (d > Math.PI) d -= Math.PI * 2; if (d < -Math.PI) d += Math.PI * 2; return d;
+  }
+
+  // ---- sizing ----
+  function resize() {
+    var rect = canvas.getBoundingClientRect();
+    W = Math.max(1, rect.width); H = Math.max(1, rect.height);
+    canvas.width = Math.round(W * dpr); canvas.height = Math.round(H * dpr);
+    cx = W / 2; cy = H / 2; R = Math.min(W, H) / 2 * 0.82;
+    draw(performance.now());
+  }
+
+  // ---- render ----
+  function draw(now) {
+    refreshTrig();
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+
+    // faint warm halo (atmosphere) — subtle on ivory
+    var halo = ctx.createRadialGradient(cx, cy, R * 0.94, cx, cy, R * 1.14);
+    halo.addColorStop(0, hexA(CORAL, 0.05));
+    halo.addColorStop(1, hexA(CORAL, 0));
+    ctx.fillStyle = halo;
+    ctx.beginPath(); ctx.arc(cx, cy, R * 1.14, 0, 6.2832); ctx.fill();
+
+    // sphere body — gentle dimensionality
+    var body = ctx.createRadialGradient(cx - R * 0.32, cy - R * 0.36, R * 0.1, cx, cy, R);
+    body.addColorStop(0, "rgba(255,255,255,0.55)");
+    body.addColorStop(0.62, "rgba(212,162,127,0.06)");
+    body.addColorStop(1, "rgba(20,20,19,0.085)");
+    ctx.fillStyle = body;
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832); ctx.fill();
+
+    // dotted surface
+    ctx.fillStyle = "rgb(" + DOT + ")";
+    for (var i = 0; i < N; i++) {
+      var p = rot3(bx[i], by[i], bz[i]);
+      var depth = (p[2] + 1) / 2;
+      ctx.globalAlpha = 0.04 + depth * depth * 0.26;
+      var s = 0.5 + depth * 1.3;
+      ctx.fillRect(cx + p[0] * R - s / 2, cy - p[1] * R - s / 2, s, s);
+    }
+    ctx.globalAlpha = 1;
+
+    // markers
+    var active = DATA[activeIndex];
+    for (var m = 0; m < countries.length; m++) {
+      var c = countries[m];
+      var v = vec(c.lat, c.lng), pp = rot3(v[0], v[1], v[2]);
+      c._front = pp[2] > 0.02;
+      if (!c._front) { c._sx = null; continue; }
+      var sx = cx + pp[0] * R, sy = cy - pp[1] * R;
+      var depth = (pp[2] + 1) / 2;
+      var isActive = active && c.code === active.code;
+      var size = (2.4 + Math.sqrt(c.count) * 2.2) * (0.72 + depth * 0.5);
+
+      // soft halo in sentiment colour
+      var g = ctx.createRadialGradient(sx, sy, 0, sx, sy, size * 4);
+      g.addColorStop(0, hexA(c.color, isActive ? 0.5 : 0.32));
+      g.addColorStop(1, hexA(c.color, 0));
+      ctx.fillStyle = g;
+      ctx.beginPath(); ctx.arc(sx, sy, size * 4, 0, 6.2832); ctx.fill();
+
+      // active: coral ring (+ pulse unless reduced motion)
+      if (isActive) {
+        if (!reduced) {
+          var t = (now % 1600) / 1600;
+          ctx.globalAlpha = (1 - t) * 0.7;
+          ctx.strokeStyle = CORAL; ctx.lineWidth = 1.5;
+          ctx.beginPath(); ctx.arc(sx, sy, size + 3 + t * 20, 0, 6.2832); ctx.stroke();
+          ctx.globalAlpha = 1;
+        }
+        ctx.strokeStyle = CORAL; ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(sx, sy, size + 5, 0, 6.2832); ctx.stroke();
+      }
+
+      // core
+      ctx.fillStyle = c.color;
+      ctx.beginPath(); ctx.arc(sx, sy, size, 0, 6.2832); ctx.fill();
+      ctx.strokeStyle = "#faf9f5"; ctx.lineWidth = 1.2;
+      ctx.stroke();
+
+      c._sx = sx; c._sy = sy;
+    }
+  }
+
+  // ---- animation loop ----
+  function frame(ts) {
+    if (!running) return;
+    var dt = Math.min(0.05, (ts - lastTs) / 1000 || 0);
+    lastTs = ts;
+
+    if (!dragging) {
+      if (seeking) {
+        rotation += angDiff(targetRot, rotation) * EASE;
+        if (Math.abs(angDiff(targetRot, rotation)) < 0.01) { rotation = targetRot; seeking = false; }
+      } else if (!reduced && (ts - lastInteract) > RESUME) {
+        rotation += DRIFT * dt; targetRot = rotation;
+      }
+      tilt += (targetTilt - tilt) * EASE;
+    }
+    if (!reduced && !seeking && !dragging && (ts - lastInteract) > RESUME && (ts - lastActivate) > DWELL) next(true);
+
+    draw(ts);
+    rafId = requestAnimationFrame(frame);
+  }
+  function start() { if (running || reduced) { draw(performance.now()); return; } running = true; lastTs = performance.now(); rafId = requestAnimationFrame(frame); }
+  function stop() { running = false; if (rafId) cancelAnimationFrame(rafId); }
+
+  // ---- quote card ----
+  function paint() {
+    var d = DATA[activeIndex], s = sentiment(d.rating);
+    textEl.textContent = "“" + d.quote + "”";
+    nameEl.textContent = d.name;
+    roleEl.textContent = d.program;
+    countryEl.textContent = d.country;
+    labelEl.textContent = s.label;
+    labelEl.style.color = s.color;
+    dotEl.style.background = s.color;
+    dotEl.style.boxShadow = "0 0 0 4px " + hexA(s.color, 0.16);
+    canvas.setAttribute("aria-label", "Globe of " + countries.length + " countries. Now showing " + d.name + " from " + d.country + ".");
+  }
+
+  function activate(index) {
+    activeIndex = index; lastActivate = performance.now();
+    var d = DATA[index];
+    targetRot = -d.lng * Math.PI / 180;
+    targetTilt = Math.max(-0.6, Math.min(0.6, d.lat * Math.PI / 180));
+    if (reduced) { rotation = targetRot; tilt = targetTilt; seeking = false; }
+    else { seeking = true; }
+    if (quoteEl) { quoteEl.classList.add("is-swapping"); setTimeout(function () { paint(); quoteEl.classList.remove("is-swapping"); }, 240); }
+    else { paint(); }
+    if (reduced) draw(performance.now());
+  }
+  function next() { var p = pool.indexOf(activeIndex); activate(pool[(p + 1) % pool.length]); }
+  function prev() { var p = pool.indexOf(activeIndex); activate(pool[(p - 1 + pool.length) % pool.length]); }
+
+  // ---- filters ----
+  function buildFilters() {
+    if (!filtersEl) return;
+    var mk = function (label, value) {
+      var b = document.createElement("button");
+      b.className = "vfilter" + (value === activeFilter ? " active" : "");
+      b.type = "button"; b.textContent = label; b.setAttribute("data-filter", value);
+      b.addEventListener("click", function () {
+        activeFilter = value;
+        filtersEl.querySelectorAll(".vfilter").forEach(function (el) { el.classList.toggle("active", el.getAttribute("data-filter") === value); });
+        lastInteract = performance.now(); rebuildPool();
+      });
+      return b;
+    };
+    filtersEl.appendChild(mk("All", "all"));
+    regions.forEach(function (r) { filtersEl.appendChild(mk(r, r)); });
+  }
+
+  function buildSrList() {
+    if (!srListEl) return;
+    DATA.forEach(function (d) {
+      var li = document.createElement("li");
+      li.textContent = "“" + d.quote + "” — " + d.name + ", " + d.program + " (" + d.country + ")";
+      srListEl.appendChild(li);
+    });
+  }
+
+  // ---- pointer interaction ----
+  function pickMarker(px, py) {
+    var best = null, bestD = 20 * 20;
+    for (var i = 0; i < countries.length; i++) {
+      var c = countries[i];
+      if (!c._front || c._sx == null) continue;
+      var dx = px - c._sx, dy = py - c._sy, dd = dx * dx + dy * dy;
+      if (dd < bestD) { bestD = dd; best = c; }
+    }
+    return best;
+  }
+  function onMove(e) {
+    var rect = canvas.getBoundingClientRect();
+    var px = e.clientX - rect.left, py = e.clientY - rect.top;
+    if (dragging) {
+      var dx = e.clientX - lastX, dy = e.clientY - lastY;
+      dragDist += Math.abs(dx) + Math.abs(dy);
+      rotation += dx * 0.006; tilt = Math.max(-0.9, Math.min(0.9, tilt + dy * 0.005));
+      targetRot = rotation; targetTilt = tilt; seeking = false;
+      lastX = e.clientX; lastY = e.clientY; lastInteract = performance.now();
+      if (reduced) draw(performance.now());
+      return;
+    }
+    var hit = pickMarker(px, py);
+    if (hit && tooltipEl) {
+      tooltipEl.textContent = hit.name + " · " + hit.count + (hit.count > 1 ? " voices" : " voice");
+      tooltipEl.style.left = hit._sx + "px"; tooltipEl.style.top = hit._sy + "px";
+      tooltipEl.classList.add("show"); canvas.style.cursor = "pointer";
+    } else if (tooltipEl) { tooltipEl.classList.remove("show"); canvas.style.cursor = "grab"; }
+  }
+  function onDown(e) {
+    dragging = true; dragDist = 0; lastX = e.clientX; lastY = e.clientY;
+    lastInteract = performance.now(); seeking = false;
+    canvas.setPointerCapture && canvas.setPointerCapture(e.pointerId);
+  }
+  function onUp(e) {
+    if (!dragging) return;
+    dragging = false; lastInteract = performance.now();
+    if (dragDist < 6) {
+      var rect = canvas.getBoundingClientRect();
+      var hit = pickMarker(e.clientX - rect.left, e.clientY - rect.top);
+      if (hit) { var p = hit.indices.indexOf(activeIndex); activate(hit.indices[(p + 1) % hit.indices.length]); }
+    }
+  }
+
+  // ---- init ----
+  buildFilters(); buildSrList(); activate(0); paint(); resize();
+  if (prevBtn) prevBtn.addEventListener("click", function () { lastInteract = performance.now(); prev(); });
+  if (nextBtn) nextBtn.addEventListener("click", function () { lastInteract = performance.now(); next(); });
+  canvas.addEventListener("pointerdown", onDown);
+  canvas.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+  canvas.addEventListener("pointerleave", function () { if (tooltipEl) tooltipEl.classList.remove("show"); });
+
+  if ("ResizeObserver" in window) { new ResizeObserver(resize).observe(canvas); }
+  else { window.addEventListener("resize", resize); }
+
+  if ("IntersectionObserver" in window && !reduced) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) { if (en.isIntersecting) start(); else stop(); });
+    }, { threshold: 0.05 });
+    io.observe(canvas);
+  } else { start(); }
+  document.addEventListener("visibilitychange", function () { if (document.hidden) stop(); else if (!reduced) start(); });
+})();

--- a/assets/js/testimonials.js
+++ b/assets/js/testimonials.js
@@ -1,0 +1,141 @@
+/* ==========================================================================
+   Student Voices — mock testimonial data for the hero globe.
+   Replace these entries with real student feedback when ready.
+   Each entry:
+     name    – student name (or initials for privacy)
+     program – course / context
+     country – display name
+     code    – short label shown on the globe
+     region  – used for the filter pills + avatar tint
+     lat,lng – map coordinates (decimal degrees) for the globe marker
+     rating  – 1–5 (drives the star row + sentiment)
+     quote   – the testimonial text
+   ========================================================================== */
+window.STUDENT_VOICES = [
+  {
+    name: "Priya Madhavan",
+    program: "MSc Information Systems · Yoobee College",
+    country: "Sri Lanka", code: "LK", region: "Asia",
+    lat: 6.9271, lng: 79.8612, rating: 5,
+    quote: "He made the hardest systems concepts finally click. Every lecture felt like a game I actually wanted to win."
+  },
+  {
+    name: "Liam Carter",
+    program: "Capstone supervisee · University of Canterbury",
+    country: "New Zealand", code: "NZ", region: "Oceania",
+    lat: -43.5321, lng: 172.6362, rating: 5,
+    quote: "Yasas pushed my AR project further than I thought I could take it — rigorous feedback, always delivered with kindness."
+  },
+  {
+    name: "Aarav Sharma",
+    program: "Project Management cohort",
+    country: "India", code: "IN", region: "Asia",
+    lat: 12.9716, lng: 77.5946, rating: 5,
+    quote: "The most engaging lecturer I've had. He turns dense theory into stories you remember months later."
+  },
+  {
+    name: "Yuki Tanaka",
+    program: "XR Design workshop",
+    country: "Japan", code: "JP", region: "Asia",
+    lat: 35.6762, lng: 139.6503, rating: 4.5,
+    quote: "His spatial-computing session reshaped how our whole studio thinks about immersive interaction."
+  },
+  {
+    name: "Maya Robinson",
+    program: "Online MOOC — AR Fundamentals",
+    country: "United States", code: "US", region: "Americas",
+    lat: 40.7128, lng: -74.0060, rating: 5,
+    quote: "I took his free course on a whim and ended up changing my career into HCI. That's the kind of teacher he is."
+  },
+  {
+    name: "Oliver Bennett",
+    program: "Guest lecture series",
+    country: "United Kingdom", code: "GB", region: "Europe",
+    lat: 51.5074, lng: -0.1278, rating: 5,
+    quote: "Clear, generous, and genuinely current. He connects research to real products better than anyone I've studied under."
+  },
+  {
+    name: "Lena Hoffmann",
+    program: "Research methods seminar",
+    country: "Germany", code: "DE", region: "Europe",
+    lat: 52.5200, lng: 13.4050, rating: 4.5,
+    quote: "Structured, patient, and deeply knowledgeable. My thesis design improved dramatically after his guidance."
+  },
+  {
+    name: "Charlotte Nguyen",
+    program: "Information Systems elective",
+    country: "Australia", code: "AU", region: "Oceania",
+    lat: -33.8688, lng: 151.2093, rating: 5,
+    quote: "He cares whether you actually understand — not whether you pass. Rare and unforgettable."
+  },
+  {
+    name: "Lucas Almeida",
+    program: "MOOC learner — Immersive Media",
+    country: "Brazil", code: "BR", region: "Americas",
+    lat: -23.5505, lng: -46.6333, rating: 5,
+    quote: "From São Paulo, his course felt like sitting in the front row of a world-class lab. Inspiring from start to finish."
+  },
+  {
+    name: "Sophie Tremblay",
+    program: "Thesis supervisee",
+    country: "Canada", code: "CA", region: "Americas",
+    lat: 43.6532, lng: -79.3832, rating: 5,
+    quote: "He believed in my idea before I did, then gave me the tools to prove it. I defended with confidence."
+  },
+  {
+    name: "Wei Lin Tan",
+    program: "Project Management cohort",
+    country: "Singapore", code: "SG", region: "Asia",
+    lat: 1.3521, lng: 103.8198, rating: 5,
+    quote: "Gamified, practical, and demanding in the best way. Easily the highlight of my postgrad year."
+  },
+  {
+    name: "Adaeze Okonkwo",
+    program: "Online MOOC — AR Fundamentals",
+    country: "Nigeria", code: "NG", region: "Africa",
+    lat: 6.5244, lng: 3.3792, rating: 5,
+    quote: "Access to teaching this good, for free, from Lagos — it genuinely opened a door for me into XR."
+  },
+  {
+    name: "Omar Al-Farsi",
+    program: "Spatial computing workshop",
+    country: "United Arab Emirates", code: "AE", region: "Middle East",
+    lat: 25.2048, lng: 55.2708, rating: 4.5,
+    quote: "He balances academic depth with industry pragmatism — exactly what our innovation team needed."
+  },
+  {
+    name: "Sanne de Vries",
+    program: "HCI guest seminar",
+    country: "Netherlands", code: "NL", region: "Europe",
+    lat: 52.3676, lng: 4.9041, rating: 5,
+    quote: "Warm, sharp, and endlessly curious. You leave his sessions thinking differently about technology and people."
+  },
+  {
+    name: "Nimal Perera",
+    program: "BSc capstone supervisee",
+    country: "Sri Lanka", code: "LK", region: "Asia",
+    lat: 6.9271, lng: 79.8612, rating: 5,
+    quote: "He treated my undergraduate project like real research. That belief changed the trajectory of my career."
+  },
+  {
+    name: "Dilani Fernando",
+    program: "MOOC learner — AR Fundamentals",
+    country: "Sri Lanka", code: "LK", region: "Asia",
+    lat: 6.9271, lng: 79.8612, rating: 4.5,
+    quote: "Studying from Kandy, his lessons were the clearest introduction to AR I could find anywhere online."
+  },
+  {
+    name: "Rohan Gupta",
+    program: "Project Management cohort",
+    country: "India", code: "IN", region: "Asia",
+    lat: 12.9716, lng: 77.5946, rating: 5,
+    quote: "Practical, patient, and genuinely invested in our progress. I still use his frameworks at work today."
+  },
+  {
+    name: "Emma Thompson",
+    program: "XR Design workshop",
+    country: "New Zealand", code: "NZ", region: "Oceania",
+    lat: -43.5321, lng: 172.6362, rating: 5,
+    quote: "He bridges deep theory and hands-on building better than any lecturer I've worked with at Canterbury."
+  }
+];

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 </script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&display=swap" rel="stylesheet"/>
 <link href="assets/css/redesign.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
@@ -181,6 +181,61 @@
     <span>Location-Based AR</span><span>Spatial Computing</span><span>Human Interface Technology</span><span>Player Experience</span><span>XR Research</span><span>HCI</span>
   </div>
 </div>
+
+<!-- STUDENT VOICES — interactive globe (Anthropic-inspired editorial section) -->
+<section class="avoices" id="voices" aria-label="What students say around the world">
+  <div class="container av-inner">
+    <div class="av-head reveal">
+      <span class="av-eyebrow">Voices from my classroom</span>
+      <h2 class="av-title">What my students say,<br/>all around the world</h2>
+      <p class="av-sub">Tens of thousands of learners across universities, MOOCs and workshops — from Colombo to Christchurch. Spin the globe, or pick a region, to hear them in their own words.</p>
+    </div>
+
+    <div class="av-grid">
+      <div class="av-stage reveal">
+        <canvas id="voicesGlobe" class="voices-globe" role="img" aria-label="Rotating globe showing the countries students wrote from"></canvas>
+        <div class="voices-tooltip" id="voicesTooltip" aria-hidden="true"></div>
+      </div>
+
+      <div class="av-panel reveal" style="--d:.1s">
+        <figure class="av-quote" id="voicesQuote">
+          <blockquote id="vqText">&hellip;</blockquote>
+          <figcaption class="av-cite">
+            <span class="av-dot" id="vqAvatar" aria-hidden="true"></span>
+            <span class="av-who">
+              <strong id="vqName">&hellip;</strong>
+              <span id="vqRole">&hellip;</span>
+            </span>
+            <span class="av-loc">
+              <span class="av-country" id="vqCountry"></span>
+              <span class="av-sentiment" id="vqStars"></span>
+            </span>
+          </figcaption>
+        </figure>
+
+        <div class="av-controls">
+          <div class="av-filters" id="voicesFilters" role="group" aria-label="Filter by region"></div>
+          <div class="av-nav">
+            <button class="av-navbtn" id="vPrev" type="button" aria-label="Previous voice">←</button>
+            <button class="av-navbtn" id="vNext" type="button" aria-label="Next voice">→</button>
+          </div>
+        </div>
+
+        <div class="av-foot">
+          <div class="av-legend" aria-hidden="true">
+            <span><i class="av-li av-li-pos"></i> Loved it</span>
+            <span><i class="av-li av-li-neu"></i> Positive</span>
+          </div>
+          <div class="av-stats">
+            <span><b class="count" data-target="14">0</b> countries</span>
+            <span><b class="count" data-target="18">0</b> voices</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <ul class="voices-srlist" id="voicesSrList"></ul>
+</section>
 
 <!-- INTRO BAND -->
 <section class="section" id="about">


### PR DESCRIPTION
Per feedback, restore the original name/cutout hero and move the interactive globe into its own editorial section beneath it, matching the look of Anthropic's "81k interviews" feature.

- index.html: restore original hero; add new .avoices section after the marquee; load Newsreader serif for editorial headlines/quotes.
- redesign.css: replace the dark hero-voices block with an ivory (#faf9f5) Anthropic-themed section — ink #141413, coral #d97757 accent, serif headline/quotes, sage/sky sentiment legend.
- globe-voices.js: re-theme for the light background — ink dots, markers sized by respondent count and coloured by sentiment (sage = "Loved it", sky = "Positive"), active country ringed in coral; quote card now shows a sentiment dot + label instead of a star rating.
- testimonials.js: add four more voices so country bubbles vary in size (18 voices across 14 countries).


Claude-Session: https://claude.ai/code/session_01Px6t6kPoMYJxm2fWuouLDg