### PR TITLE
Fix nav badge wrapping and mobile overflow from inline grid overrides

### DIFF
--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -119,15 +119,15 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
 }
 .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; line-height: 1.15; }
 .nav-logo em { color: var(--accent); font-style: normal; }
-.nav-links { display: flex; align-items: center; gap: 28px; }
-.nav-links a { font-size: 14px; font-weight: 500; color: var(--ink-soft); transition: color .25s; }
+.nav-links { display: flex; align-items: center; gap: clamp(14px, 1.7vw, 28px); flex-wrap: nowrap; }
+.nav-links a { font-size: 14px; font-weight: 500; color: var(--ink-soft); transition: color .25s; white-space: nowrap; }
 .nav-links a:hover, .nav-links a.active { color: var(--ink); }
 .nav-links a.btn { color: #fff; }
 .nav-links a.btn:hover { color: #fff; }
 .nav-badge {
   display: inline-block; font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em;
   color: #fff; background: var(--accent); border-radius: 999px;
-  padding: 1px 6px; margin-left: 5px; vertical-align: 2px;
+  padding: 1px 6px; margin-left: 5px; vertical-align: 2px; white-space: nowrap;
 }
 .mobile-menu .nav-badge { vertical-align: 1px; }
 
@@ -264,6 +264,7 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
 .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .features-4 { grid-template-columns: repeat(4, 1fr); }
 @media (max-width: 1040px) { .features-4 { grid-template-columns: repeat(2, 1fr); } }
+.split-wide-left { grid-template-columns: 1.3fr 1fr; }
 .feature {
   position: relative;
   background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
@@ -401,9 +402,11 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
 @media (max-width: 1040px) {
   .hero-float { width: 270px; }
 }
-@media (max-width: 940px) {
+@media (max-width: 1140px) {
   .nav-links { display: none; }
   .nav-toggle { display: flex; }
+}
+@media (max-width: 940px) {
   /* Hero reflows to a single column: name → cutout → cards */
   .hero-stage { height: auto; flex-direction: column; align-items: center; gap: 4px; margin-top: 4px; }
   .hero-name { position: static; transform: none; order: 1; margin-bottom: -6%; }
@@ -418,6 +421,7 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
 }
 @media (max-width: 560px) {
   .features, .tgrid { grid-template-columns: 1fr; }
+  .features-4 { grid-template-columns: 1fr; }
   .nl-form { flex-direction: column; }
   .nl-form input { border-radius: 999px; height: var(--control-h); }
   .footer-top { grid-template-columns: 1fr 1fr; }
@@ -591,7 +595,7 @@ footer { background: var(--bg-soft); border-top: 1px solid var(--line); }
 .footer-links a:hover { color: var(--accent); }
 
 @media (max-width: 940px) {
-  .feature-row, .split, .grid-2, .grid-3, .form-row { grid-template-columns: 1fr; }
+  .feature-row, .split, .split-wide-left, .grid-2, .grid-3, .form-row { grid-template-columns: 1fr; }
   .feature-row:nth-child(even) .feature-media { order: -1; }
   .sticky-col { position: static; }
   .pub-row { grid-template-columns: 1fr; gap: 8px; }

--- a/contact.html
+++ b/contact.html
@@ -146,7 +146,7 @@
 
 <section class="section" style="padding-bottom:0">
   <div class="container">
-    <div class="features" style="grid-template-columns:repeat(3,1fr)">
+    <div class="features">
       <a class="feature reveal" href="app/#/consult" style="display:block;--d:0s">
         <div class="ic"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg></div>
         <h3>Book a Free Consultation</h3>
@@ -167,7 +167,7 @@
 </section>
 
 <section class="section">
-  <div class="container split" style="grid-template-columns: 1.3fr 1fr;">
+  <div class="container split split-wide-left">
 
     <form class="form-grid reveal" id="contactForm" action="https://formspree.io/f/xleookvv" method="post">
       <div class="form-row">


### PR DESCRIPTION
11Nav: the "Platform New" badge could wrap onto a second line on mid-width viewports (~940-1140px) because .nav-links had no white-space:nowrap and a fixed 28px gap, so the anchor's own flex item would shrink and wrap its content. Fixed by making nav link text non-wrapping, using a responsive gap, and moving the hamburger-menu breakpoint from 940px to 1140px so the nav switches to mobile before it gets cramped.

Mobile layout: the CTA cards added to index.html and contact.html used inline style="grid-template-columns:repeat(N,1fr)", which has higher CSS specificity than the stylesheet's mobile media queries and so defeated the collapse-to-1-column behavior entirely. On a phone this caused real horizontal overflow and squeezed, cramped card text. Replaced the inline overrides with proper classes (.features-4, .split-wide-left) that carry their own responsive rules, matching how every other grid on the site already behaves. This also fixed a pre-existing instance of the same bug on contact.html's main form/sidebar layout (inline 1.3fr/1fr split), which never collapsed to one column on mobile before this fix either.

Verified via headless screenshots at 375px width: scrollWidth now matches viewport width (no overflow) and all cards/sections stack cleanly in a single column.


Claude-Session: https://claude.ai/code/session_01UmhnktaNLFhUMouMdzTSHH