### PR TITLE
Wire in real event photography, replacing stock/generic imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
     </div>
     <div class="casework reveal">
       <div class="casework-img">
-        <img src="assets/images/case-immersive.jpg" alt="A player wearing a headset to experience a location-based augmented reality game"/>
+        <img src="assets/images/yasas-ar-glasses.jpg" alt="Dr. Yasas Sri Wickramasinghe wearing AR eye-tracking glasses and reviewing a location-based AR scene on a tablet"/>
       </div>
       <div class="casework-body">
         <span class="tag-line">Entertainment Computing · Elsevier · 2025</span>
@@ -466,7 +466,7 @@
       </a>
 
       <a class="article-card reveal" style="--d:.1s" href="news.html">
-        <div class="article-cover" data-num="—03"><img class="cover-img" src="assets/images/news/nzgdc-ar-panel.jpg" alt="Yasas Sri Wickramasinghe on the AR game development panel at the New Zealand Game Developers Conference 2023" loading="lazy"><span class="cat">NZGDC 2023</span></div>
+        <div class="article-cover" data-num="—03"><img class="cover-img" src="assets/images/news/nzgdc-2023-panel.jpg" alt="Yasas Sri Wickramasinghe presenting on the AR game development panel at NZGDC 2023, alongside fellow panelists" loading="lazy"><span class="cat">NZGDC 2023</span></div>
         <div class="article-body">
           <span class="src">YouTube · Panel</span>
           <h3>Talking AR Game Design on the National Stage</h3>

--- a/news.html
+++ b/news.html
@@ -339,7 +339,7 @@
       </a>
 
       <a class="article-card reveal" style="--d:.05s" href="https://www.youtube.com/watch?v=Sj7ZjsN-ue4" target="_blank" rel="noopener">
-        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/news/nzgdc-ar-panel.jpg" alt="Yasas Sri Wickramasinghe on the AR game development panel at the New Zealand Game Developers Conference 2023" loading="lazy"><span class="cat">NZGDC 2023</span></div>
+        <div class="article-cover" data-num="—02"><img class="cover-img" src="assets/images/news/nzgdc-2023-panel.jpg" alt="Yasas Sri Wickramasinghe presenting on the AR game development panel at NZGDC 2023, alongside fellow panelists" loading="lazy"><span class="cat">NZGDC 2023</span></div>
         <div class="article-body">
           <span class="src">YouTube · Panel</span>
           <h3>The First Annual NZGDC AR Game Dev Rant</h3>
@@ -359,9 +359,9 @@
     </div>
 
     <!-- Embedded featured video -->
-    <div class="feature-row reveal" style="border-bottom:none; margin-top:18px;">
+    <div class="feature-row reveal" style="border-bottom:none; margin-top:18px; padding-bottom:0;">
       <div class="feature-media yt-facade" style="aspect-ratio:16/9;" data-yt="Sj7ZjsN-ue4" role="button" tabindex="0" aria-label="Play video: Talking AR Game Design on the National Stage — NZGDC 2023 AR Game Dev Rant panel">
-        <img src="assets/images/news/nzgdc-ar-panel.jpg" alt="NZGDC 2023 AR Game Dev Rant panel title slide — ‘A World of Chaos: Assorted Rants from AR Game Devs’" loading="lazy"/>
+        <img src="assets/images/news/nzgdc-2023-stream.jpg" alt="NZGDC 2023 livestream frame showing a location-based AR demo — a forest scene with an AR character and the prompt ‘Find the Ground to collect Grass!!’" loading="lazy"/>
         <span class="yt-play-btn" aria-hidden="true"></span>
       </div>
       <div>
@@ -369,6 +369,21 @@
         <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Talking AR Game Design on the National Stage</h3>
         <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">I joined a panel of New Zealand augmented reality developers for the first-ever AR Game Dev Rant at NZGDC — a candid, fast-paced conversation about what it really takes to design and ship location-based AR experiences, alongside Evie, Melanie and Devi.</p>
         <div class="tags"><span class="tag">Panel</span><span class="tag">AR Game Design</span><span class="tag">Community</span></div>
