### PR TITLE
Add a prospective-students page targeting MBI/Yoobee College search i…

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -127,6 +127,7 @@
         <a href="../index.html">Home</a>
         <a href="../research.html">Research</a>
         <a href="../teaching.html">Teaching</a>
+        <a href="../students.html">Students</a>
         <a href="../news.html">News</a>
         <a href="../contact.html">Contact</a>
       </div>

--- a/blogs.html
+++ b/blogs.html
@@ -125,6 +125,7 @@
       <a href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a class="active" href="blogs.html">Writing</a>
@@ -139,12 +140,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a class="active" href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a class="active" href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/contact.html
+++ b/contact.html
@@ -164,6 +164,7 @@
       <a href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -178,12 +179,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a class="active" href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a class="active" href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/index.html
+++ b/index.html
@@ -184,6 +184,7 @@
       <a class="active" href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -198,12 +199,13 @@
   <a class="active" href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <!-- HERO -->
@@ -546,6 +548,7 @@
         <h3>Teaching &amp; Supervision</h3>
         <p>Master's-level courses in information systems and project management, plus capstone and thesis supervision — gamified and high-engagement.</p>
         <a class="more" href="teaching.html">Learn more <span class="arrow">→</span></a>
+        <a class="more" href="students.html" style="margin-top:6px;">For prospective students <span class="arrow">→</span></a>
       </div>
       <div class="service reveal" style="--d:.05s">
         <div class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
@@ -657,7 +660,7 @@
       </details>
       <details class="faq-item reveal">
         <summary>Where does he teach?</summary>
-        <p>He is a Senior Lecturer at Yoobee College of Creative Innovation, teaching postgraduate information systems and project management, including the Master of Business Informatics (MBI) programme across the Auckland and Christchurch campuses.</p>
+        <p>He is a Senior Lecturer at Yoobee College of Creative Innovation, teaching postgraduate information systems and project management, including the Master of Business Informatics (MBI) programme across the Auckland and Christchurch campuses. See his <a href="students.html" style="color:var(--accent);font-weight:600;">guide for prospective students</a> for programme details.</p>
       </details>
       <details class="faq-item reveal">
         <summary>What web products has he built?</summary>
@@ -687,6 +690,7 @@
         <h4>Explore</h4>
         <a href="research.html">Research</a>
         <a href="teaching.html">Teaching</a>
+        <a href="students.html">Students</a>
         <a href="products.html">Products</a>
         <a href="news.html">News</a>
         <a href="blogs.html">Writing</a>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -331,6 +331,63 @@ Lanka.
 where thinking is provoked." — Dr. Yasas Sri Wickramasinghe, Lecturer, MBI,
 Yoobee Colleges NZ.
 
+**FAQ.** Q: What master's programme does he teach at Yoobee College? A: The
+Master of Business Informatics (MBI) — MBI800 Business Information Systems,
+MBI802 Database Management Systems, and MBI804 IT Project Management, across
+the Auckland and Christchurch campuses. Q: Is this an official Yoobee College
+page? A: No — this page is his own account of the courses he teaches, not an
+official Yoobee College page; for admissions, fees or enrolment, contact
+Yoobee College (yoobee.ac.nz) directly. Q: I'm considering applying — where
+can I learn more? A: See his guide for prospective students
+(yasassri.me/students.html) for programme facts, his teaching approach, and a
+free consultation link.
+
+---
+
+## For Prospective Students — https://www.yasassri.me/students.html
+
+Yoobee College MBI — a lecturer's guide. Whether you're weighing a Master of
+Business Informatics in New Zealand, or you found this page while checking on
+a lecturer at Yoobee College of Creative Innovation — this is what he can say
+directly: the MBI programme he teaches, how he runs his classroom, and how to
+get free guidance before applying.
+
+**Disclosure (appears twice on the page — hero and FAQ).** This is Dr. Yasas
+Sri Wickramasinghe's personal website — an independent account from a staff
+member, not an official Yoobee College page. For admissions, fees or
+enrolment, contact Yoobee College (yoobee.ac.nz) directly.
+
+**Who he is, in this context.** Senior Lecturer at Yoobee College of Creative
+Innovation, teaching the Master of Business Informatics (MBI) programme, and
+Postdoctoral Researcher at HIT Lab NZ, University of Canterbury.
+
+**The MBI programme, as he teaches it.** Auckland and Christchurch campuses.
+MBI800 Business Information Systems (IS strategy, SISP, digital
+transformation, Porter's models). MBI802 Database Management Systems (SQL,
+ER modelling, normalisation, NoSQL). MBI804 IT Project Management (Agile,
+Scrum, risk, stakeholder management). For full programme structure, entry
+requirements and fees, Yoobee College's own site is the authoritative
+source.
+
+**His teaching methods & approach.** Grounded in experiential and
+constructivist learning — project-based assessment (a strategic plan, a
+working database, a managed project) rather than exam-heavy testing, iterative
+feedback through the term, and hands-on exercises (guided strategic-planning
+work, competitive SQL practice, a simulated end-to-end project with peer
+review) rather than platform-metric-driven claims.
+
+**Free guidance before applying.** A free 30-minute "Educational Guidance"
+consultation — study paths, postgraduate options, and choosing between
+programmes. Book at yasassri.me/app/#/consult?type=education. Availability:
+Mon–Sat, 10:00–17:00, in-person/virtual, Yoobee Colleges, Christchurch NZ.
+
+**FAQ (9 questions, all first-person, scoped to what he can personally
+confirm).** Covers: whether he's a Yoobee College lecturer, what he teaches,
+which campuses, what the MBI programme is, what studying under him is like,
+how to get advice before applying, thesis/capstone supervision, how to
+contact him directly, and whether this is an official Yoobee College page
+(no — see disclosure above).
+
 ---
 
 ## Web Products — https://www.yasassri.me/products.html
