### PR TITLE
Add interactive academic platform at /app (consultations, speaking, blog, newsletter, forum)

### DIFF
--- a/PLATFORM_SETUP.md
+++ b/PLATFORM_SETUP.md
@@ -1,0 +1,109 @@
+# Academic Platform — Setup Guide
+
+The interactive platform lives at **`/app/`** (e.g. `https://www.yasassri.me/app/`).
+It is a fully static single-page app — it deploys with the rest of the site on
+**GitHub Pages** with zero build step — and stores its data in **Firebase
+(Firestore + Authentication)**.
+
+Until Firebase is connected, the platform runs in **preview mode**: every page
+renders, but forms, sign-in and the forum are disabled with a visible notice.
+
+## What's included
+
+| Feature | Route | Data |
+|---|---|---|
+| Platform hub | `app/#/` | — |
+| Free consultation booking (4 types, intake form, up to 3 preferred times, status tracking, cancel) | `app/#/consult` | `consultations` |
+| Speaker page + invitation form (topics catalogue, engagements, event/logistics intake) | `app/#/invite` | `invitations` |
+| Blog (Markdown articles, categories, tags, reading time, "discuss in forum") | `app/#/blog` | `posts` |
+| Newsletter signup (segments, CSV export for any email tool) | `app/#/newsletter` | `subscribers` |
+| Community forum (8 seeded categories, threads/replies, reports, pin/lock/hide) | `app/#/forum` | `threads` + `replies` |
+| Sign in (Google or email+password with email verification) | `app/#/account` | `profiles` |
+| Admin dashboard (queues, blog editor, subscribers, moderation) | `app/#/admin` | all of the above |
+
+## One-time setup (~15 minutes)
+
+### 1. Create the Firebase project
+
+1. Go to <https://console.firebase.google.com> → **Add project** (e.g. `yasassri-platform`).
+   Google Analytics optional. The free **Spark plan** is enough.
+2. In the project, click the **Web** (`</>`) icon → register an app (name: `platform`).
+   Copy the `firebaseConfig` object it shows you.
+
+### 2. Paste the config into the site
+
+Open [`app/js/firebase-config.js`](app/js/firebase-config.js) and replace the
+`PASTE_…` placeholders with the values from step 1. Commit and push — that file
+is public by design (Firebase web config is not a secret; security comes from
+the rules in step 4).
+
+### 3. Enable Authentication
+
+Firebase console → **Build → Authentication → Get started**:
+
+1. Enable **Email/Password**.
+2. Enable **Google**.
+3. Under **Settings → Authorized domains**, add `www.yasassri.me` and
+   `yasassri.me` (and your `*.github.io` domain if you use it).
+
+### 4. Create Firestore + deploy the security rules
+
+1. **Build → Firestore Database → Create database** → production mode →
+   region `australia-southeast1` (closest to NZ).
+2. Open the **Rules** tab, paste the entire contents of
+   [`firestore.rules`](firestore.rules) from this repository, and **Publish**.
+
+> ⚠️ The admin email is hard-coded in two places and must match:
+> `firestore.rules` (`isAdmin()` function) and `app/js/firebase-config.js`
+> (`window.PLATFORM_ADMINS`). Both are currently set to
+> `yasassriofficial@gmail.com`.
+
+### 5. Sign in as admin
+
+Visit `https://www.yasassri.me/app/#/account`, sign in **with Google** using the
+admin email (Google accounts are auto-verified). The nav now shows **Admin ⚙**
+and `app/#/admin` unlocks the dashboard.
+
+That's it — no servers, no build pipeline, no billing.
+
+## How day-to-day admin works
+
+- **Consultations** — requests arrive as *pending*. Open *Details*, pick one of
+  the requester's proposed times, paste a Meet/Teams/Zoom link and **Approve**
+  (the requester sees the confirmed time + link on their "My requests" list),
+  or **Decline** with a courteous templated reason. Mark *completed* afterwards.
+- **Invitations** — Accept / Discussing / Decline, plus a one-click
+  `mailto:` reply to the organizer.
+- **Blog** — write articles in Markdown (headings, bold, links, code blocks,
+  lists, quotes, images by URL). Save as draft or publish; slug, reading time
+  and cards are automatic. Each article gets a "Discuss in the Forum" button.
+- **Subscribers** — export a CSV any time and import it into Mailchimp,
+  Buttondown, Brevo, etc. to send the actual campaigns.
+- **Moderation** — reported threads queue; pin/lock/hide controls on every
+  thread; delete replies inline.
+
+## Anti-abuse measures built in
+
+- Consultation requests and forum posting require a **verified email**
+  (Google sign-in counts as verified).
+- Per-account limit of **2 open consultation requests**.
+- **Honeypot** fields on all public forms, validated again in Firestore rules.
+- Field-length validation enforced server-side by the rules.
+- Announcements category is admin-post-only; owners can only *cancel* their own
+  requests, never edit status.
+
+## Known v1 limitations (by design — no server)
+
+GitHub Pages has no backend, so anything that *sends email* needs an external
+trigger. Recommended free/cheap upgrades when you want them:
+
+| Want | Add |
+|---|---|
+| Email notifications on new requests | Firebase **Trigger Email** extension, or a Zapier/Make watch on Firestore |
+| Calendar invites (ICS) + reminders | Create the Google Calendar event when approving (its invite email covers both) |
+| Newsletter sending + double opt-in | Import CSV into Buttondown/Mailchimp — keep the platform as the signup source of truth |
+| File attachments on requests | Firebase Storage (add rules first) |
+| Verified-student flag / student-only categories enforced server-side | Firebase custom claims via a small Cloud Function |
+
+The data model already matches the full specification, so none of these
+upgrades require restructuring.

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -1,0 +1,308 @@
+/* ==========================================================================
+   Yasas Sri Wickramasinghe — Academic Platform app styles
+   Builds on the site design system in ../assets/css/redesign.css
+   ========================================================================== */
+
+.app-main { min-height: 70vh; padding: 48px 0 80px; }
+
+.app-crumb { font-size: 13px; color: var(--muted); margin-bottom: 18px; }
+.app-crumb a { color: var(--accent); font-weight: 600; }
+
+.app-head { max-width: 720px; margin-bottom: 36px; }
+.app-head h1 { font-size: clamp(30px, 4.5vw, 48px); letter-spacing: -0.02em; line-height: 1.08; }
+.app-head p { margin-top: 14px; color: var(--ink-soft); font-size: clamp(15px, 1.5vw, 17px); }
+
+/* ---------- Hub cards ---------- */
+.hub-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.hub-card {
+  display: flex; flex-direction: column; gap: 10px;
+  background: var(--card); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 28px;
+  transition: transform .35s var(--ease), box-shadow .35s var(--ease), border-color .35s;
+}
+.hub-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-sm); border-color: var(--line-strong); }
+.hub-card .ic {
+  width: 44px; height: 44px; border-radius: 12px;
+  background: var(--accent-soft); color: var(--accent);
+  display: flex; align-items: center; justify-content: center; margin-bottom: 6px;
+}
+.hub-card h3 { font-size: 18px; }
+.hub-card p { font-size: 14px; color: var(--ink-soft); flex: 1; }
+.hub-card .go { font-size: 14px; font-weight: 600; color: var(--accent); }
+
+.identity-band { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin: 44px 0 8px; }
+.identity {
+  border-left: 3px solid var(--accent); padding: 4px 0 4px 18px;
+}
+.identity b { display: block; font-size: 15px; }
+.identity span { font-size: 13.5px; color: var(--ink-soft); }
+
+/* ---------- Panels, cards, generic ---------- */
+.panel {
+  background: var(--card); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 28px;
+}
+.panel + .panel { margin-top: 20px; }
+.panel h2 { font-size: 22px; margin-bottom: 6px; }
+.panel h3 { margin-bottom: 6px; }
+.panel .sub { color: var(--ink-soft); font-size: 14px; margin-bottom: 18px; }
+
+.two-col { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 28px; align-items: start; }
+.grid-cards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+
+.notice {
+  border: 1px solid var(--line-strong); border-left: 4px solid var(--accent);
+  background: var(--accent-soft); border-radius: var(--radius-sm);
+  padding: 14px 18px; font-size: 14px; color: var(--ink-soft); margin-bottom: 24px;
+}
+.notice b { color: var(--ink); }
+.notice.warn { border-left-color: #d97706; background: #fef7ec; }
+.notice.ok { border-left-color: #16a34a; background: #f0fdf4; }
+
+.empty {
+  text-align: center; padding: 48px 20px; color: var(--muted); font-size: 14.5px;
+  border: 1px dashed var(--line-strong); border-radius: var(--radius);
+}
+
+/* ---------- Type selection cards (consultations) ---------- */
+.type-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-bottom: 28px; }
+.type-card {
+  text-align: left; cursor: pointer; background: var(--card);
+  border: 1.5px solid var(--line); border-radius: var(--radius-sm);
+  padding: 20px; font-family: var(--sans); transition: border-color .25s, background .25s;
+}
+.type-card:hover { border-color: var(--line-strong); }
+.type-card.selected { border-color: var(--accent); background: var(--accent-soft); }
+.type-card h3 { font-size: 16px; display: flex; justify-content: space-between; align-items: baseline; gap: 10px; }
+.type-card .dur { font-size: 12px; font-weight: 600; color: var(--accent); white-space: nowrap; }
+.type-card p { font-size: 13.5px; color: var(--ink-soft); margin-top: 6px; }
+.type-card .prep { font-size: 12.5px; color: var(--muted); margin-top: 8px; }
+
+/* ---------- Forms ---------- */
+.form { display: grid; gap: 18px; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.field label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; color: var(--ink); }
+.field label small { font-weight: 400; color: var(--muted); }
+.field input, .field select, .field textarea {
+  width: 100%; padding: 12px 14px; border-radius: 12px;
+  border: 1.5px solid var(--line-strong); background: var(--bg);
+  font-family: var(--sans); font-size: 14.5px; color: var(--ink);
+  transition: border-color .2s, box-shadow .2s;
+}
+.field input:focus, .field select:focus, .field textarea:focus {
+  outline: none; border-color: var(--accent); box-shadow: 0 0 0 4px var(--ring);
+}
+.field textarea { min-height: 120px; resize: vertical; line-height: 1.55; }
+.field .hint { font-size: 12px; color: var(--muted); margin-top: 5px; }
+.field .count { font-size: 12px; color: var(--muted); margin-top: 4px; text-align: right; }
+.hp-field { position: absolute !important; left: -9999px !important; opacity: 0; height: 0; overflow: hidden; }
+
+.form-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.form-msg { font-size: 14px; font-weight: 500; }
+.form-msg.err { color: #dc2626; }
+.form-msg.ok { color: #16a34a; }
+
+button.btn { font-family: var(--sans); }
+.btn.small { padding: 8px 16px; font-size: 13px; }
+.btn.danger { border-color: #fca5a5; color: #dc2626; }
+.btn.danger:hover { border-color: #dc2626; }
+.btn[disabled] { opacity: .55; pointer-events: none; }
+
+/* ---------- Badges / status ---------- */
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  padding: 4px 10px; border-radius: 999px; background: var(--bg-soft); color: var(--ink-soft);
+  border: 1px solid var(--line);
+}
+.badge.pending   { background: #fef7ec; color: #b45309; border-color: #fde5c0; }
+.badge.approved, .badge.accepted, .badge.published, .badge.subscribed { background: #f0fdf4; color: #15803d; border-color: #bbf7d0; }
+.badge.declined, .badge.cancelled { background: #fef2f2; color: #b91c1c; border-color: #fecaca; }
+.badge.completed { background: var(--accent-soft); color: var(--accent-dark); border-color: #c7d8ff; }
+.badge.draft, .badge.discussing { background: var(--bg-soft); color: var(--ink-soft); }
+.badge.cat { background: var(--accent-soft); color: var(--accent-dark); border-color: transparent; }
+
+/* ---------- Lists (requests, threads, posts) ---------- */
+.list { display: grid; gap: 12px; }
+.list-item {
+  display: flex; justify-content: space-between; align-items: flex-start; gap: 16px;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 18px 20px; transition: border-color .25s, box-shadow .25s;
+}
+a.list-item:hover, .list-item.clickable:hover { border-color: var(--line-strong); box-shadow: var(--shadow-sm); }
+.list-item .li-main { min-width: 0; flex: 1; }
+.list-item h3 { font-size: 15.5px; margin-bottom: 3px; }
+.list-item .meta { font-size: 12.5px; color: var(--muted); }
+.list-item .desc { font-size: 13.5px; color: var(--ink-soft); margin-top: 4px; }
+.list-item .li-side { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; flex-shrink: 0; }
+
+/* ---------- Blog ---------- */
+.post-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+.post-card {
+  display: flex; flex-direction: column; gap: 8px;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 26px; transition: transform .3s var(--ease), box-shadow .3s var(--ease);
+}
+.post-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-sm); }
+.post-card .pmeta { font-size: 12.5px; color: var(--muted); }
+.post-card h3 { font-size: 19px; }
+.post-card p { font-size: 14px; color: var(--ink-soft); flex: 1; }
+
+.article { max-width: 760px; margin: 0 auto; }
+.article-header { margin-bottom: 32px; }
+.article-header h1 { font-size: clamp(28px, 4vw, 42px); line-height: 1.12; margin: 12px 0; }
+.article-header .pmeta { font-size: 13.5px; color: var(--muted); }
+.article-summary {
+  font-size: 16.5px; color: var(--ink-soft); border-left: 3px solid var(--accent);
+  padding-left: 18px; margin: 20px 0 8px; line-height: 1.6;
+}
+.prose { font-size: 16.5px; line-height: 1.75; color: var(--ink); }
+.prose h2 { font-size: 26px; margin: 36px 0 14px; }
+.prose h3 { font-size: 20px; margin: 28px 0 10px; }
+.prose p { margin: 0 0 18px; }
+.prose ul, .prose ol { margin: 0 0 18px 24px; }
+.prose ul { list-style: disc; }
+.prose ol { list-style: decimal; }
+.prose li { margin-bottom: 6px; }
+.prose a { color: var(--accent); font-weight: 500; text-decoration: underline; text-underline-offset: 3px; }
+.prose blockquote {
+  border-left: 3px solid var(--accent); padding: 4px 0 4px 20px;
+  color: var(--ink-soft); font-style: italic; margin: 0 0 18px;
+}
+.prose code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.88em; background: var(--bg-soft); border: 1px solid var(--line);
+  padding: 2px 6px; border-radius: 6px;
+}
+.prose pre {
+  background: #10151f; color: #e7ecf5; border-radius: var(--radius-sm);
+  padding: 18px 20px; overflow-x: auto; margin: 0 0 20px; font-size: 13.5px; line-height: 1.6;
+}
+.prose pre code { background: none; border: none; padding: 0; color: inherit; }
+.prose img { border-radius: var(--radius-sm); margin: 0 0 18px; }
+.prose hr { border: none; border-top: 1px solid var(--line); margin: 28px 0; }
+
+/* ---------- Speaker page ---------- */
+.topic-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.topic-card {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 22px;
+}
+.topic-card h3 { font-size: 16px; margin-bottom: 6px; }
+.topic-card p { font-size: 13.5px; color: var(--ink-soft); }
+.topic-card .tmeta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+.tmeta .chip {
+  font-size: 11.5px; font-weight: 600; padding: 3px 10px; border-radius: 999px;
+  background: var(--bg-soft); border: 1px solid var(--line); color: var(--ink-soft);
+}
+
+.engagement { display: flex; gap: 16px; padding: 16px 0; border-bottom: 1px solid var(--line); }
+.engagement:last-child { border-bottom: none; }
+.engagement .when { font-size: 12.5px; font-weight: 700; color: var(--accent); white-space: nowrap; min-width: 90px; padding-top: 2px; }
+.engagement h3 { font-size: 15px; }
+.engagement p { font-size: 13px; color: var(--ink-soft); margin-top: 2px; }
+
+/* ---------- Forum ---------- */
+.cat-row {
+  display: flex; align-items: center; gap: 16px;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 18px 22px; transition: border-color .25s, box-shadow .25s;
+}
+.cat-row:hover { border-color: var(--line-strong); box-shadow: var(--shadow-sm); }
+.cat-row .ic {
+  width: 40px; height: 40px; border-radius: 11px; flex-shrink: 0;
+  background: var(--accent-soft); color: var(--accent);
+  display: flex; align-items: center; justify-content: center; font-size: 17px;
+}
+.cat-row h3 { font-size: 15.5px; }
+.cat-row p { font-size: 13px; color: var(--ink-soft); }
+.cat-row .lock { margin-left: auto; font-size: 12px; color: var(--muted); white-space: nowrap; }
+
+.thread-post {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 20px 22px;
+}
+.thread-post + .thread-post { margin-top: 12px; }
+.thread-post .tp-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
+.avatar {
+  width: 34px; height: 34px; border-radius: 50%; flex-shrink: 0;
+  background: linear-gradient(135deg, var(--accent), #7aa2ff);
+  color: #fff; font-size: 13px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+}
+.tp-head .who b { font-size: 14px; display: block; line-height: 1.2; }
+.tp-head .who span { font-size: 12px; color: var(--muted); }
+.tp-head .tp-actions { margin-left: auto; display: flex; gap: 8px; }
+.tp-body { font-size: 14.5px; line-height: 1.65; color: var(--ink); }
+.tp-body p { margin-bottom: 10px; }
+.tp-body p:last-child { margin-bottom: 0; }
+.report-btn { background: none; border: none; color: var(--muted); font-size: 12px; cursor: pointer; font-family: var(--sans); }
+.report-btn:hover { color: #dc2626; }
+
+/* ---------- Auth / account ---------- */
+.auth-box { max-width: 440px; margin: 0 auto; }
+.auth-tabs { display: flex; gap: 4px; background: var(--bg-soft); padding: 4px; border-radius: 999px; margin-bottom: 22px; }
+.auth-tabs button {
+  flex: 1; padding: 9px 0; border: none; border-radius: 999px; cursor: pointer;
+  font-family: var(--sans); font-size: 13.5px; font-weight: 600; color: var(--ink-soft); background: transparent;
+}
+.auth-tabs button.active { background: var(--card); color: var(--ink); box-shadow: var(--shadow-sm); }
+.divider { display: flex; align-items: center; gap: 12px; color: var(--muted); font-size: 12px; margin: 18px 0; }
+.divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+.btn-google { width: 100%; justify-content: center; }
+
+.user-chip { display: flex; align-items: center; gap: 10px; }
+.user-chip .info b { display: block; font-size: 14px; line-height: 1.2; }
+.user-chip .info span { font-size: 12px; color: var(--muted); }
+
+/* ---------- Admin ---------- */
+.tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 26px; }
+.tabs button {
+  padding: 9px 18px; border-radius: 999px; cursor: pointer; font-family: var(--sans);
+  font-size: 13.5px; font-weight: 600; border: 1px solid var(--line-strong);
+  background: var(--bg); color: var(--ink-soft); transition: all .25s;
+}
+.tabs button.active { background: var(--ink); border-color: var(--ink); color: #fff; }
+
+.stat-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 28px; }
+.stat {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 18px 20px;
+}
+.stat b { font-size: 28px; font-weight: 800; letter-spacing: -0.02em; display: block; }
+.stat span { font-size: 12.5px; color: var(--muted); }
+
+.detail-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 20px; font-size: 13.5px; margin: 12px 0; }
+.detail-grid dt { font-weight: 600; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .05em; }
+.detail-grid dd { margin: 0 0 8px; word-break: break-word; }
+
+/* ---------- Toast ---------- */
+.toast {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(80px);
+  background: var(--ink); color: #fff; font-size: 14px; font-weight: 500;
+  padding: 12px 22px; border-radius: 999px; box-shadow: var(--shadow);
+  opacity: 0; transition: all .35s var(--ease); z-index: 1200; pointer-events: none;
+  max-width: min(92vw, 560px); text-align: center;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ---------- Loading ---------- */
+.loading { display: flex; justify-content: center; padding: 60px 0; }
+.spinner {
+  width: 30px; height: 30px; border-radius: 50%;
+  border: 3px solid var(--line); border-top-color: var(--accent);
+  animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .hub-grid, .identity-band { grid-template-columns: 1fr 1fr; }
+  .two-col { grid-template-columns: 1fr; }
+  .stat-row { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 620px) {
+  .hub-grid, .identity-band, .type-grid, .post-grid, .topic-grid, .grid-cards, .form-row { grid-template-columns: 1fr; }
+  .list-item { flex-direction: column; }
+  .list-item .li-side { flex-direction: row; align-items: center; }
+  .detail-grid { grid-template-columns: 1fr; }
+}

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Platform — Consultations, Speaking, Blog &amp; Community | Dr. Yasas Sri Wickramasinghe</title>
+<meta name="author" content="Yasas Sri Wickramasinghe"/>
+<meta name="description" content="Request a free consultation, invite Dr. Yasas Sri Wickramasinghe to speak, read research articles, join the newsletter, and connect in the student community forum."/>
+<link rel="icon" href="../assets/images/icons/favicon.png"/>
+<meta name="robots" content="index, follow"/>
+<meta name="theme-color" content="#4b6bff"/>
+<link rel="canonical" href="https://www.yasassri.me/app/"/>
+<!-- Open Graph -->
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="Dr. Yasas Sri Wickramasinghe"/>
+<meta property="og:title" content="Platform — Consultations, Speaking, Blog &amp; Community"/>
+<meta property="og:description" content="Free consultations on education, research and technology; speaker invitations; research blog; newsletter; and a student community forum."/>
+<meta property="og:url" content="https://www.yasassri.me/app/"/>
+<meta property="og:image" content="https://www.yasassri.me/assets/images/og-card.png"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="@sri_yasas"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "url": "https://www.yasassri.me/app/",
+  "name": "Academic Platform — Dr. Yasas Sri Wickramasinghe",
+  "description": "Interactive academic platform: free consultations, speaker invitations, research blog, newsletter and student community forum.",
+  "isPartOf": { "@id": "https://www.yasassri.me/#website" },
+  "about": { "@id": "https://www.yasassri.me/#yasas" }
+}
+</script>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet"/>
+<link href="../assets/css/redesign.css" rel="stylesheet"/>
+<link href="css/app.css" rel="stylesheet"/>
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-N2BH0F6SNE');
+</script>
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="../index.html">Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="../index.html">Main Site</a>
+      <a href="#/" data-nav="hub">Platform</a>
+      <a href="#/consult" data-nav="consult">Consult</a>
+      <a href="#/invite" data-nav="invite">Invite Me</a>
+      <a href="#/blog" data-nav="blog">Blog</a>
+      <a href="#/forum" data-nav="forum">Forum</a>
+      <a href="#/account" data-nav="account" id="navAccount">Sign In</a>
+      <a class="btn btn-solid" href="#/consult">Book a Consultation <span class="arrow">→</span></a>
+    </div>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
+  </div>
+</nav>
+<div class="mobile-menu">
+  <a href="../index.html"><span class="idx">01</span>Main Site</a>
+  <a href="#/" data-nav="hub"><span class="idx">02</span>Platform Home</a>
+  <a href="#/consult" data-nav="consult"><span class="idx">03</span>Consultations</a>
+  <a href="#/invite" data-nav="invite"><span class="idx">04</span>Invite Me to Speak</a>
+  <a href="#/blog" data-nav="blog"><span class="idx">05</span>Blog</a>
+  <a href="#/newsletter" data-nav="newsletter"><span class="idx">06</span>Newsletter</a>
+  <a href="#/forum" data-nav="forum"><span class="idx">07</span>Forum</a>
+  <a href="#/account" data-nav="account" id="navAccountMobile"><span class="idx">08</span>Sign In</a>
+</div>
+
+<main class="app-main">
+  <div class="container" id="view" aria-live="polite">
+    <div class="loading"><div class="spinner"></div></div>
+  </div>
+</main>
+
+<footer class="footer">
+  <div class="container">
+    <div class="footer-top">
+      <div class="footer-news">
+        <h3>Stay in the loop</h3>
+        <p>Monthly digest — new articles, upcoming talks, research updates and student opportunities.</p>
+        <a class="btn btn-solid" href="#/newsletter">Join the Newsletter <span class="arrow">→</span></a>
+      </div>
+      <div class="footer-col">
+        <h4>Platform</h4>
+        <a href="#/consult">Consultations</a>
+        <a href="#/invite">Invite Me to Speak</a>
+        <a href="#/blog">Blog</a>
+        <a href="#/newsletter">Newsletter</a>
+        <a href="#/forum">Forum</a>
+      </div>
+      <div class="footer-col">
+        <h4>Main Site</h4>
+        <a href="../index.html">Home</a>
+        <a href="../research.html">Research</a>
+        <a href="../teaching.html">Teaching</a>
+        <a href="../news.html">News</a>
+        <a href="../contact.html">Contact</a>
+      </div>
+      <div class="footer-col">
+        <h4>Connect</h4>
+        <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn ↗</a>
+        <a href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar ↗</a>
+        <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter / X ↗</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <div class="footer-logo">Yasas Sri Wickramasinghe</div>
+      <small>© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved. · <a href="#/guidelines" style="color:var(--muted)">Community Guidelines</a></small>
+    </div>
+  </div>
+</footer>
+
+<div class="toast" id="toast" role="status"></div>
+
+<script src="js/firebase-config.js"></script>
+<script type="module" src="js/app.js"></script>
+<script>
+  // Mobile menu toggle (mirrors main-site behaviour without loading premium.js)
+  (function () {
+    var t = document.querySelector('.nav-toggle'), m = document.querySelector('.mobile-menu');
+    if (t && m) {
+      t.addEventListener('click', function () {
+        var open = m.classList.toggle('open');
+        t.classList.toggle('open', open);
+        document.body.style.overflow = open ? 'hidden' : '';
+      });
+      m.querySelectorAll('a').forEach(function (a) {
+        a.addEventListener('click', function () {
+          m.classList.remove('open'); t.classList.remove('open');
+          document.body.style.overflow = '';
+        });
+      });
+    }
+    var y = document.querySelector('.year'); if (y) y.textContent = new Date().getFullYear();
+  })();
+</script>
+</body>
+</html>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,0 +1,1622 @@
+/* ==========================================================================
+   Academic Platform — single-page app
+   Consultations · Speaking invitations · Blog · Newsletter · Forum · Admin
+   Static-host friendly (GitHub Pages) — data lives in Firebase Firestore.
+   ========================================================================== */
+
+/* ---------- Firebase bootstrap (graceful preview mode when unconfigured) --
+   The SDK is imported dynamically so the app still renders when Firebase
+   isn't configured yet, or when the CDN is unreachable.                     */
+
+const CFG = window.FIREBASE_CONFIG || {};
+let CONFIGURED = !!(CFG.apiKey && !String(CFG.apiKey).startsWith("PASTE"));
+let LOAD_ERROR = false;
+const ADMIN_EMAILS = (window.PLATFORM_ADMINS || []).map(e => e.toLowerCase());
+
+let auth = null, db = null;
+let onAuthStateChanged, GoogleAuthProvider, signInWithPopup,
+    createUserWithEmailAndPassword, signInWithEmailAndPassword,
+    sendEmailVerification, sendPasswordResetEmail, signOut, updateProfile,
+    collection, doc, addDoc, setDoc, getDoc, getDocs,
+    updateDoc, deleteDoc, query, where, orderBy, limit,
+    serverTimestamp, increment;
+
+if (CONFIGURED) {
+  try {
+    const V = "10.14.1";
+    const [appM, authM, fsM] = await Promise.all([
+      import(`https://www.gstatic.com/firebasejs/${V}/firebase-app.js`),
+      import(`https://www.gstatic.com/firebasejs/${V}/firebase-auth.js`),
+      import(`https://www.gstatic.com/firebasejs/${V}/firebase-firestore.js`)
+    ]);
+    ({ onAuthStateChanged, GoogleAuthProvider, signInWithPopup,
+       createUserWithEmailAndPassword, signInWithEmailAndPassword,
+       sendEmailVerification, sendPasswordResetEmail, signOut, updateProfile } = authM);
+    ({ collection, doc, addDoc, setDoc, getDoc, getDocs,
+       updateDoc, deleteDoc, query, where, orderBy, limit,
+       serverTimestamp, increment } = fsM);
+    const fbApp = appM.initializeApp(CFG);
+    auth = authM.getAuth(fbApp);
+    db = fsM.getFirestore(fbApp);
+  } catch (e) {
+    console.error("Failed to load Firebase SDK:", e);
+    CONFIGURED = false;
+    LOAD_ERROR = true;
+  }
+}
+
+let currentUser = null;
+let authReady = new Promise(resolve => {
+  if (!auth) { resolve(); return; }
+  onAuthStateChanged(auth, user => {
+    currentUser = user;
+    updateNav();
+    resolve();
+  });
+});
+
+const isAdmin = () =>
+  !!(currentUser && currentUser.email &&
+     currentUser.emailVerified &&
+     ADMIN_EMAILS.includes(currentUser.email.toLowerCase()));
+
+/* ---------- Static content ------------------------------------------------ */
+
+const CONSULT_TYPES = [
+  {
+    id: "education", name: "Educational Guidance", mins: 30,
+    desc: "Study paths, postgraduate options, assignment or project direction, and choosing between programmes.",
+    prep: "Bring your current study situation, options you're weighing, and one or two concrete questions."
+  },
+  {
+    id: "research", name: "Research Consultation", mins: 45,
+    desc: "Methodology, HCI / AR / UX study design, publishing advice, and supervision or PhD queries.",
+    prep: "Share a short abstract or a description of your study, plus links to any drafts or related work."
+  },
+  {
+    id: "career", name: "Career Mentoring", mins: 30,
+    desc: "Tech careers, portfolios, CV feedback, and transitioning between industry and academia.",
+    prep: "Have your CV / portfolio link ready and a sense of the role or path you're aiming for."
+  },
+  {
+    id: "general", name: "Other / General", mins: 30,
+    desc: "Anything else — collaborations, community projects, or a topic that doesn't fit the boxes above.",
+    prep: "A short summary of what you'd like to discuss is enough."
+  }
+];
+
+const SPEAKER_TOPICS = [
+  {
+    title: "Location-Based AR & Place Attachment",
+    abs: "How location-based augmented reality can meaningfully connect people to real-world places — and to each other across distance — drawing on peer-reviewed research with Sony Interactive Entertainment and Niantic.",
+    formats: ["Keynote", "Guest lecture"], duration: "30–60 min", audience: "Researchers · Industry · Students",
+    tech: "Standard AV; optional live AR demo (needs open Wi-Fi + space to move)"
+  },
+  {
+    title: "Designing AR Games for the Real World",
+    abs: "Practical design lessons from building and evaluating multiplayer location-based AR games: playtesting in the wild, safety, spatial UX patterns, and what actually engages players outdoors.",
+    formats: ["Conference talk", "Workshop"], duration: "45 min – half day", audience: "Game developers · Designers",
+    tech: "Projector; workshop version needs tables and participant phones"
+  },
+  {
+    title: "Immersive Technology in Education",
+    abs: "Where AR/VR genuinely helps learning (and where it doesn't) — evidence-informed strategies for educators and institutions adopting immersive tools, with examples from tertiary teaching.",
+    formats: ["Keynote", "Guest lecture", "Panel"], duration: "30–60 min", audience: "Educators · EdTech · Leadership",
+    tech: "Standard AV"
+  },
+  {
+    title: "UX Research Methods for Emerging Tech",
+    abs: "Choosing and combining methods to evaluate novel interfaces: from lab studies to in-the-wild deployments, measuring presence, place attachment, and player experience.",
+    formats: ["Guest lecture", "Workshop"], duration: "60 min – half day", audience: "Postgraduate students · UX teams",
+    tech: "Standard AV; workshop version needs group seating"
+  },
+  {
+    title: "Postgraduate Research Skills",
+    abs: "Surviving and thriving in a research degree: framing a contribution, writing for CHI-style venues, working with industry partners, and managing supervision relationships.",
+    formats: ["Guest lecture", "Workshop"], duration: "45–90 min", audience: "Honours · Master's · PhD students",
+    tech: "Standard AV"
+  }
+];
+
+const PAST_ENGAGEMENTS = [
+  { when: "Oct 2026", title: "Designing Shared Worlds Across Distance", detail: "NZGDC 2026 · Conference talk · Wellington, NZ", upcoming: true },
+  { when: "Jul 2026", title: "CODE with WIE 2026 — Architecting the Augmented Tomorrow", detail: "IEEE WIE Sri Lanka · Workshop · Online" },
+  { when: "Dec 2025", title: "Research Visit — Interactive Content Design Lab", detail: "Tohoku University, Japan · Invited research talk & collaboration" },
+  { when: "2024", title: "Breaking the Wall of Loneliness Through Play", detail: "Falling Walls Lab Aotearoa NZ · Royal Society Te Apārangi · Pitch talk" },
+  { when: "2023", title: "AR Game Development Panel", detail: "NZGDC 2023 · Panel · New Zealand Game Developers Conference" }
+];
+
+const FORUM_CATEGORIES = [
+  { id: "announcements", icon: "📣", name: "Announcements", desc: "Official updates from Yasas — new articles, opportunities, events.", adminOnly: true },
+  { id: "general", icon: "💬", name: "General Discussion", desc: "Introduce yourself and talk about anything loosely on-topic." },
+  { id: "course-help", icon: "🎓", name: "Course Help", desc: "Questions about coursework, assignments and study skills.", membersOnly: true },
+  { id: "research-postgrad", icon: "🔬", name: "Research & Postgrad", desc: "Methodology, publishing, thesis life, and postgraduate pathways." },
+  { id: "careers", icon: "💼", name: "Careers & Industry", desc: "Jobs, portfolios, interviews and moving between industry and academia." },
+  { id: "arvr-tech", icon: "🥽", name: "AR/VR & Tech Talk", desc: "Immersive tech, spatial computing, game design and tooling." },
+  { id: "blog-discussions", icon: "📝", name: "Blog Discussions", desc: "Threads for discussing articles published on the blog." },
+  { id: "feedback", icon: "💡", name: "Feedback & Ideas", desc: "Suggestions for this platform and the community." }
+];
+
+/* ---------- Tiny helpers -------------------------------------------------- */
+
+const view = document.getElementById("view");
+const esc = s => String(s ?? "").replace(/[&<>"']/g,
+  c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+function toast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg;
+  t.classList.add("show");
+  clearTimeout(t._h);
+  t._h = setTimeout(() => t.classList.remove("show"), 3500);
+}
+
+const tsDate = ts => (ts && typeof ts.toDate === "function") ? ts.toDate() : (ts ? new Date(ts) : null);
+function fmtDate(ts, withTime) {
+  const d = tsDate(ts);
+  if (!d || isNaN(d)) return "—";
+  const opts = { day: "numeric", month: "short", year: "numeric" };
+  if (withTime) Object.assign(opts, { hour: "numeric", minute: "2-digit" });
+  return d.toLocaleString(undefined, opts);
+}
+function timeAgo(ts) {
+  const d = tsDate(ts);
+  if (!d || isNaN(d)) return "";
+  const s = (Date.now() - d.getTime()) / 1000;
+  if (s < 60) return "just now";
+  if (s < 3600) return Math.floor(s / 60) + "m ago";
+  if (s < 86400) return Math.floor(s / 3600) + "h ago";
+  if (s < 86400 * 30) return Math.floor(s / 86400) + "d ago";
+  return fmtDate(d);
+}
+const initials = name => (name || "?").trim().split(/\s+/).map(w => w[0]).slice(0, 2).join("").toUpperCase();
+const slugify = s => String(s).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "").slice(0, 80) || "post";
+const readingTime = md => Math.max(1, Math.round(String(md).trim().split(/\s+/).length / 200));
+const badge = st => `<span class="badge ${esc(st)}">${esc(st)}</span>`;
+
+function setupNotice() {
+  if (CONFIGURED) return "";
+  if (LOAD_ERROR) return `<div class="notice warn"><b>Connection problem.</b> Couldn't reach the data service —
+  forms, sign-in and the forum are temporarily unavailable. Please check your connection and reload.</div>`;
+  return `<div class="notice warn"><b>Preview mode.</b> Firebase isn't configured yet, so forms, sign-in and the forum are disabled.
+  Site owner: follow <code>PLATFORM_SETUP.md</code> in the repository to connect Firestore.</div>`;
+}
+
+function fbError(e) {
+  const m = String(e && (e.code || e.message) || e);
+  if (m.includes("permission-denied")) return "Permission denied — you may not have access for this action.";
+  if (m.includes("auth/invalid-credential") || m.includes("auth/wrong-password")) return "Incorrect email or password.";
+  if (m.includes("auth/email-already-in-use")) return "An account with this email already exists — try signing in.";
+  if (m.includes("auth/weak-password")) return "Password should be at least 6 characters.";
+  if (m.includes("auth/invalid-email")) return "That email address doesn't look right.";
+  if (m.includes("auth/popup")) return "Sign-in popup was blocked or closed — please try again.";
+  if (m.includes("unavailable") || m.includes("network")) return "Network problem — please try again.";
+  console.error(e);
+  return "Something went wrong — please try again.";
+}
+
+/* ---------- Minimal safe Markdown renderer ------------------------------- */
+
+function mdToHtml(src) {
+  src = String(src || "").replace(/\r\n?/g, "\n");
+  const codeBlocks = [];
+  src = src.replace(/```([\w-]*)\n([\s\S]*?)```/g, (_, lang, code) => {
+    codeBlocks.push(`<pre><code${lang ? ` class="lang-${esc(lang)}"` : ""}>${esc(code.replace(/\n$/, ""))}</code></pre>`);
+    return "\u0000CODE" + (codeBlocks.length - 1) + "\u0000";
+  });
+  src = esc(src);
+
+  const inline = t => t
+    .replace(/!\[([^\]]*)\]\((https?:[^)\s]+)\)/g, '<img src="$2" alt="$1" loading="lazy"/>')
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, "$1<em>$2</em>");
+
+  const lines = src.split("\n");
+  const out = [];
+  let para = [], listType = null;
+
+  const flushPara = () => { if (para.length) { out.push(`<p>${inline(para.join(" "))}</p>`); para = []; } };
+  const closeList = () => { if (listType) { out.push(`</${listType}>`); listType = null; } };
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const code = line.match(/^\u0000CODE(\d+)\u0000$/);
+    if (code) { flushPara(); closeList(); out.push(codeBlocks[+code[1]]); continue; }
+    if (!line.trim()) { flushPara(); closeList(); continue; }
+    const h = line.match(/^(#{1,4})\s+(.+)$/);
+    if (h) { flushPara(); closeList(); const n = Math.min(h[1].length + 1, 4); out.push(`<h${n}>${inline(h[2])}</h${n}>`); continue; }
+    if (/^(---|\*\*\*)\s*$/.test(line)) { flushPara(); closeList(); out.push("<hr/>"); continue; }
+    const bq = line.match(/^&gt;\s?(.*)$/);
+    if (bq) { flushPara(); closeList(); out.push(`<blockquote><p>${inline(bq[1])}</p></blockquote>`); continue; }
+    const ul = line.match(/^[-*]\s+(.+)$/);
+    const ol = line.match(/^\d+\.\s+(.+)$/);
+    if (ul || ol) {
+      flushPara();
+      const want = ul ? "ul" : "ol";
+      if (listType !== want) { closeList(); out.push(`<${want}>`); listType = want; }
+      out.push(`<li>${inline((ul || ol)[1])}</li>`);
+      continue;
+    }
+    para.push(line.trim());
+  }
+  flushPara(); closeList();
+  return out.join("\n");
+}
+
+/* ---------- Router --------------------------------------------------------- */
+
+const routes = [
+  [/^$/, viewHub],
+  [/^consult$/, viewConsult],
+  [/^invite$/, viewInvite],
+  [/^blog$/, viewBlogList],
+  [/^blog\/([\w-]+)$/, viewBlogPost],
+  [/^newsletter$/, viewNewsletter],
+  [/^forum$/, viewForum],
+  [/^forum\/new$/, viewForumNew],
+  [/^forum\/c\/([\w-]+)$/, viewForumCategory],
+  [/^forum\/t\/([\w-]+)$/, viewForumThread],
+  [/^account$/, viewAccount],
+  [/^admin$/, viewAdmin],
+  [/^guidelines$/, viewGuidelines]
+];
+
+function parseHash() {
+  const raw = location.hash.replace(/^#\/?/, "");
+  const [path, qs] = raw.split("?");
+  return { path: path || "", params: new URLSearchParams(qs || "") };
+}
+
+async function route() {
+  const { path, params } = parseHash();
+  updateNav(path);
+  document.title = "Platform — Consultations, Speaking, Blog & Community | Dr. Yasas Sri Wickramasinghe";
+  window.scrollTo(0, 0);
+  view.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  await authReady;
+  for (const [re, fn] of routes) {
+    const m = path.match(re);
+    if (m) { try { await fn(params, ...m.slice(1)); } catch (e) { console.error(e); view.innerHTML = `<div class="empty">Something went wrong loading this page.<br/><small>${esc(fbError(e))}</small></div>`; } return; }
+  }
+  view.innerHTML = `<div class="app-head"><h1>Page not found</h1><p>That page doesn't exist. <a href="#/" style="color:var(--accent);font-weight:600">Back to the platform home →</a></p></div>`;
+}
+
+function updateNav(path) {
+  if (path === undefined) path = parseHash().path;
+  const section = path === "" ? "hub" : path.split("/")[0];
+  document.querySelectorAll("[data-nav]").forEach(a => {
+    a.classList.toggle("active", a.dataset.nav === section);
+  });
+  const label = currentUser
+    ? (isAdmin() ? "Admin ⚙" : (currentUser.displayName || "My Account"))
+    : "Sign In";
+  const d = document.getElementById("navAccount");
+  const m = document.getElementById("navAccountMobile");
+  if (d) d.textContent = label;
+  if (m) m.innerHTML = `<span class="idx">08</span>${esc(label)}`;
+}
+
+window.addEventListener("hashchange", route);
+
+/* ---------- Reusable auth prompt ------------------------------------------ */
+
+function authPrompt(reason) {
+  return `<div class="notice"><b>Sign in required.</b> ${esc(reason)}
+    <a href="#/account" style="font-weight:600;color:var(--accent)">Sign in or create a free account →</a></div>`;
+}
+function verifyPrompt() {
+  return `<div class="notice warn"><b>Please verify your email.</b> We sent a verification link to
+    <b>${esc(currentUser.email)}</b>. Click it, then reload this page.
+    <button class="btn small" id="resendVerify" style="margin-left:8px">Resend link</button></div>`;
+}
+function bindResendVerify() {
+  const b = document.getElementById("resendVerify");
+  if (b) b.onclick = async () => {
+    try { await sendEmailVerification(currentUser); toast("Verification email sent."); }
+    catch (e) { toast(fbError(e)); }
+  };
+}
+
+/* ==========================================================================
+   VIEW: Platform hub
+   ========================================================================== */
+
+function viewHub() {
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-head">
+    <span class="eyebrow">Academic Platform</span>
+    <h1 style="margin-top:14px">Learn, collaborate &amp; <em>stay connected.</em></h1>
+    <p>Free consultations on education, research and technology · invitations for talks and workshops ·
+    research writing · and a community for students and collaborators.</p>
+  </div>
+
+  <div class="hub-grid">
+    <a class="hub-card" href="#/consult">
+      <div class="ic">🗓</div>
+      <h3>Free Consultations</h3>
+      <p>Book a free 30–45 minute session on study paths, research methods, HCI/AR/UX, or tech careers.</p>
+      <span class="go">Request a consultation →</span>
+    </a>
+    <a class="hub-card" href="#/invite">
+      <div class="ic">🎤</div>
+      <h3>Invite Me to Speak</h3>
+      <p>Keynotes, guest lectures, workshops and panels on AR, immersive tech, HCI and education.</p>
+      <span class="go">See topics &amp; invite →</span>
+    </a>
+    <a class="hub-card" href="#/blog">
+      <div class="ic">✍️</div>
+      <h3>Blog</h3>
+      <p>Articles on HCI, AR/VR and immersive technologies, software engineering, and education.</p>
+      <span class="go">Read articles →</span>
+    </a>
+    <a class="hub-card" href="#/forum">
+      <div class="ic">👥</div>
+      <h3>Community Forum</h3>
+      <p>Ask questions, help peers, and stay in touch — a home base for students and followers.</p>
+      <span class="go">Join the forum →</span>
+    </a>
+    <a class="hub-card" href="#/newsletter">
+      <div class="ic">📬</div>
+      <h3>Newsletter</h3>
+      <p>A monthly digest of new articles, upcoming talks, research updates and student opportunities.</p>
+      <span class="go">Subscribe →</span>
+    </a>
+    <a class="hub-card" href="../research.html">
+      <div class="ic">📚</div>
+      <h3>Research &amp; Publications</h3>
+      <p>Peer-reviewed work in location-based AR, spatial computing and player experience.</p>
+      <span class="go">Explore research →</span>
+    </a>
+  </div>
+
+  <div class="identity-band">
+    <div class="identity"><b>Educator</b><span>Senior Lecturer at Yoobee Colleges — mentoring, consultations and a student community.</span></div>
+    <div class="identity"><b>Researcher</b><span>HCI, location-based AR and game design — published in venues like Entertainment Computing.</span></div>
+    <div class="identity"><b>Speaker</b><span>Invited talks, guest lectures and workshops — from NZGDC to IEEE WIE.</span></div>
+  </div>`;
+}
+
+/* ==========================================================================
+   VIEW: Consultations
+   ========================================================================== */
+
+async function viewConsult() {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "Pacific/Auckland";
+  const canSubmit = CONFIGURED && currentUser && currentUser.emailVerified;
+
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / Consultations</div>
+  <div class="app-head">
+    <span class="eyebrow">Free Consultations</span>
+    <h1 style="margin-top:14px">Book a free <em>consultation.</em></h1>
+    <p>Structured, free sessions for students, researchers and professionals — on education, research and
+    technology. Pick a type, tell me what you need, and propose up to three times that suit you.
+    Sessions run online (Meet/Teams/Zoom) or in person in Christchurch, NZ.</p>
+  </div>
+
+  <h2 style="font-size:20px;margin-bottom:14px">1 · Choose a consultation type</h2>
+  <div class="type-grid" id="typeGrid">
+    ${CONSULT_TYPES.map(t => `
+      <button type="button" class="type-card" data-type="${t.id}">
+        <h3>${esc(t.name)} <span class="dur">${t.mins} min</span></h3>
+        <p>${esc(t.desc)}</p>
+        <p class="prep"><b>Prepare:</b> ${esc(t.prep)}</p>
+      </button>`).join("")}
+  </div>
+
+  <h2 style="font-size:20px;margin-bottom:14px">2 · Tell me about it</h2>
+  ${!CONFIGURED ? "" : !currentUser
+      ? authPrompt("To prevent fake bookings, consultation requests need a verified account.")
+      : (!currentUser.emailVerified ? verifyPrompt() : "")}
+
+  <form class="form panel" id="consultForm" ${canSubmit ? "" : "style='opacity:.6;pointer-events:none'"}>
+    <div class="form-row">
+      <div class="field"><label>Full name *</label><input name="name" required maxlength="120" value="${esc(currentUser?.displayName || "")}"/></div>
+      <div class="field"><label>Email *</label><input name="email" type="email" required maxlength="200" value="${esc(currentUser?.email || "")}"/></div>
+    </div>
+    <div class="form-row">
+      <div class="field"><label>I am a… *</label>
+        <select name="role" required>
+          <option value="student">Student</option>
+          <option value="researcher">Researcher / academic</option>
+          <option value="professional">Industry professional</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div class="field"><label>Organization <small>(optional)</small></label><input name="organization" maxlength="200"/></div>
+    </div>
+    <div class="field">
+      <label>Topic summary * <small>(min 100 characters — the more context, the better the session)</small></label>
+      <textarea name="topic" required minlength="100" maxlength="3000"></textarea>
+      <div class="count" id="topicCount">0 / 100 minimum</div>
+    </div>
+    <div class="field">
+      <label>What do you hope to get out of it? *</label>
+      <textarea name="goals" required maxlength="2000" style="min-height:80px"></textarea>
+    </div>
+    <div class="field">
+      <label>Relevant links <small>(optional — drafts, portfolio, paper, one per line)</small></label>
+      <textarea name="links" maxlength="1000" style="min-height:60px" placeholder="https://…"></textarea>
+    </div>
+    <div class="form-row">
+      <div class="field"><label>Meeting mode *</label>
+        <select name="mode" required>
+          <option value="online">Online (Meet / Teams / Zoom)</option>
+          <option value="in-person">In person — Christchurch, NZ</option>
+        </select>
+      </div>
+      <div class="field"><label>Your timezone</label><input name="timezone" value="${esc(tz)}" maxlength="80"/>
+        <div class="hint">Auto-detected — adjust if wrong.</div></div>
+    </div>
+    <h3 style="margin-top:6px">3 · Propose up to three preferred times</h3>
+    <p class="sub" style="margin-bottom:0">In <b>your</b> timezone. I'm based in Christchurch, NZ (NZST/NZDT) — weekday late afternoons and early evenings usually work best. I'll confirm one, or suggest an alternative.</p>
+    <div class="form-row">
+      <div class="field"><label>Preferred time 1 *</label><input name="slot1" type="datetime-local" required/></div>
+      <div class="field"><label>Preferred time 2</label><input name="slot2" type="datetime-local"/></div>
+    </div>
+    <div class="form-row">
+      <div class="field"><label>Preferred time 3</label><input name="slot3" type="datetime-local"/></div>
+      <div></div>
+    </div>
+    <div class="hp-field" aria-hidden="true"><label>Leave this field empty</label><input name="website" tabindex="-1" autocomplete="off"/></div>
+    <div class="form-actions">
+      <button class="btn btn-solid" type="submit" ${canSubmit ? "" : "disabled"}>Submit Request <span class="arrow">→</span></button>
+      <span class="form-msg" id="consultMsg"></span>
+    </div>
+  </form>
+
+  <div id="myRequests" style="margin-top:40px"></div>`;
+
+  bindResendVerify();
+
+  // Type selection
+  let selectedType = CONSULT_TYPES[0].id;
+  const cards = view.querySelectorAll(".type-card");
+  const select = id => {
+    selectedType = id;
+    cards.forEach(c => c.classList.toggle("selected", c.dataset.type === id));
+  };
+  cards.forEach(c => c.addEventListener("click", () => select(c.dataset.type)));
+  select(selectedType);
+
+  // Char counter
+  const topicEl = view.querySelector("[name=topic]");
+  const countEl = document.getElementById("topicCount");
+  if (topicEl) topicEl.addEventListener("input", () => {
+    const n = topicEl.value.length;
+    countEl.textContent = n < 100 ? `${n} / 100 minimum` : `${n} characters ✓`;
+  });
+
+  // Submit
+  const form = document.getElementById("consultForm");
+  const msg = document.getElementById("consultMsg");
+  form.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    if (!canSubmit) return;
+    const f = new FormData(form);
+    msg.className = "form-msg"; msg.textContent = "";
+    if (f.get("website")) return; // honeypot
+    if (String(f.get("topic")).trim().length < 100) {
+      msg.className = "form-msg err"; msg.textContent = "Topic summary needs at least 100 characters."; return;
+    }
+    const slots = ["slot1", "slot2", "slot3"].map(k => f.get(k)).filter(Boolean);
+    if (!slots.length) { msg.className = "form-msg err"; msg.textContent = "Please propose at least one time."; return; }
+
+    const btn = form.querySelector("button[type=submit]");
+    btn.disabled = true;
+    try {
+      // Light rate limit: max 2 open (pending/approved) requests per account
+      const mine = await getDocs(query(collection(db, "consultations"), where("uid", "==", currentUser.uid)));
+      const open = mine.docs.filter(d => ["pending", "approved"].includes(d.data().status)).length;
+      if (open >= 2) throw { code: "rate", message: "" };
+
+      await addDoc(collection(db, "consultations"), {
+        uid: currentUser.uid,
+        type: selectedType,
+        typeName: (CONSULT_TYPES.find(t => t.id === selectedType) || {}).name || selectedType,
+        name: String(f.get("name")).trim(),
+        email: String(f.get("email")).trim(),
+        role: f.get("role"),
+        organization: String(f.get("organization") || "").trim(),
+        topic: String(f.get("topic")).trim(),
+        goals: String(f.get("goals")).trim(),
+        links: String(f.get("links") || "").trim(),
+        mode: f.get("mode"),
+        timezone: String(f.get("timezone") || "").trim(),
+        slots,
+        status: "pending",
+        website: "",
+        createdAt: serverTimestamp()
+      });
+      form.reset();
+      msg.className = "form-msg ok";
+      msg.textContent = "Request submitted — you'll hear back by email once it's reviewed.";
+      toast("Consultation request submitted ✓");
+      loadMyRequests();
+    } catch (e) {
+      msg.className = "form-msg err";
+      msg.textContent = e.code === "rate"
+        ? "You already have 2 open requests — please wait until they're handled."
+        : fbError(e);
+    } finally { btn.disabled = false; }
+  });
+
+  async function loadMyRequests() {
+    if (!CONFIGURED || !currentUser) return;
+    const box = document.getElementById("myRequests");
+    try {
+      const snap = await getDocs(query(collection(db, "consultations"), where("uid", "==", currentUser.uid)));
+      if (snap.empty) { box.innerHTML = ""; return; }
+      const items = snap.docs
+        .map(d => ({ id: d.id, ...d.data() }))
+        .sort((a, b) => (tsDate(b.createdAt) || 0) - (tsDate(a.createdAt) || 0));
+      box.innerHTML = `<h2 style="font-size:20px;margin-bottom:14px">My requests</h2>
+        <div class="list">${items.map(r => `
+          <div class="list-item">
+            <div class="li-main">
+              <h3>${esc(r.typeName)}</h3>
+              <div class="meta">Submitted ${fmtDate(r.createdAt)} · ${esc(r.mode)} · ${esc(r.timezone || "")}</div>
+              ${r.status === "approved" && r.scheduledAt ? `<div class="desc"><b>Confirmed:</b> ${fmtDate(r.scheduledAt, true)}${r.meetingLink ? ` · <a href="${esc(r.meetingLink)}" target="_blank" rel="noopener" style="color:var(--accent);font-weight:600">Join meeting ↗</a>` : ""}</div>` : ""}
+              ${r.status === "declined" && r.declineReason ? `<div class="desc">${esc(r.declineReason)}</div>` : ""}
+            </div>
+            <div class="li-side">
+              ${badge(r.status)}
+              ${r.status === "pending" ? `<button class="btn small danger" data-cancel="${r.id}">Cancel</button>` : ""}
+            </div>
+          </div>`).join("")}</div>`;
+      box.querySelectorAll("[data-cancel]").forEach(b => b.onclick = async () => {
+        if (!confirm("Cancel this request?")) return;
+        try {
+          await updateDoc(doc(db, "consultations", b.dataset.cancel), { status: "cancelled" });
+          toast("Request cancelled."); loadMyRequests();
+        } catch (e) { toast(fbError(e)); }
+      });
+    } catch (e) { console.error(e); }
+  }
+  loadMyRequests();
+}
+
+/* ==========================================================================
+   VIEW: Invite Me (speaker page + invitation form)
+   ========================================================================== */
+
+function viewInvite() {
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / Invite Me</div>
+  <div class="app-head">
+    <span class="eyebrow">Speaking &amp; Invitations</span>
+    <h1 style="margin-top:14px">Invite me to <em>speak.</em></h1>
+    <p>Keynotes, guest lectures, workshops and panels on augmented reality, immersive technology, HCI and
+    education. Based in Christchurch, New Zealand — available for national and international engagements,
+    and remote talks worldwide. All engagements are handled personally and promptly.</p>
+    <div class="form-actions" style="margin-top:18px">
+      <a class="btn" href="../assets/files/cv_yasas.pdf" target="_blank">Speaker Bio / CV (PDF) <span class="arrow">→</span></a>
+      <a class="btn" href="../news.html">Past Talks &amp; Media</a>
+    </div>
+  </div>
+
+  <h2 style="font-size:20px;margin-bottom:14px">Talk topics</h2>
+  <div class="topic-grid" style="margin-bottom:40px">
+    ${SPEAKER_TOPICS.map(t => `
+      <div class="topic-card">
+        <h3>${esc(t.title)}</h3>
+        <p>${esc(t.abs)}</p>
+        <div class="tmeta">
+          ${t.formats.map(f => `<span class="chip">${esc(f)}</span>`).join("")}
+          <span class="chip">⏱ ${esc(t.duration)}</span>
+          <span class="chip">👥 ${esc(t.audience)}</span>
+        </div>
+        <div class="tmeta"><span class="chip" style="background:var(--accent-soft);border-color:transparent;color:var(--accent-dark)">🔌 ${esc(t.tech)}</span></div>
+      </div>`).join("")}
+  </div>
+
+  <div class="two-col">
+    <div class="panel">
+      <h2>Send an invitation</h2>
+      <p class="sub">Tell me about your event — I typically reply within a few working days. Consultations for
+      individuals are free; for speaking engagements, travel/accommodation and honorarium details help me assess fit.</p>
+      <form class="form" id="inviteForm">
+        <div class="form-row">
+          <div class="field"><label>Your name *</label><input name="organizerName" required maxlength="120"/></div>
+          <div class="field"><label>Your role *</label><input name="organizerRole" required maxlength="120" placeholder="e.g. Programme chair"/></div>
+        </div>
+        <div class="form-row">
+          <div class="field"><label>Organization *</label><input name="organization" required maxlength="200"/></div>
+          <div class="field"><label>Email *</label><input name="email" type="email" required maxlength="200"/></div>
+        </div>
+        <div class="form-row">
+          <div class="field"><label>Phone <small>(optional)</small></label><input name="phone" maxlength="40"/></div>
+          <div class="field"><label>Event type *</label>
+            <select name="eventType" required>
+              <option value="conference">Conference</option>
+              <option value="university">University / guest lecture</option>
+              <option value="corporate">Corporate / industry</option>
+              <option value="meetup">Meetup / community</option>
+              <option value="media">Media / podcast</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+        </div>
+        <div class="field"><label>Event name *</label><input name="eventName" required maxlength="200"/></div>
+        <div class="form-row">
+          <div class="field"><label>Date(s) *</label><input name="eventDate" required maxlength="120" placeholder="e.g. 12–14 March 2027 (flexible)"/></div>
+          <div class="field"><label>Location or online *</label><input name="location" required maxlength="200"/></div>
+        </div>
+        <div class="form-row">
+          <div class="field"><label>Expected audience <small>(size &amp; profile)</small></label><input name="audience" maxlength="200" placeholder="e.g. ~150 game developers"/></div>
+          <div class="field"><label>Requested topic *</label>
+            <select name="topic" required>
+              ${SPEAKER_TOPICS.map(t => `<option>${esc(t.title)}</option>`).join("")}
+              <option value="custom">Custom topic (describe below)</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="field"><label>Format &amp; duration *</label><input name="format" required maxlength="120" placeholder="e.g. 45-min keynote + Q&amp;A"/></div>
+          <div class="field"><label>Travel / accommodation covered?</label>
+            <select name="travel"><option value="yes">Yes</option><option value="partial">Partially</option><option value="no">No</option><option value="na" selected>N/A (online)</option></select>
+          </div>
+        </div>
+        <div class="field"><label>Honorarium offered <small>(optional, free text)</small></label><input name="honorarium" maxlength="200"/></div>
+        <div class="field"><label>Anything else? <small>(custom topic, context, links)</small></label><textarea name="message" maxlength="3000"></textarea></div>
+        <div class="hp-field" aria-hidden="true"><label>Leave this field empty</label><input name="website" tabindex="-1" autocomplete="off"/></div>
+        <div class="form-actions">
+          <button class="btn btn-solid" type="submit" ${CONFIGURED ? "" : "disabled"}>Send Invitation <span class="arrow">→</span></button>
+          <span class="form-msg" id="inviteMsg"></span>
+        </div>
+      </form>
+    </div>
+
+    <div class="panel">
+      <h2>Engagements</h2>
+      <p class="sub">Selected recent and upcoming appearances.</p>
+      ${PAST_ENGAGEMENTS.map(e => `
+        <div class="engagement">
+          <span class="when">${esc(e.when)}</span>
+          <div>
+            <h3>${esc(e.title)} ${e.upcoming ? '<span class="badge pending" style="vertical-align:middle">Upcoming</span>' : ""}</h3>
+            <p>${esc(e.detail)}</p>
+          </div>
+        </div>`).join("")}
+      <blockquote style="margin-top:18px;border-left:3px solid var(--accent);padding-left:16px;color:var(--ink-soft);font-size:14px;font-style:italic">
+        "Yasas brings rare range — the rigour of a researcher and the instincts of a builder."
+        <br/><small style="font-style:normal;color:var(--muted)">— Research &amp; industry partners, HIT Lab NZ · Sony Interactive Entertainment</small>
+      </blockquote>
+    </div>
+  </div>`;
+
+  const form = document.getElementById("inviteForm");
+  const msg = document.getElementById("inviteMsg");
+  form.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    if (!CONFIGURED) return;
+    const f = new FormData(form);
+    if (f.get("website")) return; // honeypot
+    const btn = form.querySelector("button[type=submit]");
+    btn.disabled = true; msg.className = "form-msg"; msg.textContent = "";
+    try {
+      const data = { status: "pending", website: "", createdAt: serverTimestamp() };
+      for (const k of ["organizerName", "organizerRole", "organization", "email", "phone", "eventType",
+                       "eventName", "eventDate", "location", "audience", "topic", "format",
+                       "travel", "honorarium", "message"]) {
+        data[k] = String(f.get(k) || "").trim();
+      }
+      await addDoc(collection(db, "invitations"), data);
+      form.reset();
+      msg.className = "form-msg ok";
+      msg.textContent = "Invitation sent — thank you! You'll get a reply by email.";
+      toast("Invitation submitted ✓");
+    } catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+    finally { btn.disabled = false; }
+  });
+}
+
+/* ==========================================================================
+   VIEW: Blog
+   ========================================================================== */
+
+const POST_CATEGORIES = ["Research", "Teaching & Learning", "AR/VR & Immersive Tech", "Career Advice", "Announcements"];
+
+async function fetchPublishedPosts() {
+  if (!CONFIGURED) return [];
+  const snap = await getDocs(query(collection(db, "posts"), where("status", "==", "published")));
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (tsDate(b.publishedAt || b.createdAt) || 0) - (tsDate(a.publishedAt || a.createdAt) || 0));
+}
+
+async function viewBlogList() {
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / Blog</div>
+  <div class="app-head">
+    <span class="eyebrow">Blog</span>
+    <h1 style="margin-top:14px">Notes from research &amp; <em>the classroom.</em></h1>
+    <p>Articles on HCI, immersive technologies, software engineering and education.
+    Earlier writing also lives on <a href="../blogs.html" style="color:var(--accent);font-weight:600">the Writing page</a> and
+    <a href="https://yasassri.medium.com" target="_blank" rel="noopener" style="color:var(--accent);font-weight:600">Medium ↗</a>.</p>
+  </div>
+  <div id="postList"><div class="loading"><div class="spinner"></div></div></div>`;
+
+  const box = document.getElementById("postList");
+  try {
+    const posts = await fetchPublishedPosts();
+    if (!posts.length) {
+      box.innerHTML = `<div class="empty">No articles published here yet — new posts land soon.<br/>
+        Meanwhile, browse <a href="../blogs.html" style="color:var(--accent);font-weight:600">existing writing →</a></div>`;
+      return;
+    }
+    box.innerHTML = `<div class="post-grid">${posts.map(p => `
+      <a class="post-card" href="#/blog/${esc(p.slug || p.id)}">
+        <span class="pmeta"><span class="badge cat">${esc(p.category || "Article")}</span> &nbsp; ${fmtDate(p.publishedAt || p.createdAt)} · ${p.readingTime || readingTime(p.content)} min read</span>
+        <h3>${esc(p.title)}</h3>
+        <p>${esc(p.summary || "")}</p>
+        <span class="go" style="color:var(--accent);font-weight:600;font-size:14px">Read article →</span>
+      </a>`).join("")}</div>`;
+  } catch (e) {
+    box.innerHTML = `<div class="empty">${esc(fbError(e))}</div>`;
+  }
+}
+
+async function viewBlogPost(_, slug) {
+  if (!CONFIGURED) { view.innerHTML = setupNotice() + `<div class="empty">Blog isn't connected yet.</div>`; return; }
+  let post = null;
+  // Slug lookup (security rules require non-admin queries to filter on published)
+  const constraints = [where("slug", "==", slug)];
+  if (!isAdmin()) constraints.push(where("status", "==", "published"));
+  const bySlug = await getDocs(query(collection(db, "posts"), ...constraints, limit(1)));
+  if (!bySlug.empty) post = { id: bySlug.docs[0].id, ...bySlug.docs[0].data() };
+  else {
+    try { const d = await getDoc(doc(db, "posts", slug)); if (d.exists()) post = { id: d.id, ...d.data() }; } catch (_) {}
+  }
+  if (!post || (post.status !== "published" && !isAdmin())) {
+    view.innerHTML = `<div class="empty">Article not found. <a href="#/blog" style="color:var(--accent);font-weight:600">Back to the blog →</a></div>`;
+    return;
+  }
+  document.title = `${post.title} — Yasas Sri Wickramasinghe`;
+  view.innerHTML = `
+  <article class="article">
+    <div class="app-crumb"><a href="#/">Platform</a> / <a href="#/blog">Blog</a> / ${esc(post.title)}</div>
+    <header class="article-header">
+      <span class="badge cat">${esc(post.category || "Article")}</span>
+      <h1>${esc(post.title)}</h1>
+      <div class="pmeta">By Dr. Yasas Sri Wickramasinghe · ${fmtDate(post.publishedAt || post.createdAt)} ·
+        ${post.readingTime || readingTime(post.content)} min read
+        ${post.status !== "published" ? " · " + badge(post.status) : ""}</div>
+      ${post.summary ? `<p class="article-summary">${esc(post.summary)}</p>` : ""}
+    </header>
+    <div class="prose">${mdToHtml(post.content)}</div>
+    ${post.tags && post.tags.length ? `<div class="tmeta" style="margin-top:28px">${post.tags.map(t => `<span class="chip">#${esc(t)}</span>`).join("")}</div>` : ""}
+    <div class="panel" style="margin-top:36px">
+      <h3>Discuss this post</h3>
+      <p class="sub" style="margin-bottom:14px">Comments live in the community forum — one thread per article.</p>
+      <div class="form-actions">
+        <a class="btn btn-solid" href="#/forum/new?cat=blog-discussions&title=${encodeURIComponent("Discussion: " + post.title)}">Discuss in the Forum <span class="arrow">→</span></a>
+        <a class="btn" href="#/newsletter">Get new posts by email</a>
+      </div>
+    </div>
+  </article>`;
+}
+
+/* ==========================================================================
+   VIEW: Newsletter
+   ========================================================================== */
+
+function viewNewsletter(params) {
+  const prefill = params.get("email") || "";
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / Newsletter</div>
+  <div class="two-col">
+    <div>
+      <div class="app-head" style="margin-bottom:24px">
+        <span class="eyebrow">Newsletter</span>
+        <h1 style="margin-top:14px">Research notes &amp; <em>field insights.</em></h1>
+        <p>A monthly digest — new blog posts, upcoming talks, research updates and student opportunities.
+        No noise, unsubscribe anytime with one click.</p>
+      </div>
+      <ul style="list-style:disc;margin-left:20px;color:var(--ink-soft);font-size:14.5px;display:grid;gap:8px">
+        <li>New articles on HCI, AR/VR and education</li>
+        <li>Upcoming talks, workshops and where to catch them</li>
+        <li>Research updates and behind-the-scenes notes</li>
+        <li>Opportunities for students (segment-targeted)</li>
+      </ul>
+    </div>
+    <div class="panel">
+      <h2>Subscribe</h2>
+      <p class="sub">Pick the audience that fits you best — it helps target relevant content (e.g. student-only opportunities).</p>
+      <form class="form" id="nlForm">
+        <div class="field"><label>Email *</label><input name="email" type="email" required maxlength="200" value="${esc(prefill)}"/></div>
+        <div class="field"><label>Name <small>(optional)</small></label><input name="name" maxlength="120"/></div>
+        <div class="field"><label>I'm a…</label>
+          <select name="segment">
+            <option value="student">Student</option>
+            <option value="researcher">Researcher</option>
+            <option value="professional">Professional</option>
+          </select>
+        </div>
+        <div class="hp-field" aria-hidden="true"><label>Leave this field empty</label><input name="website" tabindex="-1" autocomplete="off"/></div>
+        <div class="form-actions">
+          <button class="btn btn-solid" type="submit" ${CONFIGURED ? "" : "disabled"}>Subscribe <span class="arrow">→</span></button>
+          <span class="form-msg" id="nlMsg"></span>
+        </div>
+        <p class="hint" style="font-size:12px;color:var(--muted)">You'll receive a confirmation before any regular emails (double opt-in).
+        Unsubscribe links are included in every issue.</p>
+      </form>
+    </div>
+  </div>`;
+
+  const form = document.getElementById("nlForm");
+  const msg = document.getElementById("nlMsg");
+  form.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    if (!CONFIGURED) return;
+    const f = new FormData(form);
+    if (f.get("website")) return;
+    const email = String(f.get("email")).trim().toLowerCase();
+    const btn = form.querySelector("button[type=submit]");
+    btn.disabled = true; msg.className = "form-msg"; msg.textContent = "";
+    try {
+      await setDoc(doc(db, "subscribers", email), {
+        email,
+        name: String(f.get("name") || "").trim(),
+        segment: f.get("segment"),
+        status: "subscribed",
+        website: "",
+        createdAt: serverTimestamp()
+      });
+      form.reset();
+      msg.className = "form-msg ok"; msg.textContent = "You're on the list — welcome!";
+      toast("Subscribed ✓");
+    } catch (e) {
+      if (String(e && e.code).includes("permission-denied")) {
+        msg.className = "form-msg ok"; msg.textContent = "You're already subscribed — nothing more to do!";
+      } else { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+    } finally { btn.disabled = false; }
+  });
+}
+
+/* ==========================================================================
+   VIEW: Forum
+   ========================================================================== */
+
+const catById = id => FORUM_CATEGORIES.find(c => c.id === id);
+
+async function viewForum() {
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / Forum</div>
+  <div class="app-head">
+    <span class="eyebrow">Community Forum</span>
+    <h1 style="margin-top:14px">Ask, answer &amp; <em>stay in touch.</em></h1>
+    <p>A community for students, researchers and followers. Browse as a guest; create a free account to post.
+    Please read the <a href="#/guidelines" style="color:var(--accent);font-weight:600">community guidelines</a> before your first post.</p>
+    ${CONFIGURED && !currentUser ? `<div class="form-actions" style="margin-top:16px"><a class="btn btn-solid" href="#/account">Join the community <span class="arrow">→</span></a></div>` : ""}
+  </div>
+  <div class="list">
+    ${FORUM_CATEGORIES.map(c => `
+      <a class="cat-row" href="#/forum/c/${c.id}">
+        <div class="ic">${c.icon}</div>
+        <div><h3>${esc(c.name)}</h3><p>${esc(c.desc)}</p></div>
+        <span class="lock">${c.adminOnly ? "🔒 admin posts" : c.membersOnly ? "👤 members" : ""}</span>
+      </a>`).join("")}
+  </div>`;
+}
+
+async function viewForumCategory(_, catId) {
+  const cat = catById(catId);
+  if (!cat) { location.hash = "#/forum"; return; }
+  const canPost = CONFIGURED && currentUser && currentUser.emailVerified && (!cat.adminOnly || isAdmin());
+
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / <a href="#/forum">Forum</a> / ${esc(cat.name)}</div>
+  <div class="app-head" style="margin-bottom:24px">
+    <h1 style="font-size:clamp(26px,3.5vw,36px)">${cat.icon} ${esc(cat.name)}</h1>
+    <p>${esc(cat.desc)}</p>
+  </div>
+  <div class="form-actions" style="margin-bottom:22px">
+    ${canPost ? `<a class="btn btn-solid" href="#/forum/new?cat=${cat.id}">New Thread <span class="arrow">→</span></a>`
+      : cat.adminOnly ? `<span class="form-msg">Only announcements from Yasas appear here.</span>`
+      : CONFIGURED && !currentUser ? `<a class="btn" href="#/account">Sign in to post</a>` : ""}
+  </div>
+  <div id="threads"><div class="loading"><div class="spinner"></div></div></div>`;
+
+  const box = document.getElementById("threads");
+  if (!CONFIGURED) { box.innerHTML = `<div class="empty">Forum isn't connected yet.</div>`; return; }
+  if (cat.membersOnly && !currentUser) {
+    box.innerHTML = `<div class="empty">This category is members-only. <a href="#/account" style="color:var(--accent);font-weight:600">Sign in →</a></div>`;
+    return;
+  }
+  try {
+    const snap = await getDocs(query(collection(db, "threads"), where("categoryId", "==", catId)));
+    const threads = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+      .filter(t => !t.hidden || isAdmin())
+      .sort((a, b) => (b.pinned - a.pinned) || ((tsDate(b.lastReplyAt || b.createdAt) || 0) - (tsDate(a.lastReplyAt || a.createdAt) || 0)));
+    if (!threads.length) { box.innerHTML = `<div class="empty">No threads yet — start the first one!</div>`; return; }
+    box.innerHTML = `<div class="list">${threads.map(t => `
+      <a class="list-item" href="#/forum/t/${t.id}">
+        <div class="li-main">
+          <h3>${t.pinned ? "📌 " : ""}${t.locked ? "🔒 " : ""}${esc(t.title)}${t.hidden ? " " + badge("declined").replace("declined", "hidden") : ""}</h3>
+          <div class="meta">by ${esc(t.authorName || "member")} · ${timeAgo(t.createdAt)} · ${t.replyCount || 0} repl${(t.replyCount || 0) === 1 ? "y" : "ies"}${t.lastReplyAt ? " · last activity " + timeAgo(t.lastReplyAt) : ""}</div>
+        </div>
+      </a>`).join("")}</div>`;
+  } catch (e) { box.innerHTML = `<div class="empty">${esc(fbError(e))}</div>`; }
+}
+
+function viewForumNew(params) {
+  const catId = params.get("cat") || "general";
+  const cat = catById(catId) || catById("general");
+  const prefillTitle = params.get("title") || "";
+  const canPost = CONFIGURED && currentUser && currentUser.emailVerified && (!cat.adminOnly || isAdmin());
+
+  view.innerHTML = `
+  ${setupNotice()}
+  <div class="app-crumb"><a href="#/">Platform</a> / <a href="#/forum">Forum</a> / New thread</div>
+  <div class="app-head" style="margin-bottom:24px"><h1 style="font-size:clamp(26px,3.5vw,36px)">Start a thread</h1></div>
+  ${!CONFIGURED ? "" : !currentUser ? authPrompt("You need a free account to post in the forum.")
+    : !currentUser.emailVerified ? verifyPrompt()
+    : cat.adminOnly && !isAdmin() ? `<div class="notice warn">Only the admin can post in ${esc(cat.name)}.</div>` : ""}
+  <form class="form panel" id="threadForm" ${canPost ? "" : "style='opacity:.6;pointer-events:none'"}>
+    <div class="field"><label>Category</label>
+      <select name="categoryId">${FORUM_CATEGORIES.filter(c => !c.adminOnly || isAdmin()).map(c =>
+        `<option value="${c.id}" ${c.id === cat.id ? "selected" : ""}>${esc(c.name)}</option>`).join("")}</select>
+    </div>
+    <div class="field"><label>Title *</label><input name="title" required maxlength="200" value="${esc(prefillTitle)}"/></div>
+    <div class="field"><label>Body * <small>(plain text / basic Markdown)</small></label><textarea name="body" required maxlength="8000" style="min-height:160px"></textarea></div>
+    <div class="form-actions">
+      <button class="btn btn-solid" type="submit" ${canPost ? "" : "disabled"}>Post Thread <span class="arrow">→</span></button>
+      <span class="form-msg" id="threadMsg"></span>
+    </div>
+  </form>`;
+
+  bindResendVerify();
+  const form = document.getElementById("threadForm");
+  const msg = document.getElementById("threadMsg");
+  form.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    if (!canPost) return;
+    const f = new FormData(form);
+    const btn = form.querySelector("button[type=submit]");
+    btn.disabled = true;
+    try {
+      const ref = await addDoc(collection(db, "threads"), {
+        categoryId: f.get("categoryId"),
+        title: String(f.get("title")).trim(),
+        body: String(f.get("body")).trim(),
+        uid: currentUser.uid,
+        authorName: currentUser.displayName || currentUser.email.split("@")[0],
+        replyCount: 0,
+        pinned: false, locked: false, hidden: false, reported: false,
+        createdAt: serverTimestamp(),
+        lastReplyAt: serverTimestamp()
+      });
+      toast("Thread posted ✓");
+      location.hash = `#/forum/t/${ref.id}`;
+    } catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); btn.disabled = false; }
+  });
+}
+
+async function viewForumThread(_, threadId) {
+  if (!CONFIGURED) { view.innerHTML = setupNotice() + `<div class="empty">Forum isn't connected yet.</div>`; return; }
+  const tDoc = await getDoc(doc(db, "threads", threadId));
+  if (!tDoc.exists()) { view.innerHTML = `<div class="empty">Thread not found. <a href="#/forum" style="color:var(--accent);font-weight:600">Back to forum →</a></div>`; return; }
+  const t = { id: tDoc.id, ...tDoc.data() };
+  const cat = catById(t.categoryId);
+  if (t.hidden && !isAdmin()) { view.innerHTML = `<div class="empty">This thread has been hidden by a moderator.</div>`; return; }
+  const canReply = currentUser && currentUser.emailVerified && !t.locked;
+
+  const postHtml = (p, isThread) => `
+    <div class="thread-post" ${isThread ? "" : `data-reply="${p.id}"`}>
+      <div class="tp-head">
+        <div class="avatar">${esc(initials(p.authorName))}</div>
+        <div class="who"><b>${esc(p.authorName || "member")}</b><span>${timeAgo(p.createdAt)}${p.reported && isAdmin() ? " · ⚠ reported" : ""}</span></div>
+        <div class="tp-actions">
+          ${currentUser && !isThread ? `<button class="report-btn" data-report-reply="${p.id}">Report</button>` : ""}
+          ${currentUser && isThread ? `<button class="report-btn" data-report-thread>Report</button>` : ""}
+          ${isAdmin() && !isThread ? `<button class="report-btn" data-del-reply="${p.id}">Delete</button>` : ""}
+        </div>
+      </div>
+      <div class="tp-body">${mdToHtml(p.body)}</div>
+    </div>`;
+
+  view.innerHTML = `
+  <div class="app-crumb"><a href="#/">Platform</a> / <a href="#/forum">Forum</a> / <a href="#/forum/c/${esc(t.categoryId)}">${esc(cat ? cat.name : t.categoryId)}</a></div>
+  <div class="app-head" style="margin-bottom:20px">
+    <h1 style="font-size:clamp(24px,3.2vw,34px)">${t.pinned ? "📌 " : ""}${t.locked ? "🔒 " : ""}${esc(t.title)}</h1>
+    ${isAdmin() ? `<div class="form-actions" style="margin-top:12px">
+      <button class="btn small" id="adminPin">${t.pinned ? "Unpin" : "Pin"}</button>
+      <button class="btn small" id="adminLock">${t.locked ? "Unlock" : "Lock"}</button>
+      <button class="btn small danger" id="adminHide">${t.hidden ? "Unhide" : "Hide"}</button>
+    </div>` : ""}
+  </div>
+  ${postHtml(t, true)}
+  <div id="replies" style="margin-top:12px"><div class="loading"><div class="spinner"></div></div></div>
+  <div style="margin-top:24px" id="replyBox">
+    ${t.locked ? `<div class="notice">This thread is locked — no new replies.</div>`
+      : !currentUser ? authPrompt("Sign in to reply.")
+      : !currentUser.emailVerified ? verifyPrompt()
+      : `<form class="form panel" id="replyForm">
+          <div class="field"><label>Reply as ${esc(currentUser.displayName || currentUser.email)}</label>
+          <textarea name="body" required maxlength="6000" style="min-height:100px"></textarea></div>
+          <div class="form-actions">
+            <button class="btn btn-solid" type="submit">Post Reply <span class="arrow">→</span></button>
+            <span class="form-msg" id="replyMsg"></span>
+          </div>
+        </form>`}
+  </div>`;
+
+  bindResendVerify();
+
+  // Admin thread controls
+  const flip = (id, field, cur) => {
+    const b = document.getElementById(id);
+    if (b) b.onclick = async () => {
+      try { await updateDoc(doc(db, "threads", t.id), { [field]: !cur }); route(); }
+      catch (e) { toast(fbError(e)); }
+    };
+  };
+  flip("adminPin", "pinned", t.pinned);
+  flip("adminLock", "locked", t.locked);
+  flip("adminHide", "hidden", t.hidden);
+
+  const reportThreadBtn = view.querySelector("[data-report-thread]");
+  if (reportThreadBtn) reportThreadBtn.onclick = async () => {
+    try { await updateDoc(doc(db, "threads", t.id), { reported: true }); toast("Reported — a moderator will take a look."); }
+    catch (e) { toast(fbError(e)); }
+  };
+
+  // Replies
+  async function loadReplies() {
+    const box = document.getElementById("replies");
+    try {
+      const snap = await getDocs(query(collection(db, "threads", t.id, "replies"), orderBy("createdAt", "asc")));
+      const replies = snap.docs.map(d => ({ id: d.id, ...d.data() })).filter(r => !r.hidden || isAdmin());
+      box.innerHTML = replies.length
+        ? replies.map(r => postHtml(r, false)).join("")
+        : `<div class="empty" style="padding:28px">No replies yet.</div>`;
+      box.querySelectorAll("[data-report-reply]").forEach(b => b.onclick = async () => {
+        try { await updateDoc(doc(db, "threads", t.id, "replies", b.dataset.reportReply), { reported: true }); toast("Reported ✓"); }
+        catch (e) { toast(fbError(e)); }
+      });
+      box.querySelectorAll("[data-del-reply]").forEach(b => b.onclick = async () => {
+        if (!confirm("Delete this reply?")) return;
+        try {
+          await deleteDoc(doc(db, "threads", t.id, "replies", b.dataset.delReply));
+          await updateDoc(doc(db, "threads", t.id), { replyCount: increment(-1) });
+          loadReplies();
+        } catch (e) { toast(fbError(e)); }
+      });
+    } catch (e) { box.innerHTML = `<div class="empty">${esc(fbError(e))}</div>`; }
+  }
+  loadReplies();
+
+  const replyForm = document.getElementById("replyForm");
+  if (replyForm) replyForm.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    if (!canReply) return;
+    const body = String(new FormData(replyForm).get("body")).trim();
+    if (!body) return;
+    const btn = replyForm.querySelector("button[type=submit]");
+    btn.disabled = true;
+    try {
+      await addDoc(collection(db, "threads", t.id, "replies"), {
+        body,
+        uid: currentUser.uid,
+        authorName: currentUser.displayName || currentUser.email.split("@")[0],
+        reported: false, hidden: false,
+        createdAt: serverTimestamp()
+      });
+      await updateDoc(doc(db, "threads", t.id), { replyCount: increment(1), lastReplyAt: serverTimestamp() });
+      replyForm.reset();
+      loadReplies();
+    } catch (e) {
+      document.getElementById("replyMsg").className = "form-msg err";
+      document.getElementById("replyMsg").textContent = fbError(e);
+    } finally { btn.disabled = false; }
+  });
+}
+
+/* ==========================================================================
+   VIEW: Guidelines
+   ========================================================================== */
+
+function viewGuidelines() {
+  view.innerHTML = `
+  <div class="app-crumb"><a href="#/">Platform</a> / Community Guidelines</div>
+  <article class="article">
+    <div class="app-head"><span class="eyebrow">Community</span><h1 style="margin-top:14px">Community Guidelines</h1></div>
+    <div class="prose">
+      <p>This community exists so students, researchers and followers can learn together. Keep it useful and kind:</p>
+      <ol>
+        <li><strong>Be respectful.</strong> Disagree with ideas, not people. No harassment, hate speech or personal attacks.</li>
+        <li><strong>Stay on topic.</strong> Use the category that fits; keep threads focused.</li>
+        <li><strong>No academic misconduct.</strong> Asking for guidance is great; asking others to complete assessed work for you is not.</li>
+        <li><strong>No spam or self-promotion</strong> without context. Sharing your relevant work in a discussion is fine.</li>
+        <li><strong>Protect privacy.</strong> Don't post other people's personal information, or private course material.</li>
+        <li><strong>Report, don't retaliate.</strong> Use the report button — a moderator will handle it.</li>
+      </ol>
+      <p>Posts that break these guidelines may be hidden or removed, and repeat offenders may lose posting access.
+      Questions or appeals: use the <a href="../contact.html">contact page</a>.</p>
+    </div>
+  </article>`;
+}
+
+/* ==========================================================================
+   VIEW: Account (sign in / sign up / profile)
+   ========================================================================== */
+
+function viewAccount() {
+  if (!CONFIGURED) {
+    view.innerHTML = setupNotice() + `<div class="empty">Accounts aren't available until Firebase is connected.</div>`;
+    return;
+  }
+
+  if (currentUser) {
+    view.innerHTML = `
+    <div class="app-crumb"><a href="#/">Platform</a> / Account</div>
+    <div class="auth-box">
+      <div class="panel">
+        <div class="user-chip" style="margin-bottom:18px">
+          <div class="avatar" style="width:48px;height:48px;font-size:17px">${esc(initials(currentUser.displayName || currentUser.email))}</div>
+          <div class="info"><b>${esc(currentUser.displayName || "No display name yet")}</b><span>${esc(currentUser.email)}
+            ${currentUser.emailVerified ? " · verified ✓" : " · <b style='color:#b45309'>not verified</b>"}</span></div>
+        </div>
+        ${!currentUser.emailVerified ? verifyPrompt() : ""}
+        <form class="form" id="profileForm">
+          <div class="field"><label>Display name (shown in the forum)</label>
+            <input name="displayName" maxlength="60" value="${esc(currentUser.displayName || "")}"/></div>
+          <div class="form-actions">
+            <button class="btn btn-solid small" type="submit">Save</button>
+            <button class="btn small" type="button" id="signOutBtn">Sign out</button>
+            ${isAdmin() ? `<a class="btn small" href="#/admin">Admin Dashboard ⚙</a>` : ""}
+          </div>
+        </form>
+      </div>
+      <div class="panel">
+        <h3>Quick links</h3>
+        <div class="form-actions" style="margin-top:12px">
+          <a class="btn small" href="#/consult">My consultations</a>
+          <a class="btn small" href="#/forum">Forum</a>
+          <a class="btn small" href="#/newsletter">Newsletter</a>
+        </div>
+      </div>
+    </div>`;
+    bindResendVerify();
+    document.getElementById("signOutBtn").onclick = async () => { await signOut(auth); toast("Signed out."); location.hash = "#/"; };
+    document.getElementById("profileForm").addEventListener("submit", async ev => {
+      ev.preventDefault();
+      const name = String(new FormData(ev.target).get("displayName")).trim();
+      try {
+        await updateProfile(currentUser, { displayName: name });
+        await setDoc(doc(db, "profiles", currentUser.uid), { displayName: name, updatedAt: serverTimestamp() }, { merge: true });
+        toast("Profile saved ✓"); updateNav();
+      } catch (e) { toast(fbError(e)); }
+    });
+    return;
+  }
+
+  view.innerHTML = `
+  <div class="app-crumb"><a href="#/">Platform</a> / Sign In</div>
+  <div class="auth-box">
+    <div class="app-head" style="margin-bottom:22px;text-align:center;max-width:none">
+      <h1 style="font-size:clamp(26px,3.5vw,34px)">Welcome</h1>
+      <p>One free account for consultations and the community forum.</p>
+    </div>
+    <div class="panel">
+      <div class="auth-tabs">
+        <button type="button" class="active" data-tab="signin">Sign In</button>
+        <button type="button" data-tab="signup">Create Account</button>
+      </div>
+      <button class="btn btn-google" id="googleBtn" type="button">
+        <svg width="17" height="17" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9 3.5l6.7-6.7C35.6 2.5 30.2 0 24 0 14.6 0 6.5 5.4 2.6 13.2l7.8 6.1C12.3 13.2 17.7 9.5 24 9.5z"/><path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.7c-.6 3-2.3 5.5-4.8 7.2l7.5 5.8c4.4-4.1 7.1-10.1 7.1-17.5z"/><path fill="#FBBC05" d="M10.4 28.7a14.5 14.5 0 0 1 0-9.4l-7.8-6.1a24 24 0 0 0 0 21.6l7.8-6.1z"/><path fill="#34A853" d="M24 48c6.2 0 11.4-2 15.4-5.6l-7.5-5.8c-2.1 1.4-4.8 2.3-7.9 2.3-6.3 0-11.7-3.7-13.6-9.2l-7.8 6.1C6.5 42.6 14.6 48 24 48z"/></svg>
+        Continue with Google
+      </button>
+      <div class="divider">or with email</div>
+      <form class="form" id="authForm">
+        <div class="field" id="nameField" style="display:none"><label>Display name *</label><input name="displayName" maxlength="60"/></div>
+        <div class="field"><label>Email *</label><input name="email" type="email" required maxlength="200"/></div>
+        <div class="field"><label>Password *</label><input name="password" type="password" required minlength="6" maxlength="100"/></div>
+        <div class="form-actions">
+          <button class="btn btn-solid" type="submit" id="authSubmit">Sign In</button>
+          <button class="btn small" type="button" id="forgotBtn">Forgot password?</button>
+        </div>
+        <span class="form-msg" id="authMsg"></span>
+        <p class="hint" style="font-size:12px;color:var(--muted)">By creating an account you accept the
+          <a href="#/guidelines" style="color:var(--accent)">community guidelines</a>.</p>
+      </form>
+    </div>
+  </div>`;
+
+  let mode = "signin";
+  const tabs = view.querySelectorAll(".auth-tabs button");
+  tabs.forEach(b => b.onclick = () => {
+    mode = b.dataset.tab;
+    tabs.forEach(x => x.classList.toggle("active", x === b));
+    document.getElementById("nameField").style.display = mode === "signup" ? "" : "none";
+    document.getElementById("authSubmit").textContent = mode === "signup" ? "Create Account" : "Sign In";
+  });
+
+  const msg = document.getElementById("authMsg");
+  document.getElementById("googleBtn").onclick = async () => {
+    try {
+      await signInWithPopup(auth, new GoogleAuthProvider());
+      toast("Signed in ✓"); route();
+    } catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+  };
+  document.getElementById("forgotBtn").onclick = async () => {
+    const email = String(new FormData(document.getElementById("authForm")).get("email")).trim();
+    if (!email) { msg.className = "form-msg err"; msg.textContent = "Enter your email first, then click 'Forgot password?'."; return; }
+    try { await sendPasswordResetEmail(auth, email); msg.className = "form-msg ok"; msg.textContent = "Password-reset email sent."; }
+    catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+  };
+  document.getElementById("authForm").addEventListener("submit", async ev => {
+    ev.preventDefault();
+    const f = new FormData(ev.target);
+    const email = String(f.get("email")).trim(), pass = String(f.get("password"));
+    msg.className = "form-msg"; msg.textContent = "";
+    try {
+      if (mode === "signup") {
+        const name = String(f.get("displayName") || "").trim();
+        if (!name) { msg.className = "form-msg err"; msg.textContent = "Please choose a display name."; return; }
+        const cred = await createUserWithEmailAndPassword(auth, email, pass);
+        await updateProfile(cred.user, { displayName: name });
+        await setDoc(doc(db, "profiles", cred.user.uid), { displayName: name, createdAt: serverTimestamp() });
+        await sendEmailVerification(cred.user);
+        toast("Account created — check your inbox to verify your email.");
+      } else {
+        await signInWithEmailAndPassword(auth, email, pass);
+        toast("Signed in ✓");
+      }
+      route();
+    } catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+  });
+}
+
+/* ==========================================================================
+   VIEW: Admin dashboard
+   ========================================================================== */
+
+async function viewAdmin() {
+  if (!CONFIGURED) { view.innerHTML = setupNotice(); return; }
+  if (!currentUser) { view.innerHTML = authPrompt("Admin access requires signing in."); return; }
+  if (!isAdmin()) { view.innerHTML = `<div class="empty">This area is restricted to the site owner.</div>`; return; }
+
+  view.innerHTML = `
+  <div class="app-crumb"><a href="#/">Platform</a> / Admin</div>
+  <div class="app-head" style="margin-bottom:22px"><h1 style="font-size:clamp(26px,3.5vw,38px)">Admin Dashboard</h1></div>
+  <div class="stat-row" id="adminStats"></div>
+  <div class="tabs" id="adminTabs">
+    <button data-t="consult" class="active">Consultations</button>
+    <button data-t="invites">Invitations</button>
+    <button data-t="blog">Blog</button>
+    <button data-t="subs">Subscribers</button>
+    <button data-t="mod">Moderation</button>
+  </div>
+  <div id="adminBody"><div class="loading"><div class="spinner"></div></div></div>`;
+
+  const body = document.getElementById("adminBody");
+  const tabs = document.getElementById("adminTabs").querySelectorAll("button");
+  const setTab = t => {
+    tabs.forEach(b => b.classList.toggle("active", b.dataset.t === t));
+    ({ consult: adminConsults, invites: adminInvites, blog: adminBlog, subs: adminSubs, mod: adminMod })[t](body);
+  };
+  tabs.forEach(b => b.onclick = () => setTab(b.dataset.t));
+
+  // Stats
+  (async () => {
+    try {
+      const [c, i, s, r] = await Promise.all([
+        getDocs(collection(db, "consultations")),
+        getDocs(collection(db, "invitations")),
+        getDocs(collection(db, "subscribers")),
+        getDocs(query(collection(db, "threads"), where("reported", "==", true)))
+      ]);
+      const pend = arr => arr.docs.filter(d => d.data().status === "pending").length;
+      document.getElementById("adminStats").innerHTML = `
+        <div class="stat"><b>${pend(c)}</b><span>pending consultations</span></div>
+        <div class="stat"><b>${pend(i)}</b><span>pending invitations</span></div>
+        <div class="stat"><b>${s.docs.filter(d => d.data().status === "subscribed").length}</b><span>newsletter subscribers</span></div>
+        <div class="stat"><b>${r.size}</b><span>reported threads</span></div>`;
+    } catch (e) { console.error(e); }
+  })();
+
+  setTab("consult");
+}
+
+const detailRow = (k, v) => v ? `<dt>${esc(k)}</dt><dd>${esc(v)}</dd>` : "";
+
+async function adminConsults(body) {
+  body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  const snap = await getDocs(collection(db, "consultations"));
+  const items = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (a.status === "pending" ? -1 : 1) - (b.status === "pending" ? -1 : 1) ||
+                    ((tsDate(b.createdAt) || 0) - (tsDate(a.createdAt) || 0)));
+  if (!items.length) { body.innerHTML = `<div class="empty">No consultation requests yet.</div>`; return; }
+
+  body.innerHTML = `<div class="list">${items.map(r => `
+    <div class="list-item" style="flex-direction:column;align-items:stretch">
+      <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap">
+        <div class="li-main">
+          <h3>${esc(r.typeName)} — ${esc(r.name)}</h3>
+          <div class="meta">${esc(r.email)} · ${esc(r.role)}${r.organization ? " · " + esc(r.organization) : ""} · ${fmtDate(r.createdAt)}</div>
+        </div>
+        <div class="li-side" style="flex-direction:row;align-items:center">${badge(r.status)}
+          <button class="btn small" data-open="${r.id}">Details</button></div>
+      </div>
+      <div id="detail-${r.id}" style="display:none;border-top:1px solid var(--line);margin-top:14px;padding-top:14px">
+        <dl class="detail-grid">
+          ${detailRow("Topic", r.topic)}${detailRow("Goals", r.goals)}${detailRow("Links", r.links)}
+          ${detailRow("Mode", r.mode)}${detailRow("Timezone", r.timezone)}
+          ${detailRow("Proposed times", (r.slots || []).map(s => new Date(s).toLocaleString()).join(" · "))}
+        </dl>
+        ${r.status === "pending" ? `
+        <div class="form" style="gap:12px">
+          <div class="form-row">
+            <div class="field"><label>Confirm slot</label>
+              <select id="slot-${r.id}">${(r.slots || []).map(s => `<option value="${esc(s)}">${new Date(s).toLocaleString()}</option>`).join("")}</select></div>
+            <div class="field"><label>Meeting link (Meet/Teams/Zoom)</label><input id="link-${r.id}" placeholder="https://…"/></div>
+          </div>
+          <div class="form-actions">
+            <button class="btn btn-solid small" data-approve="${r.id}">Approve</button>
+            <button class="btn small danger" data-decline="${r.id}">Decline…</button>
+          </div>
+        </div>` : `
+        <div class="form-actions">
+          ${r.status === "approved" ? `<button class="btn small" data-complete="${r.id}">Mark completed</button>` : ""}
+          <button class="btn small danger" data-delete="${r.id}">Delete</button>
+        </div>`}
+      </div>
+    </div>`).join("")}</div>`;
+
+  body.querySelectorAll("[data-open]").forEach(b => b.onclick = () => {
+    const d = document.getElementById("detail-" + b.dataset.open);
+    d.style.display = d.style.display === "none" ? "" : "none";
+  });
+  body.querySelectorAll("[data-approve]").forEach(b => b.onclick = async () => {
+    const id = b.dataset.approve;
+    try {
+      await updateDoc(doc(db, "consultations", id), {
+        status: "approved",
+        scheduledAt: document.getElementById("slot-" + id).value,
+        meetingLink: String(document.getElementById("link-" + id).value).trim(),
+        decidedAt: serverTimestamp()
+      });
+      toast("Approved — remember to email the requester and send a calendar invite.");
+      adminConsults(body);
+    } catch (e) { toast(fbError(e)); }
+  });
+  body.querySelectorAll("[data-decline]").forEach(b => b.onclick = async () => {
+    const reason = prompt("Courteous decline reason (shown to the requester):",
+      "Thanks for reaching out — I'm unable to take this one on right now, but feel free to try again next term.");
+    if (reason === null) return;
+    try {
+      await updateDoc(doc(db, "consultations", b.dataset.decline), { status: "declined", declineReason: reason, decidedAt: serverTimestamp() });
+      adminConsults(body);
+    } catch (e) { toast(fbError(e)); }
+  });
+  body.querySelectorAll("[data-complete]").forEach(b => b.onclick = async () => {
+    try { await updateDoc(doc(db, "consultations", b.dataset.complete), { status: "completed" }); adminConsults(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+  body.querySelectorAll("[data-delete]").forEach(b => b.onclick = async () => {
+    if (!confirm("Permanently delete this request?")) return;
+    try { await deleteDoc(doc(db, "consultations", b.dataset.delete)); adminConsults(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+}
+
+async function adminInvites(body) {
+  body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  const snap = await getDocs(collection(db, "invitations"));
+  const items = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (tsDate(b.createdAt) || 0) - (tsDate(a.createdAt) || 0));
+  if (!items.length) { body.innerHTML = `<div class="empty">No speaking invitations yet.</div>`; return; }
+
+  body.innerHTML = `<div class="list">${items.map(r => `
+    <div class="list-item" style="flex-direction:column;align-items:stretch">
+      <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap">
+        <div class="li-main">
+          <h3>${esc(r.eventName)} <span style="font-weight:400;color:var(--muted)">(${esc(r.eventType)})</span></h3>
+          <div class="meta">${esc(r.organizerName)} · ${esc(r.organization)} · ${esc(r.email)} · ${fmtDate(r.createdAt)}</div>
+        </div>
+        <div class="li-side" style="flex-direction:row;align-items:center">${badge(r.status)}
+          <button class="btn small" data-open="${r.id}">Details</button></div>
+      </div>
+      <div id="idetail-${r.id}" style="display:none;border-top:1px solid var(--line);margin-top:14px;padding-top:14px">
+        <dl class="detail-grid">
+          ${detailRow("Topic", r.topic)}${detailRow("Format & duration", r.format)}
+          ${detailRow("Date(s)", r.eventDate)}${detailRow("Location", r.location)}
+          ${detailRow("Audience", r.audience)}${detailRow("Travel covered", r.travel)}
+          ${detailRow("Honorarium", r.honorarium)}${detailRow("Phone", r.phone)}
+          ${detailRow("Role", r.organizerRole)}${detailRow("Message", r.message)}
+        </dl>
+        <div class="form-actions">
+          <button class="btn btn-solid small" data-set="accepted:${r.id}">Accept</button>
+          <button class="btn small" data-set="discussing:${r.id}">Discussing</button>
+          <button class="btn small danger" data-set="declined:${r.id}">Decline</button>
+          <a class="btn small" href="mailto:${esc(r.email)}?subject=${encodeURIComponent("Re: " + r.eventName)}">Reply by email ↗</a>
+          <button class="btn small danger" data-idelete="${r.id}">Delete</button>
+        </div>
+      </div>
+    </div>`).join("")}</div>`;
+
+  body.querySelectorAll("[data-open]").forEach(b => b.onclick = () => {
+    const d = document.getElementById("idetail-" + b.dataset.open);
+    d.style.display = d.style.display === "none" ? "" : "none";
+  });
+  body.querySelectorAll("[data-set]").forEach(b => b.onclick = async () => {
+    const [status, id] = b.dataset.set.split(":");
+    try { await updateDoc(doc(db, "invitations", id), { status, decidedAt: serverTimestamp() }); adminInvites(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+  body.querySelectorAll("[data-idelete]").forEach(b => b.onclick = async () => {
+    if (!confirm("Permanently delete this invitation?")) return;
+    try { await deleteDoc(doc(db, "invitations", b.dataset.idelete)); adminInvites(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+}
+
+async function adminBlog(body, editId) {
+  body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  const snap = await getDocs(collection(db, "posts"));
+  const posts = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (tsDate(b.createdAt) || 0) - (tsDate(a.createdAt) || 0));
+  const editing = editId ? posts.find(p => p.id === editId) : null;
+
+  body.innerHTML = `
+  <div class="two-col">
+    <form class="form panel" id="postForm">
+      <h3>${editing ? "Edit article" : "New article"}</h3>
+      <div class="field"><label>Title *</label><input name="title" required maxlength="200" value="${esc(editing?.title || "")}"/></div>
+      <div class="form-row">
+        <div class="field"><label>Category</label>
+          <select name="category">${POST_CATEGORIES.map(c => `<option ${editing?.category === c ? "selected" : ""}>${esc(c)}</option>`).join("")}</select></div>
+        <div class="field"><label>Tags <small>(comma-separated)</small></label><input name="tags" maxlength="200" value="${esc((editing?.tags || []).join(", "))}"/></div>
+      </div>
+      <div class="field"><label>Summary <small>(abstract-style, shown at top &amp; in cards)</small></label>
+        <textarea name="summary" maxlength="500" style="min-height:70px">${esc(editing?.summary || "")}</textarea></div>
+      <div class="field"><label>Content * <small>(Markdown: ## headings, **bold**, [links](url), \`\`\`code\`\`\`, lists, &gt; quotes, images)</small></label>
+        <textarea name="content" required maxlength="60000" style="min-height:320px;font-family:ui-monospace,Menlo,monospace;font-size:13px">${esc(editing?.content || "")}</textarea></div>
+      <div class="form-actions">
+        <button class="btn btn-solid small" type="submit" data-status="published">${editing?.status === "published" ? "Update (published)" : "Publish"}</button>
+        <button class="btn small" type="submit" data-status="draft">Save as draft</button>
+        ${editing ? `<button class="btn small" type="button" id="cancelEdit">Cancel edit</button>` : ""}
+        <span class="form-msg" id="postMsg"></span>
+      </div>
+    </form>
+    <div>
+      <h3 style="margin-bottom:12px">All articles (${posts.length})</h3>
+      <div class="list">${posts.map(p => `
+        <div class="list-item">
+          <div class="li-main"><h3>${esc(p.title)}</h3>
+            <div class="meta">${esc(p.category || "")} · ${fmtDate(p.publishedAt || p.createdAt)} · /${esc(p.slug || p.id)}</div></div>
+          <div class="li-side" style="flex-direction:row;align-items:center">
+            ${badge(p.status)}
+            <button class="btn small" data-edit="${p.id}">Edit</button>
+            <button class="btn small danger" data-pdel="${p.id}">✕</button>
+          </div>
+        </div>`).join("") || `<div class="empty" style="padding:24px">No articles yet.</div>`}</div>
+    </div>
+  </div>`;
+
+  let clickedStatus = "published";
+  const form = document.getElementById("postForm");
+  form.querySelectorAll("button[type=submit]").forEach(b => b.addEventListener("click", () => { clickedStatus = b.dataset.status; }));
+  form.addEventListener("submit", async ev => {
+    ev.preventDefault();
+    const f = new FormData(form);
+    const title = String(f.get("title")).trim();
+    const content = String(f.get("content"));
+    const data = {
+      title,
+      slug: editing?.slug || slugify(title),
+      category: f.get("category"),
+      tags: String(f.get("tags") || "").split(",").map(s => s.trim()).filter(Boolean),
+      summary: String(f.get("summary") || "").trim(),
+      content,
+      readingTime: readingTime(content),
+      status: clickedStatus,
+      updatedAt: serverTimestamp()
+    };
+    try {
+      if (editing) {
+        if (clickedStatus === "published" && editing.status !== "published") data.publishedAt = serverTimestamp();
+        await updateDoc(doc(db, "posts", editing.id), data);
+      } else {
+        data.createdAt = serverTimestamp();
+        if (clickedStatus === "published") data.publishedAt = serverTimestamp();
+        await addDoc(collection(db, "posts"), data);
+      }
+      toast(clickedStatus === "published" ? "Article published ✓" : "Draft saved ✓");
+      adminBlog(body);
+    } catch (e) {
+      document.getElementById("postMsg").className = "form-msg err";
+      document.getElementById("postMsg").textContent = fbError(e);
+    }
+  });
+  const cancel = document.getElementById("cancelEdit");
+  if (cancel) cancel.onclick = () => adminBlog(body);
+  body.querySelectorAll("[data-edit]").forEach(b => b.onclick = () => adminBlog(body, b.dataset.edit));
+  body.querySelectorAll("[data-pdel]").forEach(b => b.onclick = async () => {
+    if (!confirm("Delete this article permanently?")) return;
+    try { await deleteDoc(doc(db, "posts", b.dataset.pdel)); adminBlog(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+}
+
+async function adminSubs(body) {
+  body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  const snap = await getDocs(collection(db, "subscribers"));
+  const subs = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    .sort((a, b) => (tsDate(b.createdAt) || 0) - (tsDate(a.createdAt) || 0));
+
+  body.innerHTML = `
+  <div class="form-actions" style="margin-bottom:18px">
+    <button class="btn small btn-solid" id="csvBtn">Export CSV (${subs.length})</button>
+    <span class="form-msg">Import this into your email tool of choice for sending campaigns.</span>
+  </div>
+  <div class="list">${subs.map(s => `
+    <div class="list-item">
+      <div class="li-main"><h3 style="font-size:14.5px">${esc(s.email)}</h3>
+        <div class="meta">${esc(s.name || "—")} · ${esc(s.segment || "")} · joined ${fmtDate(s.createdAt)}</div></div>
+      <div class="li-side" style="flex-direction:row;align-items:center">
+        ${badge(s.status)}
+        <button class="btn small" data-flip="${s.id}:${s.status}">${s.status === "subscribed" ? "Unsubscribe" : "Resubscribe"}</button>
+      </div>
+    </div>`).join("") || `<div class="empty">No subscribers yet.</div>`}</div>`;
+
+  document.getElementById("csvBtn").onclick = () => {
+    const rows = [["email", "name", "segment", "status", "createdAt"]]
+      .concat(subs.map(s => [s.email, s.name || "", s.segment || "", s.status, fmtDate(s.createdAt)]));
+    const csv = rows.map(r => r.map(c => `"${String(c).replace(/"/g, '""')}"`).join(",")).join("\n");
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
+    a.download = "newsletter-subscribers.csv";
+    a.click();
+  };
+  body.querySelectorAll("[data-flip]").forEach(b => b.onclick = async () => {
+    const [id, status] = b.dataset.flip.split(":");
+    try {
+      await updateDoc(doc(db, "subscribers", id), { status: status === "subscribed" ? "unsubscribed" : "subscribed" });
+      adminSubs(body);
+    } catch (e) { toast(fbError(e)); }
+  });
+}
+
+async function adminMod(body) {
+  body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+  const snap = await getDocs(query(collection(db, "threads"), where("reported", "==", true)));
+  const reported = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  body.innerHTML = `
+  <p class="sub" style="margin-bottom:16px">Reported threads appear below. Reported <b>replies</b> are flagged with ⚠ inside their thread
+  (open the thread to hide/delete them). Pin/lock/hide controls also live on each thread page.</p>
+  <div class="list">${reported.map(t => `
+    <div class="list-item">
+      <div class="li-main">
+        <h3>⚠ ${esc(t.title)}</h3>
+        <div class="meta">${esc(catById(t.categoryId)?.name || t.categoryId)} · by ${esc(t.authorName)} · ${timeAgo(t.createdAt)}</div>
+      </div>
+      <div class="li-side" style="flex-direction:row;align-items:center">
+        <a class="btn small" href="#/forum/t/${t.id}">Open</a>
+        <button class="btn small" data-clear="${t.id}">Dismiss report</button>
+        <button class="btn small danger" data-thide="${t.id}">Hide</button>
+      </div>
+    </div>`).join("") || `<div class="empty">No reports — all quiet. 🎉</div>`}</div>`;
+
+  body.querySelectorAll("[data-clear]").forEach(b => b.onclick = async () => {
+    try { await updateDoc(doc(db, "threads", b.dataset.clear), { reported: false }); adminMod(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+  body.querySelectorAll("[data-thide]").forEach(b => b.onclick = async () => {
+    try { await updateDoc(doc(db, "threads", b.dataset.thide), { hidden: true, reported: false }); adminMod(body); }
+    catch (e) { toast(fbError(e)); }
+  });
+}
+
+/* ---------- boot ----------------------------------------------------------- */
+route();

--- a/app/js/firebase-config.js
+++ b/app/js/firebase-config.js
@@ -1,0 +1,25 @@
+/* ==========================================================================
+   Firebase configuration — Academic Platform
+   --------------------------------------------------------------------------
+   1. Create a Firebase project at https://console.firebase.google.com
+   2. Add a Web App (</> icon) and paste its config object below.
+   3. Follow PLATFORM_SETUP.md in the repository root for Auth, Firestore
+      and security-rules setup.
+
+   Until real values are pasted here, the platform runs in "preview mode":
+   all pages render, but forms and the forum are disabled with a notice.
+   ========================================================================== */
+
+window.FIREBASE_CONFIG = {
+  apiKey: "PASTE_YOUR_API_KEY",
+  authDomain: "PASTE_YOUR_PROJECT.firebaseapp.com",
+  projectId: "PASTE_YOUR_PROJECT_ID",
+  storageBucket: "PASTE_YOUR_PROJECT.appspot.com",
+  messagingSenderId: "PASTE_SENDER_ID",
+  appId: "PASTE_APP_ID"
+};
+
+/* Admin accounts — must match the emails listed in firestore.rules.
+   Sign in with one of these (email must be verified; Google sign-in is
+   verified automatically) to see the Admin Dashboard. */
+window.PLATFORM_ADMINS = ["yasassriofficial@gmail.com"];

--- a/blogs.html
+++ b/blogs.html
@@ -114,6 +114,7 @@
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a class="active" href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -127,8 +128,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a class="active" href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/contact.html
+++ b/contact.html
@@ -114,6 +114,7 @@
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a class="active" href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -127,8 +128,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a class="active" href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a class="active" href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,131 @@
+rules_version = '2';
+
+// ============================================================================
+// Firestore security rules — Academic Platform (yasassri.me/app)
+// Deploy: Firebase console → Firestore → Rules → paste & publish,
+// or `firebase deploy --only firestore:rules`. See PLATFORM_SETUP.md.
+//
+// IMPORTANT: keep the admin email list below in sync with
+// window.PLATFORM_ADMINS in app/js/firebase-config.js.
+// ============================================================================
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() { return request.auth != null; }
+    function isVerified() { return isSignedIn() && request.auth.token.email_verified == true; }
+    function isAdmin() {
+      return isVerified()
+        && request.auth.token.email.lower() in ['yasassriofficial@gmail.com'];
+    }
+    function noHoneypot() { return request.resource.data.get('website', '') == ''; }
+    function changedOnly(keys) {
+      return request.resource.data.diff(resource.data).affectedKeys().hasOnly(keys);
+    }
+
+    // ---- Consultation requests --------------------------------------------
+    match /consultations/{id} {
+      allow read: if isAdmin() || (isSignedIn() && resource.data.uid == request.auth.uid);
+      allow create: if isVerified()
+        && noHoneypot()
+        && request.resource.data.uid == request.auth.uid
+        && request.resource.data.status == 'pending'
+        && request.resource.data.name is string && request.resource.data.name.size() > 0 && request.resource.data.name.size() <= 120
+        && request.resource.data.email is string && request.resource.data.email.size() <= 200
+        && request.resource.data.topic is string
+        && request.resource.data.topic.size() >= 100 && request.resource.data.topic.size() <= 3000
+        && request.resource.data.goals is string && request.resource.data.goals.size() <= 2000
+        && request.resource.data.slots is list
+        && request.resource.data.slots.size() >= 1 && request.resource.data.slots.size() <= 3;
+      // Owners may only cancel; the admin may do anything.
+      allow update: if isAdmin()
+        || (isSignedIn() && resource.data.uid == request.auth.uid
+            && changedOnly(['status'])
+            && request.resource.data.status == 'cancelled');
+      allow delete: if isAdmin();
+    }
+
+    // ---- Speaking / talk invitations (public form) ------------------------
+    match /invitations/{id} {
+      allow create: if noHoneypot()
+        && request.resource.data.status == 'pending'
+        && request.resource.data.organizerName is string
+        && request.resource.data.organizerName.size() > 0 && request.resource.data.organizerName.size() <= 120
+        && request.resource.data.email is string
+        && request.resource.data.email.matches('.+@.+\\..+') && request.resource.data.email.size() <= 200
+        && request.resource.data.eventName is string
+        && request.resource.data.eventName.size() > 0 && request.resource.data.eventName.size() <= 200
+        && request.resource.data.message is string && request.resource.data.message.size() <= 3000;
+      allow read, update, delete: if isAdmin();
+    }
+
+    // ---- Newsletter subscribers (doc id = lowercased email) ----------------
+    match /subscribers/{email} {
+      allow create: if noHoneypot()
+        && request.resource.data.email == email
+        && request.resource.data.email.matches('.+@.+\\..+')
+        && request.resource.data.email.size() <= 200
+        && request.resource.data.status == 'subscribed'
+        && request.resource.data.name is string && request.resource.data.name.size() <= 120;
+      allow read, update, delete: if isAdmin();
+    }
+
+    // ---- Blog posts ---------------------------------------------------------
+    match /posts/{id} {
+      allow read: if resource.data.status == 'published' || isAdmin();
+      allow create, update, delete: if isAdmin();
+    }
+
+    // ---- Member profiles ----------------------------------------------------
+    match /profiles/{uid} {
+      allow read: if true;
+      allow create, update: if isSignedIn() && request.auth.uid == uid;
+      allow delete: if isAdmin();
+    }
+
+    // ---- Forum ---------------------------------------------------------------
+    match /threads/{tid} {
+      allow read: if true;
+      allow create: if isVerified()
+        && request.resource.data.uid == request.auth.uid
+        && request.resource.data.title is string
+        && request.resource.data.title.size() > 0 && request.resource.data.title.size() <= 200
+        && request.resource.data.body is string
+        && request.resource.data.body.size() > 0 && request.resource.data.body.size() <= 8000
+        && request.resource.data.replyCount == 0
+        && request.resource.data.pinned == false
+        && request.resource.data.locked == false
+        && request.resource.data.hidden == false
+        && request.resource.data.reported == false
+        && (request.resource.data.categoryId != 'announcements' || isAdmin());
+      allow update: if isAdmin()
+        // reply-counter bump when anyone posts a reply
+        || (isVerified() && changedOnly(['replyCount', 'lastReplyAt']))
+        // anyone signed-in may flag a thread
+        || (isSignedIn() && changedOnly(['reported']) && request.resource.data.reported == true)
+        // authors may edit their own title/body
+        || (isSignedIn() && resource.data.uid == request.auth.uid
+            && changedOnly(['title', 'body', 'updatedAt']));
+      allow delete: if isAdmin();
+
+      match /replies/{rid} {
+        allow read: if true;
+        allow create: if isVerified()
+          && request.resource.data.uid == request.auth.uid
+          && request.resource.data.body is string
+          && request.resource.data.body.size() > 0 && request.resource.data.body.size() <= 6000
+          && get(/databases/$(database)/documents/threads/$(tid)).data.locked != true;
+        allow update: if isAdmin()
+          || (isSignedIn() && changedOnly(['reported']) && request.resource.data.reported == true)
+          || (isSignedIn() && resource.data.uid == request.auth.uid
+              && changedOnly(['body', 'updatedAt']));
+        allow delete: if isAdmin();
+      }
+    }
+
+    // Deny everything else by default.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -174,8 +175,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <!-- HERO -->
@@ -325,7 +327,7 @@
     <div class="newsletter reveal">
       <h3>Want Research Notes &amp; Field Insights?</h3>
       <p>Occasional notes on immersive media, spatial computing, and lessons from building XR — no noise.</p>
-      <form class="nl-form" onsubmit="return false;">
+      <form class="nl-form" onsubmit="location.href='app/#/newsletter?email='+encodeURIComponent(this.querySelector('input').value);return false;">
         <input type="email" placeholder="Enter your email address" aria-label="Email address"/>
         <button class="btn btn-solid" type="submit">Subscribe</button>
       </form>
@@ -388,7 +390,7 @@
 
     </div>
     <div class="reveal" style="text-align:center; margin-top:36px;">
-      <a class="btn btn-solid" href="contact.html?subject=speaking">Invite Me to Speak <span class="arrow">→</span></a>
+      <a class="btn btn-solid" href="app/#/invite">Invite Me to Speak <span class="arrow">→</span></a>
     </div>
   </div>
 </section>
@@ -554,7 +556,7 @@
       <div class="footer-news">
         <h3>Stay in the loop</h3>
         <p>Join my research notes for occasional insights on AR, XR and immersive media.</p>
-        <form class="nl-form" onsubmit="return false;">
+        <form class="nl-form" onsubmit="location.href='app/#/newsletter?email='+encodeURIComponent(this.querySelector('input').value);return false;">
           <input type="email" placeholder="Your email address" aria-label="Email address"/>
           <button class="btn btn-solid" type="submit">Join</button>
         </form>

--- a/llms.txt
+++ b/llms.txt
@@ -25,12 +25,13 @@ This file follows the llms.txt convention (https://llmstxt.org) to help AI assis
 - [News](https://www.yasassri.me/news.html): Upcoming events (CODE with WIE 2026 workshop, 11 July 2026; NZGDC 2026 talk, 1 October 2026), invited talks, media, international collaborations (e.g. Tohoku University research visit, Falling Walls Lab NZ), and how to invite him for a talk or workshop.
 - [Writing](https://www.yasassri.me/blogs.html): Essays on AR, spatial computing, and software engineering.
 - [Contact](https://www.yasassri.me/contact.html): For research collaborations, guest talks, and consulting.
+- [Platform](https://www.yasassri.me/app/): Interactive academic platform — free consultation booking (education, research, career mentoring), speaker-invitation requests with a talk-topics catalogue, blog, newsletter signup, and a student community forum.
 
 ## Upcoming events
 
 - CODE with WIE 2026 — Workshop 01: "Architecting the Augmented Tomorrow" — 11 July 2026, 9:00 AM, online via Google Meet. Hosted by IEEE Women in Engineering Sri Lanka. Details: https://www.yasassri.me/news.html#upcoming
 - NZGDC 2026 — "Designing Shared Worlds Across Distance: Lessons from Multiplayer AR Game Research" — 1 October 2026, 3:00–3:30 PM, NZ International Convention Centre, Auckland, New Zealand. Details: https://www.yasassri.me/news.html#upcoming
-- To invite Yasas Sri Wickramasinghe for a similar talk, workshop, or seminar: https://www.yasassri.me/contact.html?subject=speaking
+- To invite Yasas Sri Wickramasinghe for a similar talk, workshop, or seminar: https://www.yasassri.me/app/#/invite
 
 ## Web products (built by Yasas Sri Wickramasinghe)
 

--- a/news.html
+++ b/news.html
@@ -206,6 +206,7 @@
       <a href="products.html">Products</a>
       <a class="active" href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -219,8 +220,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a class="active" href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/products.html
+++ b/products.html
@@ -227,6 +227,7 @@
       <a class="active" href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -240,8 +241,9 @@
   <a class="active" href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/research.html
+++ b/research.html
@@ -114,6 +114,7 @@
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -127,8 +128,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -42,4 +42,10 @@
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://www.yasassri.me/app/</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/teaching.html
+++ b/teaching.html
@@ -114,6 +114,7 @@
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform</a>
       <a href="contact.html">Contact</a>
       <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
     </div>
@@ -127,8 +128,9 @@
   <a href="products.html"><span class="idx">04</span>Products</a>
   <a href="news.html"><span class="idx">05</span>News</a>
   <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="contact.html"><span class="idx">07</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">08</span>Curriculum Vitae</a>
+  <a href="app/#/"><span class="idx">07</span>Platform</a>
+  <a href="contact.html"><span class="idx">08</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">


### PR DESCRIPTION
Keeps the existing site untouched as the landing experience and adds a
hash-routed single-page app at /app/ that deploys on GitHub Pages with
no build step, backed by Firebase Auth + Firestore:

- Free consultation booking: 4 configurable types, structured intake
  (topic ≥100 chars, goals, links, mode, auto-detected timezone, up to
  3 preferred times), verified-email requirement, 2-open-request limit,
  status tracking (pending/approved/declined/completed/cancelled) and
  self-service cancel
- "Invite Me" speaker page: talk-topics catalogue, past/upcoming
  engagements, and a public invitation form capturing event, logistics,
  travel and honorarium details
- Blog: Markdown authoring with categories, tags, drafts, reading time,
  safe client-side renderer, and per-post "Discuss in the Forum" links
- Newsletter: segmented signup (student/researcher/professional) with
  honeypot protection and admin CSV export
- Community forum: 8 seeded categories (incl. admin-only Announcements
  and members-only Course Help), threads + replies, reports, pin/lock/
  hide moderation, community guidelines page
- Admin dashboard (owner email gated): request queues, blog editor,
  subscriber management, moderation queue, overview stats
- Firestore security rules enforcing all access control server-side
- Preview mode: everything renders gracefully before Firebase is
  configured or if the SDK CDN is unreachable

Site integration: "Platform" nav link on all pages, homepage newsletter
forms hand off to the app with email prefilled, "Invite Me to Speak"
CTA routes to the invitation pipeline, sitemap + llms.txt updated.
Setup instructions in PLATFORM_SETUP.md (~15 min, free Firebase tier).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UmhnktaNLFhUMouMdzTSHH