### PR TITLE
Redesign research page as an expert research showcase

### DIFF
--- a/research.html
+++ b/research.html
@@ -134,35 +134,159 @@
 <header class="page-hero">
   <div class="container">
     <span class="eyebrow reveal">Research</span>
-    <h1 class="reveal" style="--d:.1s">Scientific inquiry &amp; <em>publication</em>.</h1>
+    <h1 class="reveal" style="--d:.1s">Connecting players &amp; places across <em>distance</em>.</h1>
     <p class="lead reveal" style="--d:.2s">
-      My research centres on location-based augmented reality — designing, building, and evaluating systems that connect remote players through shared spatial experiences. I explore how AR can extend human interaction across distance, blending physical environments with digital layers.
+      My research designs, builds, and evaluates <strong>location-based augmented reality games</strong> that let physically separated players share a single augmented space. Through a research-through-design approach, I study how AR can move beyond decoration to become a core mechanic — reframing <em>place</em> itself as a shared, interactive canvas across distance.
     </p>
     <div class="hero-actions reveal" style="--d:.3s">
+      <a class="btn btn-solid" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">Read the PhD Thesis <span class="arrow">→</span></a>
       <a class="btn" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar <span class="arrow">↗</span></a>
-      <a class="btn" href="https://www.hitlabnz.org/index.php/project/location-based-ar-game-2/" target="_blank" rel="noopener">HIT Lab NZ Project <span class="arrow">↗</span></a>
-      <a class="btn" href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">PhD Thesis <span class="arrow">↗</span></a>
+      <a class="btn" href="#publications">Publications <span class="arrow">↓</span></a>
     </div>
   </div>
 </header>
 
-<section class="section">
+<!-- ===== Overarching research question ===== -->
+<section class="section soft">
   <div class="container">
     <div class="section-head reveal">
       <span class="idx">01</span>
-      <h2>Active <em>Projects</em></h2>
+      <h2>The driving <em>question</em></h2>
+    </div>
+    <div class="reveal" style="max-width:920px;">
+      <p style="font-family:var(--sans); font-size:clamp(22px,3.2vw,34px); font-weight:600; line-height:1.3; letter-spacing:-0.02em; color:var(--ink);">
+        “How can augmented reality make meaningful use of the real world to facilitate <em>synchronous remote multiplayer</em> gameplay?”
+      </p>
+      <p style="color:var(--ink-soft); margin-top:22px; max-width:64ch;">
+        Most location-based AR games treat AR as an optional visual layer — players can often switch it off without changing the game. My doctoral research asks the opposite: what happens when AR becomes the mechanism that binds remote places and players together? I answer this across three empirical user studies, organised around three research questions on <strong>representing remote space</strong>, <strong>spatial decision-making</strong>, and <strong>interactive AR mechanics</strong>.
+      </p>
     </div>
 
-    <div class="feature-row reveal">
+    <div class="stats reveal" style="margin-top:48px;">
+      <div class="stat"><span class="stat-value">3</span><span class="stat-label">Empirical user studies</span></div>
+      <div class="stat"><span class="stat-value">128</span><span class="stat-label">Study participants</span></div>
+      <div class="stat"><span class="stat-value">5</span><span class="stat-label">Peer-reviewed articles</span></div>
+      <div class="stat"><span class="stat-value">4</span><span class="stat-label">Design-guideline themes</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== Doctoral thesis ===== -->
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>Doctoral <em>thesis</em></h2>
+    </div>
+
+    <div class="feature-row reveal" style="border-bottom:none; padding-top:0;">
       <div class="feature-media">
-        <img alt="Diagram of location-based augmented reality research connecting remote players at HIT Lab NZ" src="assets/images/research-ar-map.svg"/>
+        <img alt="Dr. Yasas Sri Wickramasinghe at his PhD graduation, University of Canterbury" src="assets/images/phd-graduation.jpg"/>
       </div>
       <div>