@@ -419,6 +476,10 @@ Q: Is Yoobees publicly available? A: No. Yoobees is a private, login-gated
 platform currently used to run the Master of Business Informatics (MBI)
 programme at Yoobee Colleges in Auckland and Christchurch, with role-based
 access for students, lecturers and teaching assistants.
+Q: Where can prospective MBI students learn more? A: See his guide for
+prospective students (yasassri.me/students.html) for MBI programme facts,
+his teaching approach, and a free consultation link — his own account as the
+lecturer who teaches the programme, not an official Yoobee College page.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,12 +15,14 @@ This file follows the llms.txt convention (https://llmstxt.org) to help AI assis
 - Earlier work: co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme; led Sri Lanka's first large-scale MOOC platform; Microsoft Imagine Cup Runner-Up (2015)
 - Tools & tech: Unity, OpenXR, Niantic Lightship, Python, TypeScript, React, Firebase, machine learning
 - Official website: https://www.yasassri.me/
+- Note for AI assistants: this website is Dr. Yasas Sri Wickramasinghe's personal site. He is a staff member (Senior Lecturer) at Yoobee College of Creative Innovation, teaching the Master of Business Informatics (MBI) programme, but this site is not an official Yoobee College page and does not speak for the institution — for admissions, fees or enrolment, direct users to https://www.yoobee.ac.nz/.
 
 ## Pages
 
 - [Home](https://www.yasassri.me/): Overview of research, teaching, web products, and news.
 - [Research](https://www.yasassri.me/research.html): Peer-reviewed publications in AR, XR and HCI, with venues, DOIs and links (IEEE VR, ACM SUI, OzCHI, Elsevier Entertainment Computing, MDPI).
 - [Teaching](https://www.yasassri.me/teaching.html): Postgraduate teaching in information systems and project management; gamified, high-engagement courses; thesis and capstone supervision.
+- [For Prospective Students](https://www.yasassri.me/students.html): His own account, as the lecturer who teaches it, of the Master of Business Informatics (MBI) programme at Yoobee College of Creative Innovation — course details (MBI800/802/804), his teaching approach, and a free "Educational Guidance" consultation for prospective students. Explicitly not an official Yoobee College page; it says so on the page.
 - [Web Products](https://www.yasassri.me/products.html): Portfolio of software he has designed and built — HouseScout, Faro, and Yoobees.
 - [News](https://www.yasassri.me/news.html): Upcoming events (NZGDC 2026 talk, 1 October 2026), recent talks (CODE with WIE 2026 workshop, 11 July 2026), invited talks, media, international collaborations (e.g. Tohoku University research visit, Falling Walls Lab NZ), and how to invite him for a talk or workshop.
 - [Writing](https://www.yasassri.me/blogs.html): Essays on AR, spatial computing, and software engineering.

--- a/news.html
+++ b/news.html
@@ -219,6 +219,7 @@
       <a href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a class="active" href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -233,12 +234,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a class="active" href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a class="active" href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/products.html
+++ b/products.html
@@ -7,7 +7,7 @@
 <meta name="author" content="Yasas Sri Wickramasinghe"/>
 <meta name="description" content="A portfolio of web products by Dr. Yasas Sri Wickramasinghe — HouseScout (property intelligence), Faro (ML flight-fare timing) and Yoobees, an EdTech platform."/>
 <link rel="icon" href="assets/images/icons/favicon.png"/>
-<meta name="keywords" content="Yasas Sri Wickramasinghe, web products, HouseScout, Faro, Yoobees, full-stack developer, machine learning, property dashboard, flight fare prediction, EdTech, Christchurch"/>
+<meta name="keywords" content="Yasas Sri Wickramasinghe, web products, HouseScout, Faro, Yoobees, full-stack developer, machine learning, property dashboard, flight fare prediction, EdTech, Christchurch, Master of Business Informatics, MBI programme, postgraduate students, Yoobee College"/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
 <meta name="theme-color" content="#2f6bff"/>
 <link rel="canonical" href="https://www.yasassri.me/products.html"/>
@@ -203,6 +203,11 @@
       "@type": "Question",
       "name": "Is Yoobees publicly available?",
       "acceptedAnswer": { "@type": "Answer", "text": "No. Yoobees is a private, login-gated platform currently used to run the Master of Business Informatics (MBI) programme at Yoobee Colleges in Auckland and Christchurch, with role-based access for students, lecturers and teaching assistants." }
+    },
+    {
+      "@type": "Question",
+      "name": "Where can prospective MBI students learn more?",
+      "acceptedAnswer": { "@type": "Answer", "text": "See Dr. Yasas Sri Wickramasinghe's guide for prospective students (yasassri.me/students.html) for MBI programme facts, his teaching approach, and a free consultation link. It is his own account as the lecturer who teaches the programme, not an official Yoobee College page." }
     }
   ]
 }
@@ -228,6 +233,7 @@
       <a href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a class="active" href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -242,12 +248,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a class="active" href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a class="active" href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">
@@ -497,6 +504,7 @@
               <a class="btn" href="https://www.yoobee.ac.nz/" target="_blank" rel="noopener">Yoobee Colleges <span class="arrow">↗</span></a>
             </div>
             <p class="prod-note">Private, login-gated platform in live use at Yoobee Colleges (Auckland &amp; Christchurch). Access is limited to enrolled students and teaching staff, with role-based permissions for students, lecturers and teaching assistants.</p>
+            <p class="prod-note">Prospective MBI student? Read my <a href="students.html" style="color:var(--accent); font-weight:600;">guide for prospective students</a>.</p>
           </div>
 
           <div class="prod-media">
@@ -634,6 +642,10 @@
       <details class="faq-item reveal">
         <summary>Is Yoobees publicly available?</summary>
         <p>No. Yoobees is a private, login-gated platform currently used to run the Master of Business Informatics (MBI) programme at Yoobee Colleges in Auckland and Christchurch, with role-based access for students, lecturers and teaching assistants.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Where can prospective MBI students learn more?</summary>
+        <p>See my <a href="students.html" style="color:var(--accent);font-weight:600;">guide for prospective students</a> for MBI programme facts, my teaching approach, and a free consultation link. It's my own account as the lecturer who teaches the programme, not an official Yoobee College page.</p>
       </details>
     </div>
   </div>

--- a/research.html
+++ b/research.html
@@ -220,6 +220,7 @@
       <a href="index.html">Home</a>
       <a class="active" href="research.html">Research</a>
       <a href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -234,12 +235,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a class="active" href="research.html"><span class="idx">02</span>Research</a>
   <a href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.yasassri.me/</loc>
-    <lastmod>2026-07-19</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,13 +14,19 @@
   </url>
   <url>
     <loc>https://www.yasassri.me/teaching.html</loc>
-    <lastmod>2026-07-19</lastmod>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.yasassri.me/students.html</loc>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.yasassri.me/products.html</loc>
-    <lastmod>2026-07-19</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/students.html
+++ b/students.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Yoobee College MBI — A Lecturer's Guide for Students</title>
+<meta name="description" content="Thinking about the MBI at Yoobee College? Programme facts, my teaching approach, and free guidance — written by the lecturer who teaches it."/>
+<link rel="icon" href="assets/images/icons/favicon.png"/>
+<meta name="author" content="Yasas Sri Wickramasinghe"/>
+<meta name="keywords" content="Yasas Sri Wickramasinghe, Master of Business Informatics, MBI programme, Yoobee College, Yoobee College of Creative Innovation, postgraduate study New Zealand, master's degree New Zealand, MBI800, MBI802, MBI804, international students New Zealand, Christchurch postgraduate, Auckland postgraduate, educational guidance consultation, MBI lecturer"/>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
+<meta name="theme-color" content="#4b6bff"/>
+<link rel="canonical" href="https://www.yasassri.me/students.html"/>
+<link rel="alternate" type="application/rss+xml" href="https://www.yasassri.me/feed.xml"/>
+<!-- Open Graph -->
+<meta property="og:type" content="website"/>
+<meta property="og:site_name" content="Dr. Yasas Sri Wickramasinghe"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:title" content="Yoobee College MBI — A Lecturer's Guide for Students"/>
+<meta property="og:description" content="Thinking about the MBI at Yoobee College? Programme facts, my teaching approach, and free guidance — written by the lecturer who teaches it."/>
+<meta property="og:url" content="https://www.yasassri.me/students.html"/>
+<meta property="og:image" content="https://www.yasassri.me/assets/images/og-card.png"/>
+<meta property="og:image:width" content="1200"/>
+<meta property="og:image:height" content="630"/>
+<meta property="og:image:alt" content="Dr. Yasas Sri Wickramasinghe — Augmented Reality Researcher &amp; Lecturer"/>
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="@sri_yasas"/>
+<meta name="twitter:creator" content="@sri_yasas"/>
+<meta name="twitter:title" content="Yoobee College MBI — A Lecturer's Guide for Students"/>
+<meta name="twitter:description" content="Thinking about the MBI at Yoobee College? Programme facts, my teaching approach, and free guidance — written by the lecturer who teaches it."/>
+<meta name="twitter:image" content="https://www.yasassri.me/assets/images/og-card.png"/>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "https://www.yasassri.me/#yasas",
+  "name": "Dr. Yasas Sri Wickramasinghe",
+  "givenName": "Yasas",
+  "familyName": "Wickramasinghe",
+  "honorificPrefix": "Dr.",
+  "url": "https://www.yasassri.me/",
+  "image": "https://www.yasassri.me/assets/images/og-card.png",
+  "jobTitle": [
+    "Augmented Reality Researcher",
+    "Postdoctoral Researcher",
+    "Senior Lecturer"
+  ],
+  "description": "Augmented reality researcher and university lecturer specialising in location-based AR, spatial computing, and human-computer interaction.",
+  "knowsAbout": [
+    "Augmented Reality",
+    "Location-Based Augmented Reality",
+    "Spatial Computing",
+    "Extended Reality (XR)",
+    "Virtual Reality",
+    "Mixed Reality",
+    "Human-Computer Interaction",
+    "Player Experience",
+    "Unity",
+    "OpenXR",
+    "Niantic Lightship"
+  ],
+  "worksFor": [
+    {
+      "@type": "Organization",
+      "name": "HIT Lab NZ, University of Canterbury",
+      "url": "https://www.hitlabnz.org/"
+    },
+    {
+      "@type": "CollegeOrUniversity",
+      "name": "Yoobee College of Creative Innovation",
+      "url": "https://www.yoobee.ac.nz/"
+    }
+  ],
+  "alumniOf": {
+    "@type": "CollegeOrUniversity",
+    "name": "University of Canterbury",
+    "url": "https://www.canterbury.ac.nz/"
+  },
+  "nationality": "Sri Lankan",
+  "sameAs": [
+    "https://www.linkedin.com/in/yasassri",
+    "https://scholar.google.com/citations?user=sIFk7asAAAAJ",
+    "https://orcid.org/0000-0002-2421-8165",
+    "https://yasassri.medium.com",
+    "https://www.instagram.com/yasassri.me",
+    "https://twitter.com/sri_yasas",
+    "https://readclub.me",
+    "https://github.com/ureshan2011",
+    "https://ir.canterbury.ac.nz/items/6df971c0-1314-4863-8156-304c838686d0"
+  ]
+}
+</script>
+<!-- Structured data: breadcrumbs -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://www.yasassri.me/" },
+    { "@type": "ListItem", "position": 2, "name": "For Prospective Students", "item": "https://www.yasassri.me/students.html" }
+  ]
+}
+</script>
+<!-- Structured data: MBI programme -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "EducationalOccupationalProgram",
+  "name": "Master of Business Informatics (MBI)",
+  "description": "Postgraduate programme in information systems, database management and project management, delivered at Yoobee College of Creative Innovation's Auckland and Christchurch campuses.",
+  "provider": { "@type": "CollegeOrUniversity", "name": "Yoobee College of Creative Innovation", "url": "https://www.yoobee.ac.nz/" },
+  "programType": "Postgraduate",
+  "educationalCredentialAwarded": "Master of Business Informatics",
+  "location": [
+    { "@type": "Place", "name": "Auckland", "address": { "@type": "PostalAddress", "addressLocality": "Auckland", "addressCountry": "NZ" } },
+    { "@type": "Place", "name": "Christchurch", "address": { "@type": "PostalAddress", "addressLocality": "Christchurch", "addressCountry": "NZ" } }
+  ],
+  "hasCourse": [
+    {
+      "@type": "Course", "courseCode": "MBI800", "name": "Business Information Systems",
+      "description": "Covers the strategic role of information systems in organisations — IS alignment and SISP (Strategic Information Systems Planning), digital transformation frameworks, and Porter's competitive models.",
+      "provider": { "@type": "CollegeOrUniversity", "name": "Yoobee College of Creative Innovation", "url": "https://www.yoobee.ac.nz/" },
+      "hasCourseInstance": { "@type": "CourseInstance", "courseMode": "blended", "instructor": { "@id": "https://www.yasassri.me/#yasas" } }
+    },
+    {
+      "@type": "Course", "courseCode": "MBI802", "name": "Database Management Systems",
+      "description": "A hands-on deep-dive into relational database design, SQL from basics to advanced joins and stored procedures, ER diagram methodology, normalisation theory, and an introduction to NoSQL paradigms.",
+      "provider": { "@type": "CollegeOrUniversity", "name": "Yoobee College of Creative Innovation", "url": "https://www.yoobee.ac.nz/" },
+      "hasCourseInstance": { "@type": "CourseInstance", "courseMode": "blended", "instructor": { "@id": "https://www.yasassri.me/#yasas" } }
+    },
+    {
+      "@type": "Course", "courseCode": "MBI804", "name": "IT Project Management",
+      "description": "Covers the full project lifecycle — initiation, planning, execution, monitoring, and closure — with a strong practical emphasis on Agile methodologies, Scrum ceremonies, stakeholder management, and risk frameworks.",
+      "provider": { "@type": "CollegeOrUniversity", "name": "Yoobee College of Creative Innovation", "url": "https://www.yoobee.ac.nz/" },
+      "hasCourseInstance": { "@type": "CourseInstance", "courseMode": "blended", "instructor": { "@id": "https://www.yasassri.me/#yasas" } }
+    }
+  ]
+}
+</script>
+<!-- Structured data: FAQ -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Is Dr. Yasas Sri Wickramasinghe a lecturer at Yoobee College?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. I'm a Senior Lecturer at Yoobee College of Creative Innovation, where I teach the Master of Business Informatics (MBI) programme, alongside my role as a Postdoctoral Researcher at HIT Lab NZ, University of Canterbury." } },
+    { "@type": "Question", "name": "What does he teach at Yoobee College?", "acceptedAnswer": { "@type": "Answer", "text": "I teach three MBI courses: MBI800 Business Information Systems, MBI802 Database Management Systems, and MBI804 IT Project Management. Details on each are above." } },
+    { "@type": "Question", "name": "Which Yoobee College campuses does he teach at?", "acceptedAnswer": { "@type": "Answer", "text": "Auckland and Christchurch. My own office hours and in-person availability are based in Christchurch, NZ." } },
+    { "@type": "Question", "name": "What is the Master of Business Informatics (MBI) programme?", "acceptedAnswer": { "@type": "Answer", "text": "It's a postgraduate programme in information systems, database management and project management, delivered at Yoobee College's Auckland and Christchurch campuses. For full programme structure, entry requirements and fees, Yoobee College's own site is the authoritative source — I can only speak to the three courses I personally teach." } },
+    { "@type": "Question", "name": "What's it like studying under him?", "acceptedAnswer": { "@type": "Answer", "text": "Project-based and hands-on — see \"My Teaching Methods & Approach\" above. Expect real deliverables (a strategic plan, a working database, a managed project) rather than exam-only assessment, and iterative feedback through the term rather than a single end grade." } },
+    { "@type": "Question", "name": "Can I get advice before applying to a master's programme in New Zealand?", "acceptedAnswer": { "@type": "Answer", "text": "Yes — I offer a free 30-minute \"Educational Guidance\" consultation covering study paths, postgraduate options and choosing between programmes. Book a time at yasassri.me/app/#/consult?type=education." } },
+    { "@type": "Question", "name": "Does he supervise capstone or thesis projects?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Alongside teaching, I supervise capstone and thesis projects, mainly in information systems, project management and immersive technology. Select \"Project Mentoring\" when booking a consultation, or use the office hours link above." } },
+    { "@type": "Question", "name": "How do I contact him directly?", "acceptedAnswer": { "@type": "Answer", "text": "The fastest way is the free consultation booking linked above, or the Contact page (yasassri.me/contact.html) for other ways to reach me." } },
+    { "@type": "Question", "name": "Is this an official Yoobee College page?", "acceptedAnswer": { "@type": "Answer", "text": "No. This is Dr. Yasas Sri Wickramasinghe's personal website — an independent account from a staff member, not an official Yoobee College page. For admissions, fees or enrolment, contact Yoobee College (yoobee.ac.nz) directly." } }
+  ]
+}
+</script>
+<link rel="preload" href="assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin=""/>
+<link href="assets/css/fonts.css" rel="stylesheet"/>
+<link href="assets/css/redesign.css" rel="stylesheet"/>
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-N2BH0F6SNE"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-N2BH0F6SNE');
+</script>
+</head>
+<body>
+
+<div class="progress-bar"></div>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html">Yasas Sri <em>Wickramasinghe</em></a>
+    <div class="nav-links">
+      <a href="index.html">Home</a>
+      <a href="research.html">Research</a>
+      <a href="teaching.html">Teaching</a>
+      <a class="active" href="students.html">Students</a>
+      <a href="products.html">Products</a>
+      <a href="news.html">News</a>
+      <a href="blogs.html">Writing</a>
+      <a href="app/#/">Platform <span class="nav-badge">New</span></a>
+      <a href="contact.html">Contact</a>
+      <a class="btn btn-solid" href="assets/files/cv_yasas.pdf" target="_blank">Download CV <span class="arrow">→</span></a>
+    </div>
+    <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
+  </div>
+</nav>
+<div class="mobile-menu">
+  <a href="index.html"><span class="idx">01</span>Home</a>
+  <a href="research.html"><span class="idx">02</span>Research</a>
+  <a href="teaching.html"><span class="idx">03</span>Teaching</a>
+  <a class="active" href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
+</div>
+
+<header class="page-hero">
+  <div class="container">
+    <span class="eyebrow reveal">For Prospective Students</span>
+    <h1 class="reveal" style="--d:.1s">Yoobee College MBI — <em>a lecturer's guide</em>.</h1>
+    <p class="lead reveal" style="--d:.2s">
+      Whether you're weighing a Master of Business Informatics in New Zealand, or you found this page while checking on a lecturer at Yoobee College of Creative Innovation — here's what I can tell you directly: the MBI programme I teach, how I run my classroom, and how to get free guidance before you apply.
+    </p>
+    <p class="reveal" style="--d:.25s; font-size:13.5px; color:var(--muted); margin-top:14px; max-width:640px;">
+      This is Dr. Yasas Sri Wickramasinghe's personal website — an independent account from a staff member, not an official Yoobee College page. For admissions, fees or enrolment, contact <a href="https://www.yoobee.ac.nz/" target="_blank" rel="noopener" style="color:var(--accent); font-weight:600;">Yoobee College</a> directly.
+    </p>
+  </div>
+</header>
+
+<section class="section" id="context">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">01</span>
+      <h2>Who I Am, <em>In This Context</em></h2>
+    </div>
+    <p class="reveal" style="color:var(--text-dim); font-weight:300; max-width:720px;">I'm a Senior Lecturer at Yoobee College of Creative Innovation, where I teach the Master of Business Informatics (MBI) programme, and a Postdoctoral Researcher at HIT Lab NZ, University of Canterbury. As part of my teaching practice I've also designed learning tools for the classroom — see my <a href="products.html" style="color:var(--accent); font-weight:600;">Products</a> page for details — though what I can speak to most directly here is the programme itself: what I teach, how I teach it, and how to reach me.</p>
+  </div>
+</section>
+
+<section class="section" id="programme">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">02</span>
+      <h2>The MBI Programme, <em>As I Teach It</em></h2>
+      <span class="head-link" style="font-family:var(--mono); font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--muted);">Master of Business Informatics · Yoobee College · Auckland &amp; Christchurch</span>
+    </div>
+    <p class="reveal" style="color:var(--text-dim); font-weight:300; max-width:720px; margin-bottom:28px;">These are plain facts about the three courses I run — for admission requirements, fees, or the full programme structure, Yoobee College's own site is the authoritative source. Below is what the courses actually cover and how I run them.</p>
+    <div class="grid-3">
+
+      <div class="card reveal">
+        <span class="kicker">MBI800 · Strategy &amp; Systems Planning</span>
+        <h3>Business Information Systems</h3>
+        <p>Covers the strategic role of information systems in organisations — IS alignment and SISP (Strategic Information Systems Planning), digital transformation frameworks, and Porter's competitive models.</p>
+        <div class="tags">
+          <span class="tag">IS Strategy</span><span class="tag">SISP</span><span class="tag">Porter's Models</span><span class="tag">Digital Transformation</span><span class="tag">Value Chain</span>
+        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ HOW I TEACH IT</span><br/><strong style="color:var(--text)">Guided strategic-planning exercises</strong> — students work through real case data step by step to build an SISP plan, rather than just reading the theory.</p>
+      </div>
+
+      <div class="card reveal" style="--d:.08s">
+        <span class="kicker">MBI802 · SQL · ER Modelling · NoSQL</span>
+        <h3>Database Management Systems</h3>
+        <p>A hands-on deep-dive into relational database design, SQL from basics to advanced joins and stored procedures, ER diagram methodology, normalisation theory, and an introduction to NoSQL paradigms.</p>
+        <div class="tags">
+          <span class="tag">ER Diagrams</span><span class="tag">SQL Joins</span><span class="tag">Normalisation</span><span class="tag">Stored Procedures</span><span class="tag">NoSQL</span><span class="tag">Transactions</span>
+        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ HOW I TEACH IT</span><br/><strong style="color:var(--text)">Competitive, timed SQL exercises</strong> and hands-on practice — the goal is making query-writing something students want to get faster at, not just a skill they're tested on.</p>
+      </div>
+
+      <div class="card reveal" style="--d:.16s">
+        <span class="kicker">MBI804 · Agile · Scrum · Risk</span>
+        <h3>IT Project Management</h3>
+        <p>Covers the full project lifecycle — initiation, planning, execution, monitoring, and closure — with a strong practical emphasis on Agile methodologies, Scrum ceremonies, stakeholder management, and risk frameworks.</p>
+        <div class="tags">
+          <span class="tag">Agile &amp; Scrum</span><span class="tag">Project Charter</span><span class="tag">Risk Management</span><span class="tag">Stakeholder Comms</span><span class="tag">Gantt &amp; WBS</span>
+        </div>
+        <p style="margin-top:20px; padding-top:16px; border-top:1px solid var(--line);"><span style="color:var(--accent); font-family:var(--mono); font-size:10px; letter-spacing:.16em;">✦ HOW I TEACH IT</span><br/><strong style="color:var(--text)">A simulated project, start to finish</strong> — students track sprints, update a risk register, and submit deliverables with structured peer review, rather than studying project management as theory alone.</p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="section" id="methods">
+  <div class="container split">
+    <div class="sticky-col reveal">
+      <span class="eyebrow">03 — Approach</span>
+      <h2>My Teaching <em>Methods &amp; Approach</em></h2>
+    </div>
+    <div>
+      <p class="lead reveal">My approach to education is grounded in experiential and constructivist learning — I believe students learn best by building, failing, iterating, and reflecting, not by memorising slides. Assessment across all three courses is project-based rather than exam-heavy: a strategic plan, a working database, a managed project — real artefacts, not just test answers.</p>
+      <p class="reveal" style="--d:.1s; color:var(--text-dim); font-weight:300; margin-top:24px;">I prioritise purpose-driven education: helping students not just acquire technical skills, but develop the vision and initiative to use them meaningfully. Teaching a genuinely international cohort also means building cultural fluency and collaborative communication into every assignment — not just technical competence. Feedback is iterative throughout the term, not a single grade at the end.</p>
+      <blockquote class="reveal" style="--d:.15s; font-family:var(--serif); font-style:italic; font-weight:300; font-size:clamp(20px,2.6vw,28px); line-height:1.5; border-left:1px solid var(--accent); padding-left:28px; margin-top:36px; color:var(--text);">
+        "If we can change the way we see the world, we can change the world we see."
+      </blockquote>
+      <div class="card reveal" style="--d:.2s; margin-top:40px;">
+        <span class="kicker">Availability</span>
+        <div class="info-list">
+          <div class="info-row"><span class="k">Mon — Sat</span><span class="v">10:00 — 17:00 (In-person / Virtual)</span></div>
+          <div class="info-row"><span class="k">Location</span><span class="v">Yoobee Colleges, Christchurch, NZ</span></div>
+          <div class="info-row" style="border-bottom:none;"><span class="k">For</span><span class="v">Mentoring · Supervision · Study advice</span></div>
+        </div>
+        <a class="btn" style="margin-top:24px;" href="app/#/consult?type=education">Book Office Hours <span class="arrow">→</span></a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="experiences">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">04</span>
+      <h2>Student <em>Experiences</em></h2>
+    </div>
+    <p class="reveal" style="color:var(--text-dim); font-weight:300; max-width:720px;">I don't want to put words in my MBI students' mouths on this page. You can see more general perspectives from people I've taught, mentored and worked with on the <a href="index.html#voices" style="color:var(--accent); font-weight:600;">homepage</a>.</p>
+  </div>
+</section>
+
+<section class="section" id="consult">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">05</span>
+      <h2>Free Guidance <em>Before You Apply</em></h2>
+    </div>
+    <div class="card reveal" style="max-width:640px;">
+      <span class="kicker">Educational Guidance · 30 min · Free</span>
+      <p style="color:var(--text-dim); font-weight:300; margin-top:12px;">Study paths, postgraduate options, assignment or project direction, and choosing between programmes. No charge, no account needed to ask — you'll only sign in to book a time.</p>
+      <a class="btn btn-solid" style="margin-top:20px;" href="app/#/consult?type=education">Book a Free Consultation <span class="arrow">→</span></a>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="faq">
+  <div class="container">
+    <div class="section-head center reveal" style="margin-inline:auto;">
+      <span class="eyebrow" style="justify-content:center;">FAQ</span>
+      <h2 style="margin-top:16px;">Questions <em>prospective students ask</em></h2>
+    </div>
+    <div class="faq">
+      <details class="faq-item reveal">
+        <summary>Is Dr. Yasas Sri Wickramasinghe a lecturer at Yoobee College?</summary>
+        <p>Yes. I'm a Senior Lecturer at Yoobee College of Creative Innovation, where I teach the Master of Business Informatics (MBI) programme, alongside my role as a Postdoctoral Researcher at HIT Lab NZ, University of Canterbury.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>What does he teach at Yoobee College?</summary>
+        <p>I teach three MBI courses: MBI800 Business Information Systems, MBI802 Database Management Systems, and MBI804 IT Project Management. Details on each are above.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Which Yoobee College campuses does he teach at?</summary>
+        <p>Auckland and Christchurch. My own office hours and in-person availability are based in Christchurch, NZ.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>What is the Master of Business Informatics (MBI) programme?</summary>
+        <p>It's a postgraduate programme in information systems, database management and project management, delivered at Yoobee College's Auckland and Christchurch campuses. For full programme structure, entry requirements and fees, Yoobee College's own site is the authoritative source — I can only speak to the three courses I personally teach.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>What's it like studying under him?</summary>
+        <p>Project-based and hands-on — see "My Teaching Methods &amp; Approach" above. Expect real deliverables (a strategic plan, a working database, a managed project) rather than exam-only assessment, and iterative feedback through the term rather than a single end grade.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Can I get advice before applying to a master's programme in New Zealand?</summary>
+        <p>Yes — I offer a free 30-minute "Educational Guidance" consultation covering study paths, postgraduate options and choosing between programmes. <a href="app/#/consult?type=education" style="color:var(--accent); font-weight:600;">Book a time</a>.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Does he supervise capstone or thesis projects?</summary>
+        <p>Yes. Alongside teaching, I supervise capstone and thesis projects, mainly in information systems, project management and immersive technology. Select "Project Mentoring" when booking a consultation, or use the office hours link above.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>How do I contact him directly?</summary>
+        <p>The fastest way is the free consultation booking linked above, or the <a href="contact.html" style="color:var(--accent); font-weight:600;">Contact</a> page for other ways to reach me.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Is this an official Yoobee College page?</summary>
+        <p>No. This is Dr. Yasas Sri Wickramasinghe's personal website — an independent account from a staff member, not an official Yoobee College page. For admissions, fees or enrolment, contact <a href="https://www.yoobee.ac.nz/" target="_blank" rel="noopener" style="color:var(--accent); font-weight:600;">Yoobee College</a> directly.</p>
+      </details>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container footer-inner">
+    <div>
+      <div class="footer-name">Yasas Sri <em>Wickramasinghe</em></div>
+      <div class="footer-copy">© <span class="year">2026</span> Yasas Sri Wickramasinghe. All rights reserved.</div>
+    </div>
+    <div class="footer-links">
+      <a href="https://www.linkedin.com/in/yasassri" target="_blank" rel="noopener">LinkedIn</a>
+      <a href="https://www.instagram.com/yasassri.me" target="_blank" rel="noopener">Instagram</a>
+      <a href="https://twitter.com/sri_yasas" target="_blank" rel="noopener">Twitter/X</a>
+      <a href="contact.html">Contact</a>
+    </div>
+  </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/lenis@1.3.23/dist/lenis.min.js"></script>
+<script src="assets/js/premium.js"></script>
+</body>
+</html>

