### PR TITLE
Render an accurate geographic globe for Student Voices

### DIFF
--- a/assets/js/globe-voices.js
+++ b/assets/js/globe-voices.js
@@ -1,14 +1,20 @@
 /* ==========================================================================
-   Student Voices Globe  —  Anthropic-inspired editorial styling
-   A dependency-free, dotted point-cloud globe rendered on <canvas>.
-   - Slowly auto-rotates; seeks the active voice's country to face front
-   - Drag to spin, hover markers for a tooltip, click a marker to select
-   - Region filter pills + prev/next, animated quote card, live stats
-   - Markers sized by number of respondents, coloured by sentiment
+   Student Voices Globe  —  Anthropic-inspired editorial globe
+   A geographically accurate, dependency-light globe on <canvas>:
+   - Real continents drawn as a dotted land grid (orthographic projection)
+   - Faint graticule + country borders, like the "81k interviews" feature
+   - The active student's country is filled in coral and ringed
+   - Markers per country, sized by number of respondents, coloured by sentiment
        sage  #788c5d  = "Loved it"  (avg rating >= 4.75)
        sky   #6a9bcc  = "Positive"  (avg rating <  4.75)
-     the active country is ringed in coral #d97757
+   - Slowly auto-rotates, seeks the active country to face front
+   - Drag to spin, hover markers for a tooltip, click a marker to select
+   - Region filter pills + prev/next, animated quote card, live stats
    - Respects prefers-reduced-motion (static render, no auto motion)
+
+   Geography: world-atlas countries (110m) loaded at runtime, projected and
+   clipped with d3-geo + topojson-client. Falls back to a wireframe sphere if
+   those libraries or the data can't be fetched, so the section is never blank.
    ========================================================================== */
 (function () {
   "use strict";
@@ -19,6 +25,7 @@
 
   var ctx = canvas.getContext("2d");
   var reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var HALF_PI = Math.PI / 2;
 
   // ---- DOM refs ----
   var quoteEl   = document.getElementById("voicesQuote");
@@ -35,35 +42,29 @@
   var nextBtn   = document.getElementById("vNext");
 
   // ---- palette (Anthropic) ----
-  var DOT = "20,20,19";        // ink dots on ivory
+  var INK = "20,20,19";        // ink — land dots / borders on ivory
   var SENT_POS = "#788c5d";    // sage  — loved it
   var SENT_NEU = "#6a9bcc";    // sky   — positive
   var CORAL = "#d97757";       // active highlight
   function sentiment(r) { return r >= 5 ? { label: "Loved it", color: SENT_POS } : { label: "Positive", color: SENT_NEU }; }
 
-  // ---- view state ----
+  // ---- view state (degrees: lambda = longitude spin, phi = tilt) ----
   var dpr = Math.min(window.devicePixelRatio || 1, 2);
   var W = 0, H = 0, cx = 0, cy = 0, R = 0;
-  var rotation = 0, tilt = 0.32;
-  var targetRot = 0, targetTilt = 0.32;
+  var lambda = -20, phi = -12;
+  var targetLambda = -20, targetPhi = -12;
   var seeking = false, dragging = false, dragDist = 0;
   var lastX = 0, lastY = 0, lastInteract = -1e9, lastActivate = 0;
   var running = false, rafId = 0, lastTs = 0;
+  var DRIFT = 6.5, DWELL = 4800, RESUME = 9000, EASE = 0.085;  // DRIFT in deg/sec
 
-  var DRIFT = 0.12, DWELL = 4800, RESUME = 9000, EASE = 0.09;
-
-  // ---- dotted sphere (Fibonacci distribution) ----
-  var N = 1500;
-  var bx = new Float32Array(N), by = new Float32Array(N), bz = new Float32Array(N);
-  (function () {
-    var golden = Math.PI * (3 - Math.sqrt(5));
-    for (var i = 0; i < N; i++) {
-      var y = 1 - (i / (N - 1)) * 2;
-      var r = Math.sqrt(Math.max(0, 1 - y * y));
-      var th = i * golden;
-      bx[i] = Math.cos(th) * r; by[i] = y; bz[i] = Math.sin(th) * r;
-    }
-  })();
+  // ---- geography (filled in once world-atlas loads) ----
+  var ready = false, geoFailed = false;
+  var projection = null, path = null;
+  var graticule = null, borders = null, sphere = { type: "Sphere" };
+  var landDots = [];                 // [lng, lat] points that fall on land
+  var featureByName = {};            // country name -> GeoJSON feature
+  var activeFeature = null;
 
   // ---- group testimonials into country markers ----
   var countries = [], byCode = {};
@@ -92,25 +93,21 @@
     if (pool.indexOf(activeIndex) === -1 && pool.length) activate(pool[0]);
   }
 
-  // ---- math ----
-  var cr = 1, sr = 0, cti = Math.cos(tilt), sti = Math.sin(tilt);
-  function refreshTrig() { cr = Math.cos(rotation); sr = Math.sin(rotation); cti = Math.cos(tilt); sti = Math.sin(tilt); }
-  function vec(lat, lng) {
-    var phi = lat * Math.PI / 180, th = lng * Math.PI / 180;
-    return [Math.cos(phi) * Math.sin(th), Math.sin(phi), Math.cos(phi) * Math.cos(th)];
-  }
-  function rot3(x, y, z) {
-    var x1 = x * cr + z * sr, z1 = -x * sr + z * cr;
-    var y2 = y * cti - z1 * sti, z2 = y * sti + z1 * cti;
-    return [x1, y2, z2];
-  }
+  // ---- small helpers ----
   function hexA(hex, a) {
     var n = parseInt(hex.slice(1), 16);
     return "rgba(" + (n >> 16 & 255) + "," + (n >> 8 & 255) + "," + (n & 255) + "," + a + ")";
   }
-  function angDiff(a, b) {
-    var d = (a - b) % (Math.PI * 2);
-    if (d > Math.PI) d -= Math.PI * 2; if (d < -Math.PI) d += Math.PI * 2; return d;
+  function angDiffDeg(a, b) {
+    var d = (a - b) % 360;
+    if (d > 180) d -= 360; if (d < -180) d += 360; return d;
+  }
+  // angular distance (radians) between a [lng,lat] point and the view centre
+  function geoDist(lng, lat, clng, clat) {
+    var a = lat * Math.PI / 180, b = clat * Math.PI / 180;
+    var dl = (lng - clng) * Math.PI / 180;
+    var c = Math.sin(a) * Math.sin(b) + Math.cos(a) * Math.cos(b) * Math.cos(dl);
+    return Math.acos(Math.max(-1, Math.min(1, c)));
   }
 
   // ---- sizing ----
@@ -118,85 +115,244 @@
     var rect = canvas.getBoundingClientRect();
     W = Math.max(1, rect.width); H = Math.max(1, rect.height);
     canvas.width = Math.round(W * dpr); canvas.height = Math.round(H * dpr);
-    cx = W / 2; cy = H / 2; R = Math.min(W, H) / 2 * 0.82;
+    cx = W / 2; cy = H / 2; R = Math.min(W, H) / 2 * 0.94;
+    if (projection) projection.scale(R).translate([cx, cy]);
     draw(performance.now());
   }
 
-  // ---- render ----
+  // ====================================================================
+  //  Geography loading (d3-geo + topojson-client + world-atlas)
+  // ====================================================================
+  function loadScript(src) {
+    return new Promise(function (res, rej) {
+      var existing = document.querySelector('script[src="' + src + '"]');
+      if (existing) { if (existing.dataset.loaded) return res(); existing.addEventListener("load", res); existing.addEventListener("error", rej); return; }
+      var s = document.createElement("script");
+      s.src = src; s.async = true;
+      s.onload = function () { s.dataset.loaded = "1"; res(); };
+      s.onerror = rej;
+      document.head.appendChild(s);
+    });
+  }
+
+  function ensureLibs() {
+    var jobs = [];
+    if (!(window.d3 && window.d3.geoOrthographic)) jobs.push(loadScript("https://cdn.jsdelivr.net/npm/d3-geo@3/dist/d3-geo.min.js"));
+    if (!window.topojson) jobs.push(loadScript("https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"));
+    return Promise.all(jobs);
+  }
+
+  // map our testimonial country names onto world-atlas feature names
+  var NAME_ALIAS = {
+    "united states": "united states of america",
+    "united kingdom": "united kingdom",
+    "united arab emirates": "united arab emirates"
+  };
+  function featureFor(name) {
+    var key = name.toLowerCase();
+    return featureByName[NAME_ALIAS[key] || key] || null;
+  }
+
+  function buildLandDots(land, d3) {
+    var pts = [];
+    for (var lat = -83; lat <= 83; lat += 2.6) {
+      var rad = Math.cos(lat * Math.PI / 180);
+      var step = 2.6 / Math.max(0.18, rad);   // keep dot density roughly even
+      for (var lng = -180; lng < 180; lng += step) {
+        if (d3.geoContains(land, [lng, lat])) pts.push([lng, lat]);
+      }
+    }
+    return pts;
+  }
+
+  function setupGeo(world) {
+    var d3 = window.d3, topojson = window.topojson;
+    var obj = world.objects.countries;
+    var fc = topojson.feature(world, obj);
+    fc.features.forEach(function (f) {
+      var nm = f.properties && f.properties.name;
+      if (nm) featureByName[nm.toLowerCase()] = f;
+    });
+    borders = topojson.mesh(world, obj);                                   // coastlines + borders
+    var land = topojson.merge(world, obj.geometries);                      // for containment test
+    graticule = d3.geoGraticule10();
+
+    projection = d3.geoOrthographic().rotate([lambda, phi]).scale(R || 200).translate([cx || 0, cy || 0]).precision(0.4);
+    path = d3.geoPath(projection, ctx);
+
+    landDots = buildLandDots(land, d3);
+    activeFeature = featureFor(DATA[activeIndex].country);
+    ready = true;
+  }
+
+  function loadGeo() {
+    ensureLibs()
+      .then(function () { return fetch("https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json"); })
+      .then(function (r) { if (!r.ok) throw new Error("geo " + r.status); return r.json(); })
+      .then(function (world) { setupGeo(world); resize(); draw(performance.now()); })
+      .catch(function (err) { geoFailed = true; if (window.console) console.warn("Globe geography unavailable, using wireframe fallback.", err); draw(performance.now()); });
+  }
+
+  // ====================================================================
+  //  Rendering
+  // ====================================================================
   function draw(now) {
-    refreshTrig();
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, W, H);
+    if (R <= 0) return;
 
-    // faint warm halo (atmosphere) — subtle on ivory
-    var halo = ctx.createRadialGradient(cx, cy, R * 0.94, cx, cy, R * 1.14);
+    // warm atmospheric halo
+    var halo = ctx.createRadialGradient(cx, cy, R * 0.95, cx, cy, R * 1.16);
     halo.addColorStop(0, hexA(CORAL, 0.05));
     halo.addColorStop(1, hexA(CORAL, 0));
     ctx.fillStyle = halo;
-    ctx.beginPath(); ctx.arc(cx, cy, R * 1.14, 0, 6.2832); ctx.fill();
+    ctx.beginPath(); ctx.arc(cx, cy, R * 1.16, 0, 6.2832); ctx.fill();
 
-    // sphere body — gentle dimensionality
-    var body = ctx.createRadialGradient(cx - R * 0.32, cy - R * 0.36, R * 0.1, cx, cy, R);
-    body.addColorStop(0, "rgba(255,255,255,0.55)");
-    body.addColorStop(0.62, "rgba(212,162,127,0.06)");
-    body.addColorStop(1, "rgba(20,20,19,0.085)");
+    // sphere body — gentle dimensionality (top-left light)
+    var body = ctx.createRadialGradient(cx - R * 0.34, cy - R * 0.38, R * 0.1, cx, cy, R);
+    body.addColorStop(0, "rgba(255,255,255,0.7)");
+    body.addColorStop(0.6, "rgba(212,162,127,0.05)");
+    body.addColorStop(1, "rgba(20,20,19,0.07)");
     ctx.fillStyle = body;
     ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832); ctx.fill();
 
