### PR TITLE
Redesign homepage with spatial-editorial design system

### DIFF
--- a/assets/css/editorial.css
+++ b/assets/css/editorial.css
@@ -1,0 +1,1119 @@
+/* ==========================================================================
+   YASASSRI.ME — Spatial Editorial design system
+   Warm paper & ink, one vermilion waypoint accent, Newsreader display serif,
+   IBM Plex Mono coordinate labels. Light-first with full dark theme.
+   ========================================================================== */
+
+/* ---- Tokens ---- */
+:root {
+  --paper: #faf7f1;
+  --surface: #ffffff;
+  --surface-2: #f3eee4;
+  --ink: #1b1913;
+  --ink-2: #5b564b;
+  --ink-3: #8a8375;
+  --hairline: #e5ddcd;
+  --accent: #b03f15;
+  --accent-strong: #96350f;
+  --on-accent: #fff8f2;
+  --wp-blue: #5c87b2;
+  --plate-shadow: 0 1px 2px rgba(27, 25, 19, 0.05), 0 12px 40px -18px rgba(27, 25, 19, 0.22);
+  --plate-shadow-lift: 0 2px 4px rgba(27, 25, 19, 0.06), 0 24px 56px -20px rgba(27, 25, 19, 0.3);
+
+  --font-display: "Newsreader", "Times New Roman", serif;
+  --font-body: "Inter", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+
+  --container: 1200px;
+  --gutter: clamp(20px, 4vw, 40px);
+  --section: clamp(88px, 12vw, 148px);
+
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+:root[data-theme="dark"] {
+  --paper: #131210;
+  --surface: #1b1917;
+  --surface-2: #201d19;
+  --ink: #ede8dd;
+  --ink-2: #aca596;
+  --ink-3: #7c7668;
+  --hairline: #2e2b25;
+  --accent: #e5764a;
+  --accent-strong: #ef8c64;
+  --on-accent: #1b0e07;
+  --wp-blue: #7ba3c9;
+  --plate-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 12px 40px -18px rgba(0, 0, 0, 0.6);
+  --plate-shadow-lift: 0 2px 4px rgba(0, 0, 0, 0.5), 0 24px 56px -20px rgba(0, 0, 0, 0.75);
+}
+
+/* ---- Reset & base ---- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16.5px;
+  line-height: 1.68;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  transition: background-color 0.35s ease, color 0.35s ease;
+}
+
+img { max-width: 100%; display: block; }
+a { color: inherit; text-decoration: none; }
+button { font: inherit; color: inherit; background: none; border: 0; cursor: pointer; }
+a, button, summary, input[type="submit"] { cursor: pointer; }
+
+::selection { background: var(--accent); color: var(--on-accent); }
+
+.container {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: var(--gutter);
+}
+
+/* ---- Type helpers ---- */
+.mono-label {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.mono-label .tick { color: var(--accent); }
+
+h1, h2, h3 { font-weight: 500; }
+
+.display {
+  font-family: var(--font-display);
+  font-weight: 420;
+  letter-spacing: -0.015em;
+  line-height: 1.06;
+  font-variation-settings: "opsz" 60;
+}
+
+.display em, .section-title em {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent);
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-size: clamp(30px, 4.2vw, 46px);
+  font-weight: 450;
+  line-height: 1.12;
+  letter-spacing: -0.012em;
+  max-width: 18em;
+}
+
+.section-sub {
+  margin-top: 16px;
+  color: var(--ink-2);
+  max-width: 34em;
+  font-size: 16px;
+}
+
+/* ---- Progress bar ---- */
+.progress-bar {
+  position: fixed;
+  top: 0; left: 0;
+  height: 2px;
+  width: 0;
+  background: var(--accent);
+  z-index: 120;
+}
+
+/* ---- Nav ---- */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  padding: 18px 0;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease, padding 0.3s ease;
+}
+
+.nav.scrolled {
+  padding: 10px 0;
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 1px 0 var(--hairline);
+}
+
+.nav-inner {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: var(--gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.nav-logo {
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.nav-logo em { font-style: italic; font-weight: 400; color: var(--accent); }
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+}
+
+.nav-links > a:not(.btn) {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ink-2);
+  letter-spacing: 0.01em;
+  position: relative;
+  padding: 4px 0;
+  transition: color 0.2s ease;
+}
+
+.nav-links > a:not(.btn):hover { color: var(--ink); }
+
+.nav-links > a.active { color: var(--ink); }
+.nav-links > a.active::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -2px;
+  height: 2px;
+  background: var(--accent);
+}
+
+/* ---- Buttons ---- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: 550;
+  padding: 12px 22px;
+  border: 1px solid var(--ink);
+  border-radius: 999px;
+  transition: background-color 0.22s ease, color 0.22s ease, border-color 0.22s ease, transform 0.22s var(--ease-out);
+}
+
+.btn:hover { background: var(--ink); color: var(--paper); transform: translateY(-1px); }
+
+.btn .arrow { transition: transform 0.22s var(--ease-out); }
+.btn:hover .arrow { transform: translateX(4px); }
+
+.btn-solid {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.btn-solid:hover { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
+
+.btn-accent {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+.btn-accent:hover { background: var(--accent-strong); border-color: var(--accent-strong); color: var(--on-accent); }
+
+/* Theme toggle */
+.theme-toggle {
+  width: 36px; height: 36px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-2);
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.3s var(--ease-out);
+}
+.theme-toggle:hover { border-color: var(--ink-2); color: var(--ink); transform: rotate(15deg); }
+.theme-toggle svg { width: 16px; height: 16px; }
+.theme-toggle .icon-moon { display: none; }
+:root[data-theme="dark"] .theme-toggle .icon-sun { display: none; }
+:root[data-theme="dark"] .theme-toggle .icon-moon { display: block; }
+
+/* Mobile nav */
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  padding: 8px;
+}
+.nav-toggle span {
+  width: 22px; height: 1.5px;
+  background: var(--ink);
+  transition: transform 0.3s var(--ease-out), opacity 0.2s;
+}
+
+.mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--gutter);
+  gap: 6px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+.mobile-menu.open { opacity: 1; visibility: visible; }
+.mobile-menu a {
+  font-family: var(--font-display);
+  font-size: clamp(28px, 7vw, 40px);
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--hairline);
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+}
+.mobile-menu a .idx {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+}
+.mobile-menu a.active { color: var(--accent); }
+
+/* ==========================================================================
+   HERO
+   ========================================================================== */
+.hero {
+  position: relative;
+  padding-top: clamp(130px, 16vh, 180px);
+  overflow: hidden;
+}
+
+/* faint graticule backdrop */
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--hairline) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hairline) 1px, transparent 1px);
+  background-size: 72px 72px;
+  opacity: 0.32;
+  -webkit-mask-image: radial-gradient(120% 90% at 50% 0%, #000 0%, transparent 72%);
+  mask-image: radial-gradient(120% 90% at 50% 0%, #000 0%, transparent 72%);
+}
+
+.hero-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  gap: clamp(32px, 5vw, 72px);
+  align-items: end;
+}
+
+.hero-copy { padding-bottom: clamp(8px, 2vw, 28px); }
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 26px;
+}
+.hero-eyebrow::before {
+  content: "";
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.hero h1 {
+  font-size: clamp(40px, 4.7vw, 66px);
+  max-width: 12.5em;
+}
+
+.hero-lede {
+  margin-top: 26px;
+  font-size: 17.5px;
+  color: var(--ink-2);
+  max-width: 30em;
+}
+
+.hero-actions {
+  margin-top: 34px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+}
+
+/* Portrait plate */
+.hero-figure {
+  position: relative;
+  align-self: end;
+}
+
+.hero-plate {
+  position: relative;
+  background: linear-gradient(175deg, var(--surface-2), color-mix(in srgb, var(--surface-2) 60%, var(--paper)));
+  border: 1px solid var(--hairline);
+  border-radius: 18px 18px 0 0;
+  overflow: hidden;
+  box-shadow: var(--plate-shadow);
+}
+
+.hero-plate::before {
+  /* concentric waypoint rings behind the portrait */
+  content: "";
+  position: absolute;
+  left: 50%; top: 58%;
+  width: 560px; height: 560px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, transparent 118px, var(--hairline) 119px, transparent 120px),
+    radial-gradient(circle, transparent 178px, var(--hairline) 179px, transparent 180px),
+    radial-gradient(circle, transparent 238px, var(--hairline) 239px, transparent 240px);
+  opacity: 0.9;
+}
+
+.hero-plate img {
+  position: relative;
+  width: 100%;
+  max-height: 460px;
+  object-fit: contain;
+  object-position: bottom center;
+  filter: saturate(0.96);
+}
+
+.hero-caption {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 4px 0;
+  border-top: 1px solid var(--ink);
+}
+
+/* Route strip: Colombo -> Christchurch */
+.route {
+  margin-top: clamp(48px, 7vw, 84px);
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+  background: color-mix(in srgb, var(--surface-2) 45%, var(--paper));
+}
+
+.route-inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(16px, 3vw, 36px);
+  padding-block: 18px;
+}
+
+.route-node { display: flex; flex-direction: column; gap: 2px; }
+.route-node .city {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 19px;
+  color: var(--ink);
+}
+
+.route-line { position: relative; height: 34px; }
+.route-line svg { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
+.route-line .dash {
+  stroke: var(--ink-3);
+  stroke-width: 1.2;
+  stroke-dasharray: 5 6;
+  fill: none;
+}
+.route-line .dot { fill: var(--accent); }
+.route-line .plane { fill: var(--ink-2); }
+.route-note {
+  position: absolute;
+  left: 50%; top: -13px;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+/* Stats band */
+.stats {
+  border-bottom: 1px solid var(--hairline);
+}
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+.stat {
+  padding: clamp(26px, 3.6vw, 44px) clamp(14px, 2vw, 28px);
+  border-left: 1px solid var(--hairline);
+}
+.stat:first-child { border-left: 0; }
+.stat .num {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 4.4vw, 54px);
+  font-weight: 450;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--ink);
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.stat .num .suffix { color: var(--accent); font-size: 0.62em; }
+.stat .lbl { margin-top: 10px; display: block; max-width: 15em; }
+
+/* ==========================================================================
+   SECTIONS — editorial numbered structure
+   ========================================================================== */
+.section { padding-block: var(--section); }
+.section.tint { background: color-mix(in srgb, var(--surface-2) 52%, var(--paper)); }
+
+.section-head { margin-bottom: clamp(40px, 6vw, 64px); }
+.section-head .mono-label { display: inline-flex; gap: 12px; margin-bottom: 18px; }
+.section-head.center { text-align: center; }
+.section-head.center .section-title, .section-head.center .section-sub { margin-inline: auto; }
+
+.rule { border: 0; border-top: 1px solid var(--hairline); }
+
+/* About */
+.about-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  gap: clamp(36px, 6vw, 80px);
+  align-items: start;
+}
+
+.about-copy p {
+  margin-top: 18px;
+  color: var(--ink-2);
+  font-size: 17px;
+  max-width: 36em;
+}
+.about-copy p strong { color: var(--ink); font-weight: 600; }
+.about-copy p:first-of-type {
+  font-family: var(--font-display);
+  font-size: clamp(21px, 2.5vw, 26px);
+  line-height: 1.42;
+  color: var(--ink);
+  font-weight: 420;
+}
+
+.trust {
+  margin-top: 36px;
+  padding-top: 26px;
+  border-top: 1px solid var(--hairline);
+}
+.trust-logos {
+  margin-top: 18px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(22px, 4vw, 44px);
+}
+.trust-logos img {
+  height: 30px;
+  width: auto;
+  filter: grayscale(1) contrast(0.85);
+  opacity: 0.72;
+  transition: filter 0.25s ease, opacity 0.25s ease;
+}
+.trust-logos img.logo-sony { height: 20px; }
+.trust-logos img:hover { filter: grayscale(0); opacity: 1; }
+:root[data-theme="dark"] .trust-logos img { filter: grayscale(1) invert(0.88); }
+:root[data-theme="dark"] .trust-logos img:hover { filter: grayscale(1) invert(1); }
+
+.about-actions { margin-top: 32px; display: flex; flex-wrap: wrap; gap: 14px; }
+
+.figure { position: relative; }
+.figure .frame {
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--hairline);
+  box-shadow: var(--plate-shadow);
+}
+.figure img { width: 100%; aspect-ratio: 4/4.6; object-fit: cover; }
+.figure figcaption {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 12px;
+  margin-top: 2px;
+  border-top: 1px solid var(--ink);
+}
+
+/* Research frontiers — numbered editorial rows */
+.frontiers { border-top: 1px solid var(--hairline); }
+.frontier {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 4fr) minmax(0, 6fr) 48px;
+  gap: clamp(16px, 3vw, 40px);
+  align-items: center;
+  padding-block: clamp(26px, 4vw, 40px);
+  border-bottom: 1px solid var(--hairline);
+  transition: background-color 0.25s ease;
+}
+.frontier:hover { background: color-mix(in srgb, var(--surface-2) 55%, transparent); }
+.frontier .no {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent);
+}
+.frontier h3 {
+  font-family: var(--font-display);
+  font-size: clamp(22px, 2.6vw, 30px);
+  font-weight: 450;
+  letter-spacing: -0.01em;
+}
+.frontier p { color: var(--ink-2); font-size: 15.5px; max-width: 34em; }
+.frontier .go {
+  width: 40px; height: 40px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-2);
+  transition: transform 0.25s var(--ease-out), background-color 0.25s, color 0.25s, border-color 0.25s;
+}
+.frontier:hover .go {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+  transform: rotate(-45deg);
+}
+
+/* Featured work plate */
+.casework {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--surface);
+  box-shadow: var(--plate-shadow);
+}
+.casework-img { position: relative; min-height: 340px; }
+.casework-img img {
+  position: absolute;
+  inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+}
+.casework-img .fig-tag {
+  position: absolute;
+  left: 16px; bottom: 14px;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  padding: 6px 14px;
+  color: var(--ink);
+}
+.casework-body {
+  padding: clamp(28px, 4vw, 52px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  justify-content: center;
+}
+.casework-body h3 {
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3vw, 34px);
+  font-weight: 450;
+  line-height: 1.16;
+}
+.casework-body p { color: var(--ink-2); font-size: 15.5px; }
+.casework-body .btn { align-self: flex-start; }
+
+/* ==========================================================================
+   VOICES — globe panel stays paper-toned in both themes (print figure)
+   ========================================================================== */
+.avoices .av-plate {
+  background: #faf7f1;
+  border: 1px solid #e5ddcd;
+  border-radius: 22px;
+  box-shadow: var(--plate-shadow);
+  padding: clamp(28px, 4.5vw, 60px);
+  color: #1b1913;
+}
+:root[data-theme="dark"] .avoices .av-plate {
+  border-color: #35322b;
+}
+
+.av-head { margin-bottom: clamp(30px, 4vw, 44px); }
+.av-head .mono-label { display: inline-flex; gap: 12px; margin-bottom: 16px; color: #8a8375; }
+.av-head .mono-label .tick { color: #b03f15; }
+.av-title {
+  font-family: var(--font-display);
+  font-size: clamp(28px, 3.8vw, 42px);
+  font-weight: 450;
+  line-height: 1.12;
+  color: #1b1913;
+}
+.av-title em { font-style: italic; font-weight: 400; color: #b03f15; }
+.av-sub { margin-top: 14px; color: #5b564b; max-width: 32em; font-size: 15.5px; }
+
+.av-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+  gap: clamp(28px, 4vw, 56px);
+  align-items: center;
+}
+
+.av-stage { position: relative; }
+.voices-globe {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  max-height: 520px;
+  display: block;
+  cursor: grab;
+  --globe-ink: 27, 25, 19;
+  --globe-marker: #5c87b2;
+  --globe-active: #b03f15;
+}
+.voices-globe:active { cursor: grabbing; }
+
+.voices-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: #1b1913;
+  color: #faf7f1;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 6px 10px;
+  border-radius: 6px;
+  transform: translate(-50%, -130%);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  white-space: nowrap;
+  z-index: 4;
+}
+.voices-tooltip.show { opacity: 1; }
+
+.av-quote blockquote {
+  font-family: var(--font-display);
+  font-size: clamp(19px, 2.2vw, 24px);
+  line-height: 1.45;
+  font-weight: 420;
+  color: #1b1913;
+  min-height: 5.6em;
+}
+/* opening/closing quote marks come from globe-voices.js */
+
+.av-cite {
+  margin-top: 22px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.av-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: #5c87b2;
+  flex: none;
+}
+.av-who { display: flex; flex-direction: column; }
+.av-who strong { font-size: 14.5px; font-weight: 600; color: #1b1913; }
+.av-who span { font-size: 13px; color: #5b564b; }
+.av-loc { margin-left: auto; }
+.av-country {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8a8375;
+  border: 1px solid #e5ddcd;
+  border-radius: 999px;
+  padding: 5px 12px;
+}
+
+.av-controls { margin-top: 26px; }
+.av-nav { display: flex; gap: 10px; }
+.av-navbtn {
+  width: 42px; height: 42px;
+  border: 1px solid #cfc7b6;
+  border-radius: 999px;
+  color: #1b1913;
+  font-size: 16px;
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+}
+.av-navbtn:hover { background: #1b1913; color: #faf7f1; border-color: #1b1913; }
+
+.av-foot { margin-top: 26px; padding-top: 20px; border-top: 1px solid #e5ddcd; }
+.av-stats { display: flex; gap: 28px; font-size: 13.5px; color: #5b564b; }
+.av-stats b {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 500;
+  color: #1b1913;
+  margin-right: 6px;
+}
+.voices-srlist { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+
+/* ==========================================================================
+   CARDS — events & news
+   ========================================================================== */
+.grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(20px, 2.6vw, 32px); }
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: clamp(20px, 2.6vw, 32px); }
+
+.article-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: transform 0.3s var(--ease-out), box-shadow 0.3s var(--ease-out), border-color 0.25s;
+  box-shadow: var(--plate-shadow);
+}
+.article-card:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--plate-shadow-lift);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--hairline));
+}
+
+.article-cover {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  background: var(--surface-2);
+}
+.article-cover .cover-img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s var(--ease-out);
+}
+.article-card:hover .cover-img { transform: scale(1.04); }
+.article-cover .cat {
+  position: absolute;
+  top: 12px; left: 12px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--paper) 90%, transparent);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--hairline);
+  color: var(--ink);
+  padding: 5px 11px;
+  border-radius: 999px;
+}
+.article-cover::after {
+  content: attr(data-num);
+  position: absolute;
+  right: 14px; bottom: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: #faf7f1;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.5);
+}
+
+.article-body {
+  padding: 20px 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+.article-body .src {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.article-body h3 {
+  font-family: var(--font-display);
+  font-size: 20.5px;
+  font-weight: 480;
+  line-height: 1.28;
+}
+.article-body .read {
+  margin-top: auto;
+  padding-top: 8px;
+  font-size: 13.5px;
+  font-weight: 550;
+  color: var(--accent);
+}
+
+.section-cta { text-align: center; margin-top: clamp(32px, 4vw, 48px); }
+
+/* ==========================================================================
+   WORK WITH ME — compact editorial list
+   ========================================================================== */
+.engage { border-top: 1px solid var(--hairline); }
+.engage-row {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 5fr) minmax(0, 6fr) 48px;
+  gap: clamp(16px, 3vw, 40px);
+  align-items: center;
+  padding-block: 24px;
+  border-bottom: 1px solid var(--hairline);
+  transition: background-color 0.25s ease;
+}
+.engage-row:hover { background: color-mix(in srgb, var(--surface-2) 55%, transparent); }
+.engage-row .no { font-family: var(--font-mono); font-size: 13px; color: var(--accent); }
+.engage-row h3 { font-size: 17px; font-weight: 600; }
+.engage-row p { color: var(--ink-2); font-size: 14.5px; }
+.engage-row .go {
+  width: 36px; height: 36px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-2);
+  transition: transform 0.25s var(--ease-out), background-color 0.25s, color 0.25s, border-color 0.25s;
+}
+.engage-row:hover .go {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--paper);
+  transform: rotate(-45deg);
+}
+
+/* ==========================================================================
+   FAQ
+   ========================================================================== */
+.faq { max-width: 760px; margin-inline: auto; border-top: 1px solid var(--hairline); }
+.faq-item { border-bottom: 1px solid var(--hairline); }
+.faq-item summary {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 18px;
+  padding: 22px 4px;
+  font-family: var(--font-display);
+  font-size: 19.5px;
+  font-weight: 480;
+  transition: color 0.2s;
+}
+.faq-item summary::-webkit-details-marker { display: none; }
+.faq-item summary::after {
+  content: "+";
+  font-family: var(--font-mono);
+  font-size: 18px;
+  color: var(--accent);
+  flex: none;
+  transition: transform 0.25s var(--ease-out);
+}
+.faq-item[open] summary::after { transform: rotate(45deg); }
+.faq-item summary:hover { color: var(--accent); }
+.faq-item p {
+  padding: 0 4px 24px;
+  color: var(--ink-2);
+  font-size: 15.5px;
+  max-width: 42em;
+}
+.faq-item a { color: var(--accent); font-weight: 550; }
+
+/* ==========================================================================
+   BIG CTA
+   ========================================================================== */
+.bigcta {
+  position: relative;
+  background: var(--ink);
+  color: var(--paper);
+  border-radius: 22px;
+  padding: clamp(44px, 7vw, 88px) clamp(28px, 6vw, 80px);
+  overflow: hidden;
+  text-align: center;
+}
+:root[data-theme="dark"] .bigcta {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  color: var(--ink);
+}
+.bigcta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(250,247,241,0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(250,247,241,0.07) 1px, transparent 1px);
+  background-size: 64px 64px;
+  -webkit-mask-image: radial-gradient(100% 120% at 50% 100%, #000, transparent 75%);
+  mask-image: radial-gradient(100% 120% at 50% 100%, #000, transparent 75%);
+  pointer-events: none;
+}
+.bigcta .mono-label { color: color-mix(in srgb, currentColor 55%, transparent); }
+.bigcta h2 {
+  position: relative;
+  font-family: var(--font-display);
+  font-size: clamp(30px, 4.6vw, 52px);
+  font-weight: 440;
+  line-height: 1.1;
+  max-width: 17em;
+  margin: 18px auto 0;
+}
+.bigcta h2 em { font-style: italic; font-weight: 400; color: #e5764a; }
+.bigcta p {
+  position: relative;
+  margin: 18px auto 0;
+  max-width: 34em;
+  color: color-mix(in srgb, currentColor 70%, transparent);
+}
+.bigcta .btn { margin-top: 32px; position: relative; }
+.bigcta .btn-paper {
+  background: var(--paper);
+  color: var(--ink);
+  border-color: var(--paper);
+}
+.bigcta .btn-paper:hover { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
+:root[data-theme="dark"] .bigcta .btn-paper { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+:root[data-theme="dark"] .bigcta .btn-paper:hover { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
+
+/* ==========================================================================
+   FOOTER
+   ========================================================================== */
+.footer {
+  border-top: 1px solid var(--hairline);
+  padding: clamp(52px, 7vw, 84px) 0 36px;
+  background: color-mix(in srgb, var(--surface-2) 40%, var(--paper));
+}
+
+.footer-top {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) repeat(3, minmax(0, 2fr));
+  gap: clamp(28px, 4vw, 56px);
+}
+
+.footer-news h3 {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 480;
+}
+.footer-news p { margin-top: 10px; color: var(--ink-2); font-size: 14.5px; max-width: 26em; }
+
+.nl-form {
+  margin-top: 18px;
+  display: flex;
+  gap: 10px;
+  max-width: 420px;
+}
+.nl-form input {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  font-size: 14px;
+  padding: 11px 16px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--ink);
+  transition: border-color 0.2s;
+}
+.nl-form input:focus { outline: none; border-color: var(--accent); }
+.nl-form .btn { padding-block: 11px; }
+
+.footer-col h4 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 16px;
+}
+.footer-col a {
+  display: block;
+  padding: 5px 0;
+  font-size: 14.5px;
+  color: var(--ink-2);
+  transition: color 0.2s;
+}
+.footer-col a:hover { color: var(--accent); }
+
+.footer-bottom {
+  margin-top: clamp(40px, 6vw, 64px);
+  padding-top: 24px;
+  border-top: 1px solid var(--hairline);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.footer-logo {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 500;
+}
+.footer-bottom small { color: var(--ink-3); font-size: 12.5px; }
+.footer-coords { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; color: var(--ink-3); }
+
+/* ==========================================================================
+   MOTION — reveal system (premium.js adds .in)
+   ========================================================================== */
+.reveal {
+  opacity: 0;
+  transform: translateY(26px);
+  transition: opacity 0.8s var(--ease-out), transform 0.8s var(--ease-out);
+  transition-delay: var(--d, 0s);
+}
+.reveal.in { opacity: 1; transform: none; }
+
+.scroll-hint {
+  position: absolute;
+  right: var(--gutter);
+  bottom: 22px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .reveal { opacity: 1; transform: none; transition: none; }
+  *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
+}
+
+/* ==========================================================================
+   RESPONSIVE
+   ========================================================================== */
+@media (max-width: 1024px) {
+  .hero-grid { grid-template-columns: 1fr; align-items: start; }
+  .hero-figure { max-width: 520px; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .stat:nth-child(3) { border-left: 0; }
+  .stat { border-top: 1px solid var(--hairline); }
+  .stat:nth-child(-n+2) { border-top: 0; }
+  .about-grid { grid-template-columns: 1fr; }
+  .about-grid .figure { max-width: 520px; }
+  .av-grid { grid-template-columns: 1fr; }
+  .grid-3 { grid-template-columns: 1fr 1fr; }
+  .casework { grid-template-columns: 1fr; }
+  .casework-img { min-height: 280px; }
+  .footer-top { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 720px) {
+  .nav-links > a:not(.btn):not(.theme-toggle) { display: none; }
+  .nav-links .btn { display: none; }
+  .nav-toggle { display: flex; }
+  .frontier { grid-template-columns: 48px 1fr 40px; }
+  .frontier p { grid-column: 2; }
+  .engage-row { grid-template-columns: 48px 1fr 36px; }
+  .engage-row p { grid-column: 2; }
+  .grid-2, .grid-3 { grid-template-columns: 1fr; }
+  .route-inner { grid-template-columns: 1fr; gap: 10px; padding-block: 22px; }
+  .route-line { display: none; }
+  .route-node { flex-direction: row; align-items: baseline; gap: 12px; text-align: left !important; }
+  .route-node .mono-label { flex: none; }
+  .stats-grid { grid-template-columns: 1fr 1fr; }
+  .footer-top { grid-template-columns: 1fr; }
+  .hero h1 { font-size: clamp(38px, 10.5vw, 52px); }
+}

--- a/assets/js/globe-voices.js
+++ b/assets/js/globe-voices.js
@@ -37,10 +37,11 @@
   var prevBtn   = document.getElementById("vPrev");
   var nextBtn   = document.getElementById("vNext");
 
-  // ---- palette (Anthropic) ----
-  var INK = "20,20,19";        // ink — land fill / borders on ivory
-  var MARKER = "#6a9bcc";      // sky — every student marker is the same blue
-  var CORAL = "#d97757";       // active student's country highlight
+  // ---- palette (overridable via --globe-* CSS custom properties on the canvas) ----
+  var cssPalette = getComputedStyle(canvas);
+  var INK = cssPalette.getPropertyValue("--globe-ink").trim() || "20,20,19";          // rgb triplet — land fill / borders on ivory
+  var MARKER = cssPalette.getPropertyValue("--globe-marker").trim() || "#6a9bcc";     // every student marker is the same blue
+  var CORAL = cssPalette.getPropertyValue("--globe-active").trim() || "#d97757";      // active student's country highlight
 
   // ---- view state (degrees: lambda = longitude spin, phi = tilt) ----
   var dpr = Math.min(window.devicePixelRatio || 1, 2);

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <link rel="icon" href="assets/images/icons/favicon.png"/>
 <meta name="keywords" content="Yasas Sri Wickramasinghe, augmented reality researcher, AR researcher, augmented reality lecturer, AR lecturer, spatial computing, extended reality, XR researcher, human-computer interaction, HCI, location-based AR, immersive technology, virtual reality, mixed reality, HIT Lab NZ, Yoobee College, University of Canterbury"/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
-<meta name="theme-color" content="#4b6bff"/>
+<meta name="theme-color" content="#faf7f1"/>
 <link rel="canonical" href="https://www.yasassri.me/"/>
 <!-- Open Graph -->
 <meta property="og:type" content="website"/>
@@ -134,10 +134,20 @@
   ]
 }
 </script>
+<script>
+  // Apply saved/system theme before first paint to avoid a flash.
+  (function () {
+    try {
+      var t = localStorage.getItem("theme");
+      if (!t) t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      document.documentElement.dataset.theme = t;
+    } catch (e) {}
+  })();
+</script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&display=swap" rel="stylesheet"/>
-<link href="assets/css/redesign.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="assets/css/editorial.css" rel="stylesheet"/>
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
 <script>
@@ -163,8 +173,12 @@
       <a href="blogs.html">Writing</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
+      <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+      </button>
+      <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
     </div>
-    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
   </div>
 </nav>
 <div class="mobile-menu">
@@ -182,84 +196,206 @@
 <header class="hero" id="top">
   <div class="hero-bg" aria-hidden="true"></div>
   <div class="container">
-    <span class="hero-eyebrow">Postdoctoral Researcher · Senior Lecturer</span>
-    <div class="hero-stage">
-      <h1 class="hero-name" aria-label="Yasas Sri Wickramasinghe">
-        <span class="l1" data-parallax data-speed="0.16">Yasas</span>
-        <span class="l2" data-parallax data-speed="0.10">Wickramasinghe</span>
-      </h1>
-      <img class="hero-cutout" src="assets/images/hero-cutout.png" alt="Dr. Yasas Sri Wickramasinghe, augmented reality researcher and lecturer" data-parallax data-speed="-0.05"/>
-      <div class="hero-float hero-float-l" data-parallax data-speed="-0.10">
-        <div class="hero-card">
-          <h3>Let's Build Immersive Futures</h3>
-          <p>Location-based AR &amp; spatial computing research — turned into things people can actually use.</p>
-          <a class="btn" href="research.html">Explore Research <span class="arrow">→</span></a>
+    <div class="hero-grid">
+      <div class="hero-copy">
+        <span class="hero-eyebrow mono-label">Postdoctoral Researcher, HIT Lab NZ · Senior Lecturer, Yoobee</span>
+        <h1 class="display" data-parallax data-speed="0.05">Designing augmented realities that connect <em>people&nbsp;&amp;&nbsp;places</em> across distance.</h1>
+        <p class="hero-lede">I research, build, and teach location-based AR and spatial computing — multiplayer experiences studied with Sony Interactive Entertainment and Niantic, then shipped as things people actually use.</p>
+        <div class="hero-actions">
+          <a class="btn btn-solid" href="research.html">Explore the Research <span class="arrow">→</span></a>
+          <a class="btn" href="contact.html">Get in Touch</a>
         </div>
       </div>
-      <div class="hero-float hero-float-r" data-parallax data-speed="-0.10">
-        <div class="hero-stat-card">
-          <span class="num">150K+ <span class="up">↗</span></span>
-          <span class="lbl">learners reached through platforms I helped build</span>
-          <hr/>
-          <p class="role">AR · XR · HCI research at HIT Lab NZ in collaboration with Sony Interactive Entertainment.</p>
+      <figure class="hero-figure" data-parallax data-speed="-0.03">
+        <div class="hero-plate">
+          <img src="assets/images/hero-cutout.png" alt="Dr. Yasas Sri Wickramasinghe, augmented reality researcher and lecturer" width="640" height="520"/>
+        </div>
+        <figcaption class="hero-caption">
+          <span class="mono-label">Fig. 01 — Dr. Yasas Sri Wickramasinghe</span>
+          <span class="mono-label">Ōtautahi Christchurch</span>
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+
+  <!-- Route strip: the thesis, as a map instrument -->
+  <div class="route" aria-label="From Colombo to Christchurch — connected by research">
+    <div class="container route-inner">
+      <div class="route-node">
+        <span class="mono-label"><span class="tick">●</span> Origin — 6.93°N 79.86°E</span>
+        <span class="city">Colombo, Sri Lanka</span>
+      </div>
+      <div class="route-line" aria-hidden="true">
+        <svg viewBox="0 0 600 34" preserveAspectRatio="none">
+          <path class="dash" d="M6 28 Q 300 -14 594 28"/>
+          <circle class="dot" cx="6" cy="28" r="3.5"/>
+          <circle class="dot" cx="594" cy="28" r="3.5"/>
+        </svg>
+        <span class="route-note mono-label">11,300 km — connected by design</span>
+      </div>
+      <div class="route-node" style="text-align:right">
+        <span class="mono-label">Base — 43.53°S 172.64°E <span class="tick">●</span></span>
+        <span class="city">Christchurch, New Zealand</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Stats band -->
+  <div class="stats" aria-label="Key numbers">
+    <div class="container">
+      <div class="stats-grid">
+        <div class="stat reveal">
+          <span class="num"><span class="count" data-target="150">0</span><span class="suffix">K+</span></span>
+          <span class="lbl mono-label">Learners reached through platforms I helped build</span>
+        </div>
+        <div class="stat reveal" style="--d:.06s">
+          <span class="num"><span class="count" data-target="5">0</span></span>
+          <span class="lbl mono-label">Peer-reviewed articles in leading HCI venues</span>
+        </div>
+        <div class="stat reveal" style="--d:.12s">
+          <span class="num"><span class="count" data-target="128">0</span></span>
+          <span class="lbl mono-label">Participants across three empirical user studies</span>
+        </div>
+        <div class="stat reveal" style="--d:.18s">
+          <span class="num"><span class="count" data-target="16">0</span></span>
+          <span class="lbl mono-label">Countries represented in my classrooms</span>
         </div>
       </div>
     </div>
   </div>
-  <a class="scroll-hint" href="#about">Scroll <span></span></a>
 </header>
 
-<!-- MARQUEE -->
-<div class="marquee" aria-hidden="true">
-  <div class="marquee-track">
-    <span>Location-Based AR</span><span>Spatial Computing</span><span>Human Interface Technology</span><span>Player Experience</span><span>XR Research</span><span>HCI</span>
-  </div>
-  <div class="marquee-track">
-    <span>Location-Based AR</span><span>Spatial Computing</span><span>Human Interface Technology</span><span>Player Experience</span><span>XR Research</span><span>HCI</span>
-  </div>
-</div>
-
-<!-- STUDENT VOICES — interactive globe (Anthropic-inspired editorial section) -->
-<section class="avoices" id="voices" aria-label="What students say around the world">
-  <div class="container av-inner">
-    <div class="av-head reveal">
-      <span class="av-eyebrow">Voices from my classroom</span>
-      <h2 class="av-title">What my students say,<br/>all around the world</h2>
-      <p class="av-sub">Thousands of learners across universities, MOOCs and workshops — from Colombo to Christchurch.</p>
-    </div>
-
-    <div class="av-grid">
-      <div class="av-stage reveal">
-        <canvas id="voicesGlobe" class="voices-globe" role="img" aria-label="Rotating globe showing the countries students wrote from"></canvas>
-        <div class="voices-tooltip" id="voicesTooltip" aria-hidden="true"></div>
-      </div>
-
-      <div class="av-panel reveal" style="--d:.1s">
-        <figure class="av-quote" id="voicesQuote">
-          <blockquote id="vqText">&hellip;</blockquote>
-          <figcaption class="av-cite">
-            <span class="av-dot" id="vqAvatar" aria-hidden="true"></span>
-            <span class="av-who">
-              <strong id="vqName">&hellip;</strong>
-              <span id="vqRole">&hellip;</span>
-            </span>
-            <span class="av-loc">
-              <span class="av-country" id="vqCountry"></span>
-            </span>
-          </figcaption>
-        </figure>
-
-        <div class="av-controls">
-          <div class="av-nav">
-            <button class="av-navbtn" id="vPrev" type="button" aria-label="Previous voice">←</button>
-            <button class="av-navbtn" id="vNext" type="button" aria-label="Next voice">→</button>
+<!-- 01 — ABOUT -->
+<section class="section" id="about">
+  <div class="container">
+    <div class="about-grid">
+      <div class="about-copy reveal">
+        <span class="mono-label"><span class="tick">01</span> / About</span>
+        <p>I'm Dr. Yasas Sri Wickramasinghe — a Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) and Senior Lecturer at Yoobee College of Creative Innovation.</p>
+        <p>I hold a PhD in Human Interface Technology, with a dissertation on designing <strong>multiplayer location-based AR games that connect remote players and places</strong>. My work is conducted with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc.</p>
+        <p>Earlier I co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme and led Sri Lanka's first large-scale MOOC platform.</p>
+        <div class="trust">
+          <span class="mono-label">Research conducted with</span>
+          <div class="trust-logos">
+            <img src="assets/images/logo-hitlabnz.png" alt="HIT Lab NZ, University of Canterbury — augmented reality research lab logo"/>
+            <img class="logo-sony" src="assets/images/logo-sony.svg" alt="Sony Interactive Entertainment logo"/>
+            <img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial logo"/>
           </div>
         </div>
+        <div class="about-actions">
+          <a class="btn btn-solid" href="contact.html">Get in Touch <span class="arrow">→</span></a>
+          <a class="btn" href="research.html">See My Work</a>
+        </div>
+      </div>
+      <figure class="figure reveal" style="--d:.12s">
+        <div class="frame">
+          <img src="assets/images/phd-graduation.jpg" alt="Dr. Yasas Sri Wickramasinghe at his PhD graduation, University of Canterbury"/>
+        </div>
+        <figcaption>
+          <span class="mono-label">Fig. 02 — PhD in Human Interface Technology</span>
+          <span class="mono-label">Univ. of Canterbury</span>
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+</section>
 
-        <div class="av-foot">
-          <div class="av-stats">
-            <span><b class="count" data-target="16">0</b> countries</span>
-            <span><b class="count" data-target="23">0</b> voices</span>
+<!-- 02 — RESEARCH FRONTIERS -->
+<section class="section tint" id="research">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="mono-label"><span class="tick">02</span> / What I explore</span>
+      <h2 class="section-title">Three frontiers my research <em>pushes forward.</em></h2>
+      <p class="section-sub">Where spatial computing meets human behaviour — backed by peer-reviewed work and real industry deployment.</p>
+    </div>
+    <div class="frontiers">
+      <a class="frontier reveal" href="research.html">
+        <span class="no">F.01</span>
+        <h3>Location-Based AR</h3>
+        <p>Designing multiplayer AR experiences that meaningfully connect remote players to real-world places.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="frontier reveal" style="--d:.06s" href="research.html">
+        <span class="no">F.02</span>
+        <h3>Spatial Computing &amp; XR</h3>
+        <p>Studying how immersive interfaces reshape cognition, trust, and decision-making in shared spaces.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="frontier reveal" style="--d:.12s" href="research.html">
+        <span class="no">F.03</span>
+        <h3>Player Experience &amp; HCI</h3>
+        <p>Evaluating how people feel, behave, and collaborate inside the systems we design and deploy.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- 03 — SELECTED WORK -->
+<section class="section" id="work">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="mono-label"><span class="tick">03</span> / Selected work</span>
+      <h2 class="section-title">From lab to real impact — <em>research that ships.</em></h2>
+    </div>
+    <div class="casework reveal">
+      <div class="casework-img">
+        <img src="assets/images/case-immersive.jpg" alt="A player wearing a headset to experience a location-based augmented reality game"/>
+        <span class="fig-tag mono-label">Fig. 03 — Field study</span>
+      </div>
+      <div class="casework-body">
+        <span class="mono-label"><span class="tick">●</span> Entertainment Computing · Elsevier · 2025</span>
+        <h3>Representing Remote Locations with Location-Based AR Game Design</h3>
+        <p>A multiplayer location-based AR system, designed and evaluated with Sony Interactive Entertainment, exploring how players experience and represent distant real-world places together — published across leading HCI venues.</p>
+        <a class="btn btn-solid" href="research.html">Read the Research <span class="arrow">→</span></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 04 — STUDENT VOICES — interactive globe -->
+<section class="avoices section tint" id="voices" aria-label="What students say around the world">
+  <div class="container">
+    <div class="av-plate reveal">
+      <div class="av-head">
+        <span class="mono-label"><span class="tick">04</span> / Voices from my classroom</span>
+        <h2 class="av-title">What my students say, <em>all around the world.</em></h2>
+        <p class="av-sub">Thousands of learners across universities, MOOCs and workshops — from Colombo to Christchurch.</p>
+      </div>
+
+      <div class="av-grid">
+        <div class="av-stage">
+          <canvas id="voicesGlobe" class="voices-globe" role="img" aria-label="Rotating globe showing the countries students wrote from"></canvas>
+          <div class="voices-tooltip" id="voicesTooltip" aria-hidden="true"></div>
+        </div>
+
+        <div class="av-panel">
+          <figure class="av-quote" id="voicesQuote">
+            <blockquote id="vqText">&hellip;</blockquote>
+            <figcaption class="av-cite">
+              <span class="av-dot" id="vqAvatar" aria-hidden="true"></span>
+              <span class="av-who">
+                <strong id="vqName">&hellip;</strong>
+                <span id="vqRole">&hellip;</span>
+              </span>
+              <span class="av-loc">
+                <span class="av-country" id="vqCountry"></span>
+              </span>
+            </figcaption>
+          </figure>
+
+          <div class="av-controls">
+            <div class="av-nav">
+              <button class="av-navbtn" id="vPrev" type="button" aria-label="Previous voice">←</button>
+              <button class="av-navbtn" id="vNext" type="button" aria-label="Next voice">→</button>
+            </div>
+          </div>
+
+          <div class="av-foot">
+            <div class="av-stats">
+              <span><b class="count" data-target="16">0</b> countries</span>
+              <span><b class="count" data-target="23">0</b> voices</span>
+            </div>
           </div>
         </div>
       </div>
@@ -268,108 +404,18 @@
   <ul class="voices-srlist" id="voicesSrList"></ul>
 </section>
 
-<!-- INTRO BAND -->
-<section class="section" id="about">
-  <div class="container intro">
-    <div class="reveal">
-      <span class="eyebrow">About Me</span>
-      <h2 style="margin-top:16px">If You're <span class="hl">SERIOUS</span> About Immersive Technology, I'd Love to Collaborate.</h2>
-      <p>I'm Dr. Yasas Sri Wickramasinghe — a Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) and Senior Lecturer at Yoobee College of Creative Innovation. I hold a PhD in Human Interface Technology, with a dissertation on designing multiplayer location-based AR games that connect remote players and places.</p>
-      <p>My work is conducted with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc. Earlier I co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme and led Sri Lanka's first large-scale MOOC platform.</p>
-      <div class="intro-meta">
-        <span class="trust-label">Trusted by</span>
-        <div class="trust-logos">
-          <img src="assets/images/logo-hitlabnz.png" alt="HIT Lab NZ, University of Canterbury — augmented reality research lab logo"/>
-          <img class="logo-sony" src="assets/images/logo-sony.svg" alt="Sony Interactive Entertainment logo"/>
-          <img src="assets/images/logo-niantic-spatial.png" alt="Niantic Spatial logo"/>
-        </div>
-      </div>
-      <div class="intro-actions">
-        <a class="btn btn-solid" href="contact.html">Get in Touch <span class="arrow">→</span></a>
-        <a class="btn" href="research.html">See My Work</a>
-      </div>
-    </div>
-    <div class="intro-visual reveal" style="--d:.15s">
-      <img src="assets/images/phd-graduation.jpg" alt="Dr. Yasas Sri Wickramasinghe at his PhD graduation, University of Canterbury"/>
-    </div>
-  </div>
-</section>
-
-<!-- FEATURES (3 research truths) -->
-<section class="section soft">
-  <div class="container">
-    <div class="section-head center reveal">
-      <span class="eyebrow">What I Explore</span>
-      <h2 style="margin-top:16px">3 Frontiers My Research <em>Pushes Forward</em></h2>
-      <p>Where spatial computing meets human behaviour — backed by peer-reviewed work and real industry deployment.</p>
-    </div>
-    <div class="features">
-      <div class="feature reveal">
-        <div class="ic"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 2 3 7v10l9 5 9-5V7z"/><path d="M3 7l9 5 9-5M12 12v10"/></svg></div>
-        <h3>Location-Based AR</h3>
-        <p>Designing multiplayer AR experiences that meaningfully connect remote players to real-world places.</p>
-      </div>
-      <div class="feature reveal" style="--d:.1s">
-        <div class="ic"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M19 5l-2 2M7 17l-2 2"/></svg></div>
-        <h3>Spatial Computing &amp; XR</h3>
-        <p>Studying how immersive interfaces reshape cognition, trust, and decision-making in shared spaces.</p>
-      </div>
-      <div class="feature reveal" style="--d:.2s">
-        <div class="ic"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
-        <h3>Player Experience &amp; HCI</h3>
-        <p>Evaluating how people feel, behave, and collaborate inside the systems we design and deploy.</p>
-      </div>
-    </div>
-
-    <!-- Newsletter -->
-    <div class="newsletter reveal">
-      <h3>Want Research Notes &amp; Field Insights?</h3>
-      <p>Occasional notes on immersive media, spatial computing, and lessons from building XR — no noise.</p>
-      <form class="nl-form" onsubmit="return false;">
-        <input type="email" placeholder="Enter your email address" aria-label="Email address"/>
-        <button class="btn btn-solid" type="submit">Subscribe</button>
-      </form>
-    </div>
-  </div>
-</section>
-
-<!-- FEATURED PROJECT / CASE -->
-<section class="section" id="work">
-  <div class="container">
-    <div class="section-head reveal">
-      <span class="eyebrow">Selected Work</span>
-      <h2 style="margin-top:16px">From Lab to Real Impact — <em>Research That Ships.</em></h2>
-    </div>
-    <div class="casework reveal">
-      <div class="casework-img">
-        <img src="assets/images/case-immersive.jpg" alt="A player wearing a headset to experience a location-based augmented reality game"/>
-      </div>
-      <div class="casework-body">
-        <span class="tag-line">Entertainment Computing · Elsevier · 2025</span>
-        <h3>Representing Remote Locations with Location-Based AR Game Design</h3>
-        <p>A multiplayer location-based AR system, designed and evaluated with Sony Interactive Entertainment, exploring how players experience and represent distant real-world places together — published across leading HCI venues.</p>
-        <a class="btn btn-solid" href="research.html" style="align-self:flex-start">Read the Research <span class="arrow">→</span></a>
-        <div class="casework-foot">
-          <a class="dot-btn" href="research.html" aria-label="Previous">←</a>
-          <a class="dot-btn" href="research.html" aria-label="Next">→</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- UPCOMING EVENTS -->
+<!-- 05 — UPCOMING EVENTS -->
 <section class="section" id="upcoming-events">
   <div class="container">
     <div class="section-head reveal">
-      <span class="eyebrow">Upcoming</span>
-      <h2 style="margin-top:16px">Catch Me at an <em>Upcoming Event.</em></h2>
-      <p>Two talks and workshops coming up — follow along or invite me for something similar.</p>
+      <span class="mono-label"><span class="tick">05</span> / Upcoming</span>
+      <h2 class="section-title">Catch me at an <em>upcoming event.</em></h2>
+      <p class="section-sub">Two talks and workshops coming up — follow along or invite me for something similar.</p>
     </div>
     <div class="grid-2">
 
       <a class="article-card reveal" href="news.html#upcoming">
-        <div class="article-cover" data-num="—01"><img class="cover-img" src="assets/images/events/code-with-wie-2026-workshop-01-architecting-augmented-tomorrow.jpg" alt="CODE with WIE 2026 Workshop 01 flyer — Architecting the Augmented Tomorrow, with speaker Dr. Yasas Sri Wickramasinghe" loading="lazy"><span class="cat">Workshop</span></div>
+        <div class="article-cover" data-num="—01"><img class="cover-img" src="assets/images/events/code-with-wie-2026-workshop-01-architecting-augmented-tomorrow.jpg" alt="CODE with WIE 2026 Workshop 01 flyer — Architecting the Augmented Tomorrow, with speaker Dr. Yasas Sri Wickramasinghe" loading="lazy"/><span class="cat">Workshop</span></div>
         <div class="article-body">
           <span class="src">IEEE WIE Sri Lanka · 11 July 2026</span>
           <h3>CODE with WIE 2026 — Architecting the Augmented Tomorrow</h3>
@@ -377,8 +423,8 @@
         </div>
       </a>
 
-      <a class="article-card reveal" style="--d:.05s" href="news.html#upcoming">
-        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/events/nzgdc-2026-designing-shared-worlds-across-distance.png" alt="NZGDC 2026 speaker flyer — Designing Shared Worlds Across Distance: Lessons from Multiplayer AR Game Research" loading="lazy"><span class="cat">Conference Talk</span></div>
+      <a class="article-card reveal" style="--d:.06s" href="news.html#upcoming">
+        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/events/nzgdc-2026-designing-shared-worlds-across-distance.png" alt="NZGDC 2026 speaker flyer — Designing Shared Worlds Across Distance: Lessons from Multiplayer AR Game Research" loading="lazy"/><span class="cat">Conference Talk</span></div>
         <div class="article-body">
           <span class="src">NZGDC · 1 October 2026</span>
           <h3>Designing Shared Worlds Across Distance</h3>
@@ -387,24 +433,24 @@
       </a>
 
     </div>
-    <div class="reveal" style="text-align:center; margin-top:36px;">
-      <a class="btn btn-solid" href="contact.html?subject=speaking">Invite Me to Speak <span class="arrow">→</span></a>
+    <div class="section-cta reveal">
+      <a class="btn" href="contact.html?subject=speaking">Invite Me to Speak <span class="arrow">→</span></a>
     </div>
   </div>
 </section>
 
-<!-- IN THE NEWS -->
-<section class="section soft" id="news">
+<!-- 06 — IN THE NEWS -->
+<section class="section tint" id="news">
   <div class="container">
     <div class="section-head reveal">
-      <span class="eyebrow">In the News</span>
-      <h2 style="margin-top:16px">On Stage, in the Field &amp; <em>in the News.</em></h2>
-      <p>Invited talks, international collaborations and outreach — moments where the research reaches real people and places.</p>
+      <span class="mono-label"><span class="tick">06</span> / In the news</span>
+      <h2 class="section-title">On stage, in the field &amp; <em>in the news.</em></h2>
+      <p class="section-sub">Invited talks, international collaborations and outreach — moments where the research reaches real people and places.</p>
     </div>
     <div class="grid-3">
 
       <a class="article-card reveal" href="news.html">
-        <div class="article-cover" data-num="—01"><img class="cover-img" src="assets/images/news/tohoku-visit-2.jpg" alt="Dr. Yasas Sri Wickramasinghe presenting at the Interactive Content Design Lab, Tohoku University, Japan" loading="lazy"><span class="cat">Collaboration</span></div>
+        <div class="article-cover" data-num="—01"><img class="cover-img" src="assets/images/news/tohoku-visit-2.jpg" alt="Dr. Yasas Sri Wickramasinghe presenting at the Interactive Content Design Lab, Tohoku University, Japan" loading="lazy"/><span class="cat">Collaboration</span></div>
         <div class="article-body">
           <span class="src">Tohoku University · Dec 2025</span>
           <h3>Research Visit to Tohoku University — An NZ–Japan AR Collaboration</h3>
@@ -412,8 +458,8 @@
         </div>
       </a>
 
-      <a class="article-card reveal" style="--d:.05s" href="news.html">
-        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/news/falling-walls-cohort-2024.jpg" alt="Official Falling Walls Lab Aotearoa New Zealand 2024 cohort collage of all nineteen participants, including Dr. Yasas Sri Wickramasinghe" loading="lazy"><span class="cat">Falling Walls Lab</span></div>
+      <a class="article-card reveal" style="--d:.06s" href="news.html">
+        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/news/falling-walls-cohort-2024.jpg" alt="Official Falling Walls Lab Aotearoa New Zealand 2024 cohort collage of all nineteen participants, including Dr. Yasas Sri Wickramasinghe" loading="lazy"/><span class="cat">Falling Walls Lab</span></div>
         <div class="article-body">
           <span class="src">Royal Society Te Apārangi · 2024</span>
           <h3>Breaking the Wall of Loneliness Through Play</h3>
@@ -421,8 +467,8 @@
         </div>
       </a>
 
-      <a class="article-card reveal" style="--d:.1s" href="news.html">
-        <div class="article-cover" data-num="—03"><img class="cover-img" src="assets/images/news/nzgdc-ar-panel.jpg" alt="Yasas Sri Wickramasinghe on the AR game development panel at the New Zealand Game Developers Conference 2023" loading="lazy"><span class="cat">NZGDC 2023</span></div>
+      <a class="article-card reveal" style="--d:.12s" href="news.html">
+        <div class="article-cover" data-num="—03"><img class="cover-img" src="assets/images/news/nzgdc-ar-panel.jpg" alt="Yasas Sri Wickramasinghe on the AR game development panel at the New Zealand Game Developers Conference 2023" loading="lazy"/><span class="cat">NZGDC 2023</span></div>
         <div class="article-body">
           <span class="src">YouTube · Panel</span>
           <h3>Talking AR Game Design on the National Stage</h3>
@@ -431,96 +477,55 @@
       </a>
 
     </div>
-    <div class="reveal" style="text-align:center; margin-top:36px;">
-      <a class="btn btn-solid" href="news.html">See All News &amp; Highlights <span class="arrow">→</span></a>
+    <div class="section-cta reveal">
+      <a class="btn" href="news.html">See All News &amp; Highlights <span class="arrow">→</span></a>
     </div>
   </div>
 </section>
 
-<!-- SERVICES -->
-<section class="section soft">
+<!-- 07 — WORK WITH ME -->
+<section class="section" id="engage">
   <div class="container">
     <div class="section-head reveal">
-      <span class="eyebrow">What I Do</span>
-      <h2 style="margin-top:16px">Research, Teaching &amp; Building <em>That Lasts.</em></h2>
-      <p>Bridging rigorous academic research with hands-on engineering and high-engagement teaching.</p>
+      <span class="mono-label"><span class="tick">07</span> / Work with me</span>
+      <h2 class="section-title">Research, teaching &amp; building <em>that lasts.</em></h2>
+      <p class="section-sub">Bridging rigorous academic research with hands-on engineering and high-engagement teaching.</p>
     </div>
-    <div class="services-grid">
-      <div class="service reveal">
-        <div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></div>
+    <div class="engage">
+      <a class="engage-row reveal" href="research.html">
+        <span class="no">W.01</span>
         <h3>Research &amp; Publications</h3>
         <p>Peer-reviewed work in AR, XR and HCI — from study design and experimental platforms to journal and conference papers.</p>
-        <a class="more" href="research.html">Learn more <span class="arrow">→</span></a>
-      </div>
-      <div class="service reveal" style="--d:.1s">
-        <div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/></svg></div>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="engage-row reveal" style="--d:.05s" href="teaching.html">
+        <span class="no">W.02</span>
         <h3>Teaching &amp; Supervision</h3>
-        <p>Master's-level courses in information systems and project management, plus capstone and thesis supervision — gamified and high-engagement.</p>
-        <a class="more" href="teaching.html">Learn more <span class="arrow">→</span></a>
-      </div>
-      <div class="service reveal" style="--d:.05s">
-        <div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
+        <p>Master's-level courses in information systems and project management, plus capstone and thesis supervision.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="engage-row reveal" style="--d:.1s" href="research.html">
+        <span class="no">W.03</span>
         <h3>XR &amp; Software Development</h3>
-        <p>Building immersive prototypes and production systems with Unity, OpenXR and Niantic Lightship — drawing on a senior engineering background.</p>
-        <a class="more" href="research.html">Learn more <span class="arrow">→</span></a>
-      </div>
-      <div class="service reveal" style="--d:.15s">
-        <div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 11l19-9-9 19-2-8-8-2z"/></svg></div>
+        <p>Building immersive prototypes and production systems with Unity, OpenXR and Niantic Lightship.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="engage-row reveal" style="--d:.15s" href="contact.html">
+        <span class="no">W.04</span>
         <h3>Talks &amp; Consulting</h3>
-        <p>Speaking and advising on immersive media, spatial computing strategy, and translating emerging XR research into product.</p>
-        <a class="more" href="contact.html">Learn more <span class="arrow">→</span></a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- TESTIMONIAL -->
-<section class="section">
-  <div class="container">
-    <div class="section-head reveal">
-      <span class="eyebrow">In Their Words</span>
-      <h2 style="margin-top:16px">What Collaborators &amp; <em>Students Say</em></h2>
-    </div>
-    <div class="testi">
-      <div class="testi-photo reveal">
-        <img src="assets/images/collab.jpg" alt="Dr. Yasas Sri Wickramasinghe collaborating with HIT Lab NZ and Sony Interactive Entertainment research partners"/>
-      </div>
-      <div class="testi-quote reveal" style="--d:.1s">
-        <div class="mark">"</div>
-        <blockquote>Yasas brings rare range — the rigour of a researcher and the instincts of a builder. His work on location-based AR genuinely advanced how we think about connecting remote players, and his teaching makes complex ideas click for students.</blockquote>
-        <div class="testi-author">Research &amp; Industry Partners<small>HIT Lab NZ · Sony Interactive Entertainment</small></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- BIG CTA -->
-<section class="section soft">
-  <div class="container">
-    <div class="bigcta reveal">
-      <div class="bigcta-text">
-        <span class="eyebrow">Collaboration</span>
-        <h2>Let's Take Your Immersive Idea to the <em style="color:#6ea0ff">Next Level.</em></h2>
-        <p>Whether it's a research collaboration, a guest talk, or building the next spatial experience — I'd love to hear from you.</p>
-        <a class="btn" href="contact.html">Get in Touch <span class="arrow">→</span></a>
-      </div>
-      <div class="bigcta-visual">
-        <svg width="100%" height="200" viewBox="0 0 400 200" fill="none" preserveAspectRatio="none">
-          <polyline points="20,170 90,150 160,120 230,130 300,70 380,30" stroke="#6ea0ff" stroke-width="3" fill="none" stroke-linecap="round"/>
-          <circle cx="380" cy="30" r="6" fill="#6ea0ff"/>
-        </svg>
-        <div class="chartstat">312%<small>RESEARCH IMPACT GROWTH</small></div>
-      </div>
+        <p>Speaking and advising on immersive media, spatial computing strategy, and translating XR research into product.</p>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
     </div>
   </div>
 </section>
 
 <!-- FAQ -->
-<section class="section" id="faq">
+<section class="section tint" id="faq">
   <div class="container">
-    <div class="section-head center reveal" style="margin-inline:auto;">
-      <span class="eyebrow" style="justify-content:center;">FAQ</span>
-      <h2 style="margin-top:16px">Frequently asked <em>questions</em></h2>
+    <div class="section-head center reveal">
+      <span class="mono-label"><span class="tick">§</span> FAQ</span>
+      <h2 class="section-title">Frequently asked <em>questions.</em></h2>
     </div>
     <div class="faq">
       <details class="faq-item reveal">
@@ -537,12 +542,24 @@
       </details>
       <details class="faq-item reveal">
         <summary>What web products has he built?</summary>
-        <p>He has designed and built <a href="products.html" style="color:var(--accent);font-weight:600;">HouseScout</a> (a property-intelligence dashboard for Christchurch home buyers), Faro (a machine-learning flight-fare timing assistant) and Yoobees (an EdTech attendance and learning-support platform). See the <a href="products.html" style="color:var(--accent);font-weight:600;">Products</a> page.</p>
+        <p>He has designed and built <a href="products.html">HouseScout</a> (a property-intelligence dashboard for Christchurch home buyers), Faro (a machine-learning flight-fare timing assistant) and Yoobees (an EdTech attendance and learning-support platform). See the <a href="products.html">Products</a> page.</p>
       </details>
       <details class="faq-item reveal">
         <summary>How can I get in touch?</summary>
-        <p>You can reach out via the <a href="contact.html" style="color:var(--accent);font-weight:600;">contact page</a> for research collaborations, guest talks, consulting and academic mentorship.</p>
+        <p>You can reach out via the <a href="contact.html">contact page</a> for research collaborations, guest talks, consulting and academic mentorship.</p>
       </details>
+    </div>
+  </div>
+</section>
+
+<!-- BIG CTA -->
+<section class="section">
+  <div class="container">
+    <div class="bigcta reveal">
+      <span class="mono-label">Collaboration — open</span>
+      <h2>Let's build the next <em>shared world</em> together.</h2>
+      <p>Whether it's a research collaboration, a guest talk, or the next spatial experience — I'd love to hear from you.</p>
+      <a class="btn btn-paper" href="contact.html">Get in Touch <span class="arrow">→</span></a>
     </div>
   </div>
 </section>
@@ -552,10 +569,10 @@
   <div class="container">
     <div class="footer-top">
       <div class="footer-news">
-        <h3>Stay in the loop</h3>
-        <p>Join my research notes for occasional insights on AR, XR and immersive media.</p>
-        <form class="nl-form" onsubmit="return false;">
-          <input type="email" placeholder="Your email address" aria-label="Email address"/>
+        <h3>Research notes &amp; field insights</h3>
+        <p>Occasional notes on immersive media, spatial computing, and lessons from building XR — no noise.</p>
+        <form class="nl-form" id="nlForm">
+          <input type="email" placeholder="Your email address" aria-label="Email address" required/>
           <button class="btn btn-solid" type="submit">Join</button>
         </form>
       </div>
@@ -583,7 +600,8 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <div class="footer-logo">Yasas Sri Wickramasinghe</div>
+      <div class="footer-logo">Yasas Sri <em style="font-style:italic;color:var(--accent)">Wickramasinghe</em></div>
+      <span class="footer-coords">43.53°S 172.64°E — ŌTAUTAHI CHRISTCHURCH</span>
       <small>© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</small>
     </div>
   </div>
@@ -596,5 +614,29 @@
 <script src="https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"></script>
 <script src="assets/js/testimonials.js"></script>
 <script src="assets/js/globe-voices.js"></script>
+<script>
+  // Theme toggle
+  (function () {
+    var btn = document.querySelector(".theme-toggle");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      var next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem("theme", next); } catch (e) {}
+    });
+  })();
+  // Newsletter — opens a pre-filled email (no backend on this static site)
+  (function () {
+    var form = document.getElementById("nlForm");
+    if (!form) return;
+    form.addEventListener("submit", function (e) {
+      e.preventDefault();
+      var email = form.querySelector("input[type=email]").value;
+      location.href = "mailto:yasassriofficial@gmail.com?subject=" +
+        encodeURIComponent("Subscribe me to your research notes") +
+        "&body=" + encodeURIComponent("Please add " + email + " to your research notes list.");
+    });
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Rebuild index.html on a new hand-written design system (editorial.css):
warm paper/ink palette with a vermilion waypoint accent, Newsreader
display serif + Inter body + IBM Plex Mono coordinate labels, and a
full dark theme (system preference + toggle, no-FOUC inline script).

Design concept draws on the research itself — connecting people and
places across distance: a Colombo→Christchurch route strip with
geographic coordinates, figure-style captions on photos, numbered
editorial sections, and a stats band backed by real study numbers.

Content preserved (bio, partners, featured paper, events, news, FAQ,
SEO/JSON-LD); removed template-era filler (fake growth chart, generic
testimonial). Student-voices globe kept and restyled — its palette now
reads from --globe-* CSS variables with the previous values as
fallbacks. Newsletter form now opens a pre-filled email instead of a
dead submit.

Verified with headless Chromium at 1440/390px in light and dark:
counters, globe navigation, theme toggle, FAQ, and no horizontal
overflow.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011q5camMLtsnyqADZncPRn8