-        <span class="eyebrow">Principal Investigator</span>
-        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Location-Based AR Games Connecting Remote Players &amp; Places</h3>
-        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Postdoctoral research at HIT Lab NZ designing, building, and evaluating multiplayer location-based AR games. Players at different physical locations share a single augmented space through custom Unity + Niantic Lightship systems.</p>
-        <div class="tags"><span class="tag">AR Games</span><span class="tag">Remote Play</span><span class="tag">HCI</span></div>
+        <span class="eyebrow">PhD · University of Canterbury · HIT Lab NZ</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Designing Multiplayer Location-Based Augmented Reality Games that Connect Remote Players and Places</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">
+          Supervised by Prof. Stephan Lukosch, A. Prof. Heide Lukosch, and James Everett, this thesis uses an iterative research-through-design method — cycles of design, development, and evaluation — to investigate how AR can represent remote spaces, support spatial decision-making, and drive engagement through core game mechanics. The work spans five peer-reviewed publications (Articles I–V) and contributes theoretically, empirically, methodologically, and practically to the design of remote multiplayer AR games.
+        </p>
+        <div class="tags">
+          <span class="tag gold">Research through Design</span>
+          <span class="tag">Spatial Presence</span>
+          <span class="tag">Remote Multiplayer</span>
+          <span class="tag">Meaningful Play</span>
+        </div>
+        <div class="pub-links" style="margin-top:22px;">
+          <a href="https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0" target="_blank" rel="noopener">UC Research Repository ↗</a>
+          <a href="Wickramasinghe.pdf" target="_blank">Full Thesis PDF</a>
+        </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== The three studies ===== -->
+<section class="section soft">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">03</span>
+      <h2>Three <em>studies</em></h2>
+      <p>Each study sharpens the next, building from how a remote place should look, to how players behave inside it, to the mechanics that make distributed play meaningful.</p>
+    </div>
+
+    <div class="grid-3">
+      <div class="card reveal">
+        <span class="kicker">Study 01 · RQ1</span>
+        <h3>Representing Remote Spaces</h3>
+        <p>Compared three AR techniques — <strong>Overlay</strong>, <strong>Window</strong>, and <strong>Tabletop</strong> — for portraying a remote location. Overlay produced the strongest sense of “being there” and self-location; Window felt like the remote place extending into your own; Tabletop offered a detached strategic overview.</p>
+        <div class="tags">
+          <span class="tag">30 participants</span>
+          <span class="tag gold">Entertainment Computing</span>
+        </div>
+      </div>
+
+      <div class="card reveal" style="--d:.06s">
+        <span class="kicker">Study 02 · RQ2</span>
+        <h3>Decision-Making &amp; Experience</h3>
+        <p>A remote multiplayer AR hide-and-seek game compared against co-located play. AR shifted spatial strategies — players exploited mid-air and vertical space — and a lightweight frustum cue strengthened social connection without avatars or video.</p>
+        <div class="tags">
+          <span class="tag">60 participants</span>
+          <span class="tag gold">IEEE VR · MDPI MTI</span>
+        </div>
+      </div>
+
+      <div class="card reveal" style="--d:.12s">
+        <span class="kicker">Study 03 · RQ3</span>
+        <h3>Mechanics &amp; Constraints</h3>
+        <p>Introduced interactive core AR mechanics — real-time object manipulation, particle-effect feedback, and time pressure. These deepened strategic search behaviour and engagement when paired with clear feedback and well-calibrated constraints.</p>
+        <div class="tags">
+          <span class="tag">38 participants</span>
+          <span class="tag gold">OzCHI 2025</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== Design guidelines ===== -->
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">04</span>
+      <h2>Design <em>guidelines</em></h2>
+      <p>Synthesised from all three studies — practical guidance for designing AR games that connect remote players and places.</p>
+    </div>
+
+    <div class="grid-2">
+      <div class="card reveal">
+        <span class="kicker">01 — Remote Space Representation</span>
+        <h3>Make the place feel present</h3>
+        <p>Prioritise real-world-scale Overlay views for spatial presence, use Window “portals” as an intuitive interface for sharing resources between locations, and ground it all in high-fidelity 3D scans of the remote environment.</p>
+      </div>
+      <div class="card reveal" style="--d:.06s">
+        <span class="kicker">02 — Player Interaction &amp; Coordination</span>
+        <h3>Lightweight presence beats fidelity</h3>
+        <p>Visualise the remote player's viewpoint in real time and add voice. Minimal orientation cues (a frustum avatar) coordinated players as effectively as far heavier embodiment — connection without high-fidelity avatars.</p>
+      </div>
+      <div class="card reveal" style="--d:.12s">
+        <span class="kicker">03 — AR Mechanics &amp; Constraints</span>
+        <h3>AR as a core mechanic</h3>
+        <p>Embed AR in the gameplay loop rather than as decoration: multiple remotely anchored objects, real-time manipulation, and carefully calibrated time pressure that stretches players without overwhelming them.</p>
+      </div>
+      <div class="card reveal" style="--d:.18s">
+        <span class="kicker">04 — Engagement &amp; Spatial Decisions</span>
+        <h3>Guide without removing the challenge</h3>
+        <p>Subtle feedback — like particle trails marking object swaps — supports orientation while preserving discovery. Support onboarding to reduce early disorientation, and design for player safety during physical movement.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== Other projects ===== -->
+<section class="section soft">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">05</span>
+      <h2>Other <em>projects</em></h2>
     </div>
 
     <div class="feature-row reveal">