-    // dotted surface
-    ctx.fillStyle = "rgb(" + DOT + ")";
-    for (var i = 0; i < N; i++) {
-      var p = rot3(bx[i], by[i], bz[i]);
-      var depth = (p[2] + 1) / 2;
-      ctx.globalAlpha = 0.04 + depth * depth * 0.26;
-      var s = 0.5 + depth * 1.3;
-      ctx.fillRect(cx + p[0] * R - s / 2, cy - p[1] * R - s / 2, s, s);
+    if (ready) drawGeo(now); else drawFallback(now);
+
+    // crisp sphere edge
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832);
+    ctx.strokeStyle = hexA(INK, 0.16); ctx.lineWidth = 1; ctx.stroke();
+  }
+
+  function drawGeo(now) {
+    projection.rotate([lambda, phi]).scale(R).translate([cx, cy]);
+    var clng = -lambda, clat = -phi;
+
+    // clip everything to the sphere disc
+    ctx.save();
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832); ctx.clip();
+
+    // graticule
+    ctx.beginPath(); path(graticule);
+    ctx.strokeStyle = hexA(INK, 0.06); ctx.lineWidth = 0.6; ctx.stroke();
+
+    // dotted land
+    ctx.fillStyle = "rgb(" + INK + ")";
+    for (var i = 0; i < landDots.length; i++) {
+      var p = landDots[i];
+      var dist = geoDist(p[0], p[1], clng, clat);
+      if (dist > HALF_PI - 0.015) continue;
+      var xy = projection(p); if (!xy) continue;
+      var cosD = Math.cos(dist);            // 1 at centre → 0 at horizon
+      ctx.globalAlpha = 0.1 + cosD * 0.45;
+      var s = 0.55 + cosD * 1.25;
+      ctx.fillRect(xy[0] - s / 2, xy[1] - s / 2, s, s);
     }
     ctx.globalAlpha = 1;
 
-    // markers
+    // country borders
+    ctx.beginPath(); path(borders);
+    ctx.strokeStyle = hexA(INK, 0.14); ctx.lineWidth = 0.6; ctx.stroke();
+
+    // active country fill + outline (coral)
+    if (activeFeature) {
+      ctx.beginPath(); path(activeFeature);
+      ctx.fillStyle = hexA(CORAL, 0.22); ctx.fill();
+      ctx.strokeStyle = CORAL; ctx.lineWidth = 1.1; ctx.stroke();
+    }
+
+    drawMarkers(now, clng, clat);
+    ctx.restore();
+  }
+
+  // wireframe fallback if libraries/data are unavailable
+  var fbDots = null;
+  function buildFallbackDots() {
+    var N = 1400, golden = Math.PI * (3 - Math.sqrt(5));
+    fbDots = new Float32Array(N * 2);
+    for (var i = 0; i < N; i++) {
+      var y = 1 - (i / (N - 1)) * 2, r = Math.sqrt(Math.max(0, 1 - y * y)), th = i * golden;
+      fbDots[i * 2] = Math.atan2(Math.sin(th) * r, Math.cos(th) * r) * 180 / Math.PI;  // lng
+      fbDots[i * 2 + 1] = Math.asin(y) * 180 / Math.PI;                                 // lat
+    }
+  }
+  function projFallback(lng, lat, clng, clat) {
+    // simple orthographic projection (no library)
+    var a = lat * Math.PI / 180, b = clat * Math.PI / 180, dl = (lng - clng) * Math.PI / 180;
+    var x = Math.cos(a) * Math.sin(dl);
+    var y = Math.cos(b) * Math.sin(a) - Math.sin(b) * Math.cos(a) * Math.cos(dl);
+    return [cx + x * R, cy - y * R];
+  }
+  function drawFallback(now) {
+    if (!fbDots) buildFallbackDots();
+    var clng = -lambda, clat = -phi;
+    ctx.save();
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 6.2832); ctx.clip();
+    ctx.fillStyle = "rgb(" + INK + ")";
+    for (var i = 0; i < fbDots.length; i += 2) {
+      var dist = geoDist(fbDots[i], fbDots[i + 1], clng, clat);
+      if (dist > HALF_PI - 0.01) continue;
+      var xy = projFallback(fbDots[i], fbDots[i + 1], clng, clat);
+      var cosD = Math.cos(dist);
+      ctx.globalAlpha = 0.05 + cosD * cosD * 0.28;
+      var s = 0.5 + cosD * 1.3;
+      ctx.fillRect(xy[0] - s / 2, xy[1] - s / 2, s, s);
+    }
+    ctx.globalAlpha = 1;
+    drawMarkersFallback(now, clng, clat);
+    ctx.restore();
+  }
+
+  function drawMarkers(now, clng, clat) {
     var active = DATA[activeIndex];
     for (var m = 0; m < countries.length; m++) {
       var c = countries[m];
-      var v = vec(c.lat, c.lng), pp = rot3(v[0], v[1], v[2]);
-      c._front = pp[2] > 0.02;
-      if (!c._front) { c._sx = null; continue; }
-      var sx = cx + pp[0] * R, sy = cy - pp[1] * R;
-      var depth = (pp[2] + 1) / 2;
-      var isActive = active && c.code === active.code;
-      var size = (2.4 + Math.sqrt(c.count) * 2.2) * (0.72 + depth * 0.5);
-
-      // soft halo in sentiment colour
-      var g = ctx.createRadialGradient(sx, sy, 0, sx, sy, size * 4);
-      g.addColorStop(0, hexA(c.color, isActive ? 0.5 : 0.32));
-      g.addColorStop(1, hexA(c.color, 0));
-      ctx.fillStyle = g;
-      ctx.beginPath(); ctx.arc(sx, sy, size * 4, 0, 6.2832); ctx.fill();
-
-      // active: coral ring (+ pulse unless reduced motion)
-      if (isActive) {
-        if (!reduced) {
-          var t = (now % 1600) / 1600;
-          ctx.globalAlpha = (1 - t) * 0.7;
-          ctx.strokeStyle = CORAL; ctx.lineWidth = 1.5;
-          ctx.beginPath(); ctx.arc(sx, sy, size + 3 + t * 20, 0, 6.2832); ctx.stroke();
-          ctx.globalAlpha = 1;
-        }
-        ctx.strokeStyle = CORAL; ctx.lineWidth = 2;
-        ctx.beginPath(); ctx.arc(sx, sy, size + 5, 0, 6.2832); ctx.stroke();
-      }
-
-      // core
-      ctx.fillStyle = c.color;
-      ctx.beginPath(); ctx.arc(sx, sy, size, 0, 6.2832); ctx.fill();
-      ctx.strokeStyle = "#faf9f5"; ctx.lineWidth = 1.2;
-      ctx.stroke();
-
-      c._sx = sx; c._sy = sy;
+      var dist = geoDist(c.lng, c.lat, clng, clat);
+      if (dist > HALF_PI - 0.01) { c._sx = null; continue; }
+      var xy = projection([c.lng, c.lat]); if (!xy) { c._sx = null; continue; }
+      paintMarker(c, xy[0], xy[1], Math.cos(dist), active, now);
     }
   }
+  function drawMarkersFallback(now, clng, clat) {
+    var active = DATA[activeIndex];
+    for (var m = 0; m < countries.length; m++) {
+      var c = countries[m];
+      var dist = geoDist(c.lng, c.lat, clng, clat);
+      if (dist > HALF_PI - 0.01) { c._sx = null; continue; }
+      var xy = projFallback(c.lng, c.lat, clng, clat);
+      paintMarker(c, xy[0], xy[1], Math.cos(dist), active, now);
+    }
+  }
+  function paintMarker(c, sx, sy, cosD, active, now) {
+    var isActive = active && c.code === active.code;
+    var size = (2.4 + Math.sqrt(c.count) * 2.2) * (0.72 + cosD * 0.45);
 
-  // ---- animation loop ----
+    var g = ctx.createRadialGradient(sx, sy, 0, sx, sy, size * 4);
+    g.addColorStop(0, hexA(c.color, isActive ? 0.5 : 0.3));
+    g.addColorStop(1, hexA(c.color, 0));
+    ctx.fillStyle = g;
+    ctx.beginPath(); ctx.arc(sx, sy, size * 4, 0, 6.2832); ctx.fill();
+
+    if (isActive && !reduced) {
+      var t = (now % 1600) / 1600;
+      ctx.globalAlpha = (1 - t) * 0.7;
+      ctx.strokeStyle = CORAL; ctx.lineWidth = 1.5;
+      ctx.beginPath(); ctx.arc(sx, sy, size + 3 + t * 20, 0, 6.2832); ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+    if (isActive) {
+      ctx.strokeStyle = CORAL; ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(sx, sy, size + 5, 0, 6.2832); ctx.stroke();
+    }
+    ctx.fillStyle = c.color;
+    ctx.beginPath(); ctx.arc(sx, sy, size, 0, 6.2832); ctx.fill();
+    ctx.strokeStyle = "#faf9f5"; ctx.lineWidth = 1.2; ctx.stroke();
+
+    c._sx = sx; c._sy = sy;
+  }
+
+  // ====================================================================
+  //  Animation loop
+  // ====================================================================
   function frame(ts) {
     if (!running) return;
     var dt = Math.min(0.05, (ts - lastTs) / 1000 || 0);
@@ -204,14 +360,20 @@
 
     if (!dragging) {
       if (seeking) {
-        rotation += angDiff(targetRot, rotation) * EASE;
-        if (Math.abs(angDiff(targetRot, rotation)) < 0.01) { rotation = targetRot; seeking = false; }
+        lambda += angDiffDeg(targetLambda, lambda) * EASE;
+        phi += (targetPhi - phi) * EASE;
+        if (Math.abs(angDiffDeg(targetLambda, lambda)) < 0.4 && Math.abs(targetPhi - phi) < 0.4) {
+          lambda = targetLambda; phi = targetPhi; seeking = false;
+        }
       } else if (!reduced && (ts - lastInteract) > RESUME) {
-        rotation += DRIFT * dt; targetRot = rotation;
+        lambda -= DRIFT * dt; targetLambda = lambda;
+        phi += (targetPhi - phi) * EASE;
+      } else {
+        phi += (targetPhi - phi) * EASE;
       }
-      tilt += (targetTilt - tilt) * EASE;
+      lambda = ((lambda + 180) % 360 + 360) % 360 - 180;
     }
-    if (!reduced && !seeking && !dragging && (ts - lastInteract) > RESUME && (ts - lastActivate) > DWELL) next(true);
+    if (!reduced && !seeking && !dragging && (ts - lastInteract) > RESUME && (ts - lastActivate) > DWELL) next();
 
     draw(ts);
     rafId = requestAnimationFrame(frame);
@@ -219,7 +381,9 @@
   function start() { if (running || reduced) { draw(performance.now()); return; } running = true; lastTs = performance.now(); rafId = requestAnimationFrame(frame); }
   function stop() { running = false; if (rafId) cancelAnimationFrame(rafId); }
 
-  // ---- quote card ----
+  // ====================================================================
+  //  Quote card + selection
+  // ====================================================================
   function paint() {
     var d = DATA[activeIndex], s = sentiment(d.rating);
     textEl.textContent = "“" + d.quote + "”";
@@ -236,9 +400,10 @@
   function activate(index) {
     activeIndex = index; lastActivate = performance.now();
     var d = DATA[index];
-    targetRot = -d.lng * Math.PI / 180;
-    targetTilt = Math.max(-0.6, Math.min(0.6, d.lat * Math.PI / 180));
-    if (reduced) { rotation = targetRot; tilt = targetTilt; seeking = false; }
+    targetLambda = -d.lng;
+    targetPhi = Math.max(-62, Math.min(62, -d.lat));
+    activeFeature = ready ? featureFor(d.country) : null;
+    if (reduced) { lambda = targetLambda; phi = targetPhi; seeking = false; }
     else { seeking = true; }
     if (quoteEl) { quoteEl.classList.add("is-swapping"); setTimeout(function () { paint(); quoteEl.classList.remove("is-swapping"); }, 240); }
     else { paint(); }
@@ -247,7 +412,9 @@
   function next() { var p = pool.indexOf(activeIndex); activate(pool[(p + 1) % pool.length]); }
   function prev() { var p = pool.indexOf(activeIndex); activate(pool[(p - 1 + pool.length) % pool.length]); }
 
-  // ---- filters ----
+  // ====================================================================
+  //  Filters + a11y list
+  // ====================================================================
   function buildFilters() {
     if (!filtersEl) return;
     var mk = function (label, value) {
@@ -274,12 +441,14 @@
     });
   }
 
-  // ---- pointer interaction ----
+  // ====================================================================
+  //  Pointer interaction
+  // ====================================================================
   function pickMarker(px, py) {
-    var best = null, bestD = 20 * 20;
+    var best = null, bestD = 22 * 22;
     for (var i = 0; i < countries.length; i++) {
       var c = countries[i];
-      if (!c._front || c._sx == null) continue;
+      if (c._sx == null) continue;
       var dx = px - c._sx, dy = py - c._sy, dd = dx * dx + dy * dy;
       if (dd < bestD) { bestD = dd; best = c; }
     }
@@ -291,8 +460,8 @@
     if (dragging) {
       var dx = e.clientX - lastX, dy = e.clientY - lastY;
       dragDist += Math.abs(dx) + Math.abs(dy);
-      rotation += dx * 0.006; tilt = Math.max(-0.9, Math.min(0.9, tilt + dy * 0.005));
-      targetRot = rotation; targetTilt = tilt; seeking = false;
+      lambda -= dx * 0.3; phi = Math.max(-82, Math.min(82, phi + dy * 0.3));
+      targetLambda = lambda; targetPhi = phi; seeking = false;
       lastX = e.clientX; lastY = e.clientY; lastInteract = performance.now();
       if (reduced) draw(performance.now());
       return;
@@ -319,8 +488,12 @@
     }
   }
 
-  // ---- init ----
+  // ====================================================================
+  //  Init
+  // ====================================================================
   buildFilters(); buildSrList(); activate(0); paint(); resize();
+  loadGeo();
+
   if (prevBtn) prevBtn.addEventListener("click", function () { lastInteract = performance.now(); prev(); });
   if (nextBtn) nextBtn.addEventListener("click", function () { lastInteract = performance.now(); next(); });
   canvas.addEventListener("pointerdown", onDown);

--- a/index.html
+++ b/index.html
@@ -447,5 +447,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1.3.23/dist/lenis.min.js"></script>
 <script src="assets/js/premium.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-geo@3/dist/d3-geo.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"></script>
+<script src="assets/js/testimonials.js"></script>
+<script src="assets/js/globe-voices.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The section was showing the quote card but no globe: the testimonials.js and globe-voices.js script tags had been dropped during the revert/rebase, so nothing initialised. Re-add them, plus d3-geo + topojson-client.

Replace the uniform Fibonacci dot-sphere with a real, Anthropic-style orthographic globe: dotted landmasses sampled from world-atlas country polygons, a faint graticule and country borders, and the active student's country filled in coral. Markers stay sized by respondent count and coloured by sentiment. Falls back to a wireframe sphere if the geography libraries or data can't be fetched, so the section is never blank.


Claude-Session: https://claude.ai/code/session_01Px6t6kPoMYJxm2fWuouLDg