+      </div>
+    </div>
+
+    <!-- More from the same talk -->
+    <div class="reveal" style="margin-top:28px;">
+      <span style="display:block; font-family:var(--mono); font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--muted); margin-bottom:14px;">More from the panel</span>
+      <div class="grid-2">
+        <div style="position:relative; border-radius:6px; overflow:hidden; border:1px solid var(--line); aspect-ratio:16/10;">
+          <img src="assets/images/news/nzgdc-2023-lidar-talk.jpg" alt="Yasas Sri Wickramasinghe presenting ‘Creating Sharable Spaces with Lidar’ at NZGDC 2023, with the audience in the foreground" loading="lazy" style="width:100%; height:100%; object-fit:cover;"/>
+          <span style="position:absolute; bottom:14px; left:14px; font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; background:rgba(11,11,13,.7); backdrop-filter:blur(8px); padding:8px 14px; border-radius:3px; color:var(--text-dim);">Creating Sharable Spaces with Lidar</span>
+        </div>
+        <div style="position:relative; border-radius:6px; overflow:hidden; border:1px solid var(--line); aspect-ratio:16/10;">
+          <img src="assets/images/news/nzgdc-2023-panel.jpg" alt="Yasas Sri Wickramasinghe on stage with fellow panelists Evie, Melanie and Devi at the NZGDC 2023 AR Game Dev Rant" loading="lazy" style="width:100%; height:100%; object-fit:cover; object-position:center 30%;"/>
+          <span style="position:absolute; bottom:14px; left:14px; font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; background:rgba(11,11,13,.7); backdrop-filter:blur(8px); padding:8px 14px; border-radius:3px; color:var(--text-dim);">On stage with the panel</span>
+        </div>
       </div>
     </div>
   </div>

--- a/research.html
+++ b/research.html
@@ -215,6 +215,17 @@
       <p>Each study sharpens the next, building from how a remote place should look, to how players behave inside it, to the mechanics that make distributed play meaningful.</p>
     </div>
 
+    <div class="feature-row reveal" style="border-bottom:1px solid var(--line); padding-top:0; margin-bottom:8px;">
+      <div class="feature-media">
+        <img src="assets/images/news/ar-view-modes.jpg" alt="The three AR representations compared in Study 01: Window, Overlay and Tabletop views of the same remote room, each with a shared health-bar HUD"/>
+      </div>
+      <div>
+        <span class="eyebrow">Study 01 Stimuli</span>
+        <h3 style="font-family:var(--serif); font-size:clamp(24px,3vw,34px); font-weight:400; line-height:1.25; margin-top:18px;">Window, Overlay &amp; Tabletop</h3>
+        <p style="color:var(--text-dim); font-weight:300; margin-top:16px;">The three AR techniques compared in Study 01 — each renders the same remote room differently. <strong>Window</strong> frames it as a portal players walk toward; <strong>Overlay</strong> extends it directly into the player's own space; <strong>Tabletop</strong> shrinks it to a detached, strategic miniature.</p>
+      </div>
+    </div>
+
     <div class="grid-3">
       <div class="card reveal">
         <span class="kicker">Study 01 · RQ1</span>


### PR DESCRIPTION
- Home "Selected Research & Deployments": case-immersive.jpg (generic headset stock photo) -> yasas-ar-glasses.jpg, a real photo of Yasas wearing AR eye-tracking glasses reviewing a scene on a tablet
- Research "Three studies": added a feature-row above the study grid using the Window/Overlay/Tabletop tri-panel diagram (ar-view-modes.jpg) as the actual Study 01 stimuli -- it's the real comparison image, not an illustration
- Home + News NZGDC 2023 card and video facade: nzgdc-ar-panel.jpg (a generic title-slide graphic) -> nzgdc-2023-panel.jpg, the real photo of Yasas on stage with fellow panelists; the video facade now shows the nzgdc-2023-stream.jpg livestream frame with the live AR gameplay demo instead of a static slide
- News "Talks & Media": added a "More from the panel" two-image gallery (nzgdc-2023-lidar-talk.jpg, nzgdc-2023-panel.jpg) beneath the featured video, following the same bordered/captioned pattern already used for the campus photo on the contact page

Retired assets/images/case-immersive.jpg and nzgdc-ar-panel.jpg from all markup (grep-verified no remaining references). Verified in Chromium: all crops render as intended at 1280px, no horizontal overflow at 390px, no console errors.


Claude-Session: https://claude.ai/code/session_01AwjujnheyfgiJK5zaU9wWK