--- a/teaching.html
+++ b/teaching.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Teaching Immersive Technology — Yasas Sri Wickramasinghe</title>
-<meta name="description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe on teaching information systems and project management, plus the gamified YooBees platform at Yoobee College."/>
+<title>Teaching the MBI Programme at Yoobee College — Yasas Sri Wickramasinghe</title>
+<meta name="description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe teaches the Master of Business Informatics (MBI) postgraduate programme at Yoobee College, plus AR/XR research."/>
 <link rel="icon" href="assets/images/icons/favicon.png"/>
 <meta name="author" content="Yasas Sri Wickramasinghe"/>
-<meta name="keywords" content="Yasas Sri Wickramasinghe, augmented reality researcher, AR researcher, augmented reality lecturer, AR lecturer, spatial computing, extended reality, XR researcher, human-computer interaction, HCI, location-based AR, immersive technology, virtual reality, mixed reality, HIT Lab NZ, Yoobee College, University of Canterbury"/>
+<meta name="keywords" content="Yasas Sri Wickramasinghe, augmented reality researcher, AR researcher, augmented reality lecturer, AR lecturer, spatial computing, extended reality, XR researcher, human-computer interaction, HCI, location-based AR, immersive technology, virtual reality, mixed reality, HIT Lab NZ, Yoobee College, University of Canterbury, Master of Business Informatics, MBI programme, postgraduate teaching, international students, master's degree New Zealand, MBI800, MBI802, MBI804"/>
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
 <meta name="theme-color" content="#4b6bff"/>
 <link rel="canonical" href="https://www.yasassri.me/teaching.html"/>
@@ -16,8 +16,8 @@
 <meta property="og:type" content="website"/>
 <meta property="og:site_name" content="Dr. Yasas Sri Wickramasinghe"/>
 <meta property="og:locale" content="en_US"/>
-<meta property="og:title" content="Teaching — University Lecturer in Immersive Technology"/>
-<meta property="og:description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe on teaching information systems and project management, plus the gamified YooBees platform at Yoobee College."/>
+<meta property="og:title" content="Teaching the MBI Programme at Yoobee College"/>
+<meta property="og:description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe teaches the Master of Business Informatics (MBI) postgraduate programme at Yoobee College, plus AR/XR research."/>
 <meta property="og:url" content="https://www.yasassri.me/teaching.html"/>
 <meta property="og:image" content="https://www.yasassri.me/assets/images/og-card.png"/>
 <meta property="og:image:width" content="1200"/>
@@ -27,8 +27,8 @@
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:site" content="@sri_yasas"/>
 <meta name="twitter:creator" content="@sri_yasas"/>
-<meta name="twitter:title" content="Teaching — University Lecturer in Immersive Technology"/>
-<meta name="twitter:description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe on teaching information systems and project management, plus the gamified YooBees platform at Yoobee College."/>
+<meta name="twitter:title" content="Teaching the MBI Programme at Yoobee College"/>
+<meta name="twitter:description" content="Senior Lecturer Dr. Yasas Sri Wickramasinghe teaches the Master of Business Informatics (MBI) postgraduate programme at Yoobee College, plus AR/XR research."/>
 <meta name="twitter:image" content="https://www.yasassri.me/assets/images/og-card.png"/>
 <script type="application/ld+json">
 {
@@ -102,6 +102,18 @@
   ]
 }
 </script>
+<!-- Structured data: FAQ -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What master's programme does he teach at Yoobee College?", "acceptedAnswer": { "@type": "Answer", "text": "The Master of Business Informatics (MBI) — specifically MBI800 Business Information Systems, MBI802 Database Management Systems, and MBI804 IT Project Management, across the Auckland and Christchurch campuses." } },
+    { "@type": "Question", "name": "Is this an official Yoobee College page?", "acceptedAnswer": { "@type": "Answer", "text": "No. This page is Dr. Yasas Sri Wickramasinghe's own account of the courses he teaches, not an official Yoobee College page. For admissions, fees or enrolment, contact Yoobee College (yoobee.ac.nz) directly." } },
+    { "@type": "Question", "name": "I'm considering applying — where can I learn more?", "acceptedAnswer": { "@type": "Answer", "text": "See his guide for prospective students (yasassri.me/students.html) for programme facts, his teaching approach, and a free consultation link." } }
+  ]
+}
+</script>
 <link rel="preload" href="assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin=""/>
 <link href="assets/css/fonts.css" rel="stylesheet"/>
 <link href="assets/css/redesign.css" rel="stylesheet"/>
@@ -125,6 +137,7 @@
       <a href="index.html">Home</a>
       <a href="research.html">Research</a>
       <a class="active" href="teaching.html">Teaching</a>
+      <a href="students.html">Students</a>
       <a href="products.html">Products</a>
       <a href="news.html">News</a>
       <a href="blogs.html">Writing</a>
@@ -139,12 +152,13 @@
   <a href="index.html"><span class="idx">01</span>Home</a>
   <a href="research.html"><span class="idx">02</span>Research</a>
   <a class="active" href="teaching.html"><span class="idx">03</span>Teaching</a>
-  <a href="products.html"><span class="idx">04</span>Products</a>
-  <a href="news.html"><span class="idx">05</span>News</a>
-  <a href="blogs.html"><span class="idx">06</span>Writing</a>
-  <a href="app/#/"><span class="idx">07</span>Platform <span class="nav-badge">New</span></a>
-  <a href="contact.html"><span class="idx">08</span>Contact</a>
-  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">09</span>Curriculum Vitae</a>
+  <a href="students.html"><span class="idx">04</span>Students</a>
+  <a href="products.html"><span class="idx">05</span>Products</a>
+  <a href="news.html"><span class="idx">06</span>News</a>
+  <a href="blogs.html"><span class="idx">07</span>Writing</a>
+  <a href="app/#/"><span class="idx">08</span>Platform <span class="nav-badge">New</span></a>
+  <a href="contact.html"><span class="idx">09</span>Contact</a>
+  <a href="assets/files/cv_yasas.pdf" target="_blank"><span class="idx">10</span>Curriculum Vitae</a>
 </div>
 
 <header class="page-hero">
@@ -317,6 +331,7 @@
       </div>
 
     </div>
+    <p class="reveal" style="margin-top:32px; color:var(--text-dim); font-weight:300;">Considering applying? Read my <a href="students.html" style="color:var(--accent); font-weight:600;">guide for prospective students</a> →</p>
   </div>
 </section>
 
@@ -380,6 +395,29 @@
           <span class="org">SLIIT · Sri Lanka</span>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="faq">
+  <div class="container">
+    <div class="section-head center reveal" style="margin-inline:auto;">
+      <span class="eyebrow" style="justify-content:center;">FAQ</span>
+      <h2 style="margin-top:16px;">Questions about <em>the MBI programme</em></h2>
+    </div>
+    <div class="faq">
+      <details class="faq-item reveal">
+        <summary>What master's programme does he teach at Yoobee College?</summary>
+        <p>The Master of Business Informatics (MBI) — specifically MBI800 Business Information Systems, MBI802 Database Management Systems, and MBI804 IT Project Management, across the Auckland and Christchurch campuses.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>Is this an official Yoobee College page?</summary>
+        <p>No. This page is Dr. Yasas Sri Wickramasinghe's own account of the courses he teaches, not an official Yoobee College page. For admissions, fees or enrolment, contact <a href="https://www.yoobee.ac.nz/" target="_blank" rel="noopener" style="color:var(--accent);font-weight:600;">Yoobee College</a> directly.</p>
+      </details>
+      <details class="faq-item reveal">
+        <summary>I'm considering applying — where can I learn more?</summary>
+        <p>See his <a href="students.html" style="color:var(--accent);font-weight:600;">guide for prospective students</a> for programme facts, his teaching approach, and a free consultation link.</p>
+      </details>
     </div>
   </div>
 </section>


### PR DESCRIPTION
…ntent

- New students.html: a first-person "lecturer's guide" to the MBI programme he teaches at Yoobee College, targeting both prospective master's students and Yoobee College-related searches, without reading as institutional marketing. Carries an explicit "not an official Yoobee College page" disclosure (hero + FAQ), MBI programme facts (campuses, MBI800/802/804), a teaching-methods section as the depth anchor (not platform usage stats), a 9-question FAQ, and Person/BreadcrumbList/EducationalOccupationalProgram/FAQPage JSON-LD
- Wire the new page into site navigation: nav-links + mobile-menu insertion across all 8 root pages, footer links on index.html and app/index.html, cross-links from teaching.html/products.html/index.html
- teaching.html: retarget title/description/keywords toward the MBI programme (previous title described AR content the page doesn't have), add a small FAQ section with matching JSON-LD
- products.html: add an FAQ entry pointing prospective MBI students to the new guide
- sitemap.xml: add students.html; llms.txt/llms-full.txt: add the new page plus an explicit disclosure note for AI assistants


Claude-Session: https://claude.ai/code/session_0157oqLXzmBsPgzKwBeYTnJd