@@ -177,34 +301,15 @@
       </div>
     </div>
 
-    <div class="feature-row reveal">
-      <div class="feature-media">
-        <img alt="Participants at a virtual and augmented reality research workshop" src="assets/images/photography_img13.jpg"/>
-      </div>
-      <div>
-        <span class="eyebrow">IEEE VR 2025 · MDPI</span>
-        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Multiplayer AR — Player Experience &amp; Spatial Decision-Making</h3>
-        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">A 60-participant empirical study comparing AR hide-and-seek against traditional gameplay. Published in IEEE VR 2025 and Multimodal Technologies &amp; Interaction (MDPI).</p>
-        <div class="tags"><span class="tag gold">60 Participants</span><span class="tag">12 Publications</span><span class="tag">5 Venues in 2025</span></div>
-      </div>
-    </div>
-
     <div class="feature-row reveal" style="border-bottom:none;">
+      <div class="feature-media">
+        <img alt="Location-based augmented reality research connecting remote players at HIT Lab NZ" src="assets/images/research-ar-map.svg"/>
+      </div>
       <div>
         <span class="eyebrow">2015 — 2019</span>
         <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">NavitaZ VR Labs</h3>
-        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Co-founded AR/VR startup under the MIT Global Startup Labs programme. Built mobile AR apps and VR web applications in Sri Lanka — Microsoft Imagine Cup Runner-Up 2015.</p>
-        <div class="tags"><span class="tag">Startup</span><span class="tag">MIT GSL</span></div>
-      </div>
-      <div class="card" style="display:flex; flex-direction:column; justify-content:center; min-height:240px;">
-        <span class="kicker">Citation Metrics — Google Scholar, 2026</span>
-        <div class="info-list">
-          <div class="info-row"><span class="k">Publications</span><span class="v">12</span></div>
-          <div class="info-row"><span class="k">Citations</span><span class="v">7</span></div>
-          <div class="info-row"><span class="k">Since 2021</span><span class="v">6</span></div>
-          <div class="info-row"><span class="k">h-index</span><span class="v">1</span></div>
-          <div class="info-row" style="border-bottom:none;"><span class="k">Active Years</span><span class="v">2015 — 2025</span></div>
-        </div>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">Co-founded an AR/VR startup under the MIT Global Startup Labs programme. Built mobile AR apps and VR web applications in Sri Lanka — Microsoft Imagine Cup Runner-Up 2015.</p>
+        <div class="tags"><span class="tag">Startup</span><span class="tag">MIT GSL</span><span class="tag">Imagine Cup</span></div>
       </div>
     </div>
   </div>
@@ -213,8 +318,8 @@
 <section class="section" id="publications">
   <div class="container">
     <div class="section-head reveal">
-      <span class="idx">02</span>
-      <h2>Publication <em>Index</em></h2>
+      <span class="idx">06</span>
+      <h2>Publication <em>index</em></h2>
       <a class="link-arrow head-link" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar ↗</a>
     </div>
 
@@ -260,7 +365,7 @@
       <span class="pub-type">Journal</span>
       <div>
         <h3 class="pub-title">Representing Remote Locations with Location-Based Augmented Reality Game Design</h3>
-        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. — Entertainment Computing, 53, 100932. Elsevier. <span class="cite">1 citation</span></p>
+        <p class="pub-venue">Wickramasinghe, Y.S., Lukosch, H.K., Everett, J., &amp; Lukosch, S. — Entertainment Computing, 53, 100932. Elsevier.</p>
         <div class="pub-links">
           <a href="https://www.sciencedirect.com/science/article/pii/S1875952125000126" target="_blank" rel="noopener">ScienceDirect</a>
           <a href="https://doi.org/10.1016/j.entcom.2025.100932" target="_blank" rel="noopener">DOI: 10.1016/j.entcom.2025.100932</a>
