### PR TITLE
Load d3-array before d3-geo so the globe geography initialises

### DIFF
--- a/assets/js/globe-voices.js
+++ b/assets/js/globe-voices.js
@@ -136,10 +136,13 @@
   }
 
   function ensureLibs() {
-    var jobs = [];
-    if (!(window.d3 && window.d3.geoOrthographic)) jobs.push(loadScript("https://cdn.jsdelivr.net/npm/d3-geo@3/dist/d3-geo.min.js"));
-    if (!window.topojson) jobs.push(loadScript("https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"));
-    return Promise.all(jobs);
+    var topo = window.topojson ? Promise.resolve() : loadScript("https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js");
+    var d3geo = (window.d3 && window.d3.geoOrthographic)
+      ? Promise.resolve()
+      // d3-geo depends on d3-array's Adder, so it must load first
+      : (window.d3 && window.d3.Adder ? Promise.resolve() : loadScript("https://cdn.jsdelivr.net/npm/d3-array@3/dist/d3-array.min.js"))
+          .then(function () { return loadScript("https://cdn.jsdelivr.net/npm/d3-geo@3/dist/d3-geo.min.js"); });
+    return Promise.all([topo, d3geo]);
   }
 
   // map our testimonial country names onto world-atlas feature names

--- a/index.html
+++ b/index.html
@@ -447,6 +447,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1.3.23/dist/lenis.min.js"></script>
 <script src="assets/js/premium.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-array@3/dist/d3-array.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/d3-geo@3/dist/d3-geo.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"></script>
 <script src="assets/js/testimonials.js"></script>


### PR DESCRIPTION
d3-geo's standalone UMD bundle expects d3-array's Adder on the global d3 object; without it, d3-geo threw "t.Adder is not a constructor" at load, the geometry setup failed, and the globe silently fell back to the plain dot-sphere. Load d3-array first (both in the page and in the JS loader).


Claude-Session: https://claude.ai/code/session_01Px6t6kPoMYJxm2fWuouLDg