@@ -298,7 +403,7 @@
       <span class="pub-type">Tech Report</span>
       <div>
         <h3 class="pub-title">Trust and Trustworthiness While Exchanging Virtual Items in Shared Augmented Reality</h3>
-        <p class="pub-venue">Ritter, M., Lukosch, S., Liew, K., &amp; Wickramasinghe, Y. — HIT Lab NZ, University of Canterbury. <span class="cite">1 citation</span></p>
+        <p class="pub-venue">Ritter, M., Lukosch, S., Liew, K., &amp; Wickramasinghe, Y. — HIT Lab NZ, University of Canterbury.</p>
         <div class="pub-links">
           <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
         </div>
@@ -336,7 +441,7 @@
       <span class="pub-type">Conference</span>
       <div>
         <h3 class="pub-title">A Review on Reimagining Medical Education with Virtual Reality in Emerging Medical Disciplines</h3>
-        <p class="pub-venue">Inparajah, J., &amp; Wickramasinghe, W. — 15th International Research Conference, p. 36. <span class="cite">1 citation</span></p>
+        <p class="pub-venue">Inparajah, J., &amp; Wickramasinghe, W. — 15th International Research Conference, p. 36.</p>
         <div class="pub-links">
           <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar</a>
         </div>
@@ -349,7 +454,7 @@
       <span class="pub-type">Conference</span>
       <div>
         <h3 class="pub-title">Virtual Reality Markup Framework for Generating Interactive Indoor Environment</h3>
-        <p class="pub-venue">Wickramasinghe, W., De Saram, P., Liyanage, C.P., Rangika, L.N.R., et al. — 2017 IEEE 3rd International Conference on Engineering Technologies and Social Sciences (ICETSS). IEEE. <span class="cite">4 citations</span></p>
+        <p class="pub-venue">Wickramasinghe, W., De Saram, P., Liyanage, C.P., Rangika, L.N.R., et al. — 2017 IEEE 3rd International Conference on Engineering Technologies and Social Sciences (ICETSS). IEEE.</p>
         <div class="pub-links">
           <a href="https://ieeexplore.ieee.org/document/8324175" target="_blank" rel="noopener">IEEE Xplore</a>
         </div>
@@ -362,7 +467,7 @@
       <span class="pub-type">Conference</span>
       <div>
         <h3 class="pub-title">A Mobile Application with Augmented Reality to Enhance Sinhala Learning Experience for Children</h3>
-        <p class="pub-venue">Wickramasinghe, W., &amp; Gunasekara, E.H.D.A. — Research Symposium of the Information Technology Research Unit (ITRU 2015). University of Moratuwa, Sri Lanka. <span class="cite">1 citation</span></p>
+        <p class="pub-venue">Wickramasinghe, W., &amp; Gunasekara, E.H.D.A. — Research Symposium of the Information Technology Research Unit (ITRU 2015). University of Moratuwa, Sri Lanka.</p>
         <div class="pub-links">
           <a href="http://dl.lib.uom.lk/handle/123/12494" target="_blank" rel="noopener">UoM Repository</a>
         </div>
@@ -372,11 +477,11 @@
   </div>
 </section>
 
-<section class="section">
+<section class="section soft">
   <div class="container split">
     <div class="sticky-col reveal">
-      <span class="eyebrow">03 — Network</span>
-      <h2>Collaborators &amp; <em>Links</em></h2>
+      <span class="eyebrow">07 — Network</span>
+      <h2>Collaborators &amp; <em>links</em></h2>
       <p style="color:var(--text-dim); font-weight:300; margin-top:20px; font-size:15px;">Co-authoring with researchers at HIT Lab NZ, University of Moratuwa, and Niantic Aotearoa.</p>
     </div>
     <div class="grid-2">


### PR DESCRIPTION
- Remove the Google Scholar citation-metrics card and inline citation badges
- Add a driving research-question section with study/participant stats
- Feature the PhD thesis with thesis links and contribution framing
- Add the three doctoral studies (Overlay/Window/Tabletop, hide-and-seek, interactive AR mechanics) with participant counts and venues
- Add a four-theme design-guidelines section synthesised from the studies
- Keep the full, verified 12-item publication index (matches Google Scholar)


Claude-Session: https://claude.ai/code/session_0134zLvKur9RJ7CYFJ6Jehu7