### PR TITLE
Gate book download behind email request, add open-to-work badge, fill CV gaps

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -316,6 +316,28 @@ a.list-item:hover, .list-item.clickable:hover { border-color: var(--line-strong)
 }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 
+/* ---------- Modal ---------- */
+.modal-scrim {
+  position: fixed; inset: 0; background: rgba(19, 26, 38, 0.55); backdrop-filter: blur(3px);
+  display: flex; align-items: center; justify-content: center; padding: 20px;
+  z-index: 1300; opacity: 0; transition: opacity .25s var(--ease);
+}
+.modal-scrim.show { opacity: 1; }
+.modal-box {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  box-shadow: var(--shadow); padding: 30px; max-width: 420px; width: 100%;
+  text-align: center; transform: translateY(10px) scale(.98); transition: transform .25s var(--ease);
+}
+.modal-scrim.show .modal-box { transform: translateY(0) scale(1); }
+.modal-box .ic {
+  width: 48px; height: 48px; margin: 0 auto 16px; border-radius: 50%;
+  background: var(--accent-soft); color: var(--accent);
+  display: flex; align-items: center; justify-content: center; font-size: 22px;
+}
+.modal-box h3 { font-size: 19px; }
+.modal-box p { margin-top: 10px; color: var(--ink-soft); font-size: 14.5px; line-height: 1.55; }
+.modal-box .btn { margin-top: 20px; width: 100%; justify-content: center; }
+
 /* ---------- Loading ---------- */
 .loading { display: flex; justify-content: center; padding: 60px 0; }
 .spinner {

--- a/app/index.html
+++ b/app/index.html
@@ -146,6 +146,7 @@
 </footer>
 
 <div class="toast" id="toast" role="status"></div>
+<div class="modal-scrim" id="modalScrim" role="dialog" aria-modal="true" hidden></div>
 
 <script src="js/firebase-config.js"></script>
 <script type="module" src="js/app.js"></script>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -181,6 +181,27 @@ function toast(msg) {
   t._h = setTimeout(() => t.classList.remove("show"), 3500);
 }
 
+function openModal({ icon = "✉️", title, body, actionLabel = "Got it" }) {
+  const scrim = document.getElementById("modalScrim");
+  scrim.innerHTML = `
+    <div class="modal-box" role="document">
+      <div class="ic" aria-hidden="true">${icon}</div>
+      <h3>${esc(title)}</h3>
+      <p>${esc(body)}</p>
+      <button class="btn btn-solid" type="button" id="modalCloseBtn">${esc(actionLabel)}</button>
+    </div>`;
+  scrim.hidden = false;
+  requestAnimationFrame(() => scrim.classList.add("show"));
+  const close = () => closeModal();
+  scrim.onclick = e => { if (e.target === scrim) close(); };
+  document.getElementById("modalCloseBtn").onclick = close;
+}
+function closeModal() {
+  const scrim = document.getElementById("modalScrim");
+  scrim.classList.remove("show");
+  setTimeout(() => { scrim.hidden = true; scrim.innerHTML = ""; }, 250);
+}
+
 const tsDate = ts => (ts && typeof ts.toDate === "function") ? ts.toDate() : (ts ? new Date(ts) : null);
 function fmtDate(ts, withTime) {
   const d = tsDate(ts);
@@ -477,7 +498,7 @@ function viewHub() {
     <a class="hub-card" href="#/book" style="border-color:var(--accent)">
       <div class="ic">📘</div>
       <h3>The Collaboration Reflex</h3>
-      <p>My new book on why the instinct to “collaborate” is usually the wrong answer to conflict — free to download.</p>
+      <p>My new book on why the instinct to “collaborate” is usually the wrong answer to conflict — free, sent by email.</p>
       <span class="go">Get the book →</span>
     </a>
     <a class="hub-card" href="#/consult">
@@ -1157,43 +1178,16 @@ async function viewBook() {
 
   const panel = document.getElementById("bookDownloadPanel");
 
-  // Fetches the PDF (stored as base64 chunks, since Firebase Storage now
-  // requires the paid Blaze plan even for free-tier usage) through
-  // firestore.rules — isVerified() is re-checked by Google's servers on
-  // every one of these reads, so this is not a shareable link, it fails
-  // fresh for anyone who isn't signed in and verified — then reassembles
-  // and saves it via a short-lived local object URL.
-  async function fetchAndTriggerDownload() {
-    const metaSnap = await getDoc(doc(db, BOOK.fileDocPath));
-    if (!metaSnap.exists()) throw { code: "book/not-found" };
-    const meta = metaSnap.data();
-
-    const chunkSnaps = await Promise.all(
-      Array.from({ length: meta.chunkCount }, (_, i) =>
-        getDoc(doc(db, BOOK.fileDocPath, "chunks", String(i))))
-    );
-    const base64 = chunkSnaps.map(s => s.data().data).join("");
-    const binary = atob(base64);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-
-    const blobUrl = URL.createObjectURL(new Blob([bytes], { type: meta.mimeType || "application/pdf" }));
-    const a = document.createElement("a");
-    a.href = blobUrl;
-    a.download = BOOK.fileName;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    setTimeout(() => URL.revokeObjectURL(blobUrl), 30000);
-  }
-
+  // Direct download is switched off — a request just records the reader's
+  // name/email in bookDownloads (rules-gated, same as before) and points
+  // them to email instead, so every copy goes out personally.
   function renderDownloadCta(record) {
     const already = record && record.downloadCount > 0;
     panel.innerHTML = `
     <div class="panel">
-      <h3>Download your copy</h3>
-      <p class="sub" style="margin-bottom:16px">Free, full PDF. ${already ? `You first downloaded this on ${fmtDate(record.firstDownloadAt)} — ${record.downloadCount} download${record.downloadCount === 1 ? "" : "s"} so far.` : "I keep a simple record of who's downloaded it — no spam, ever — just so I know the book is reaching people."}</p>
-      <button class="btn btn-solid" type="button" id="bookDownloadBtn" style="width:100%;justify-content:center">${already ? "Download Again" : "Download the Book"} <span class="arrow">→</span></button>
+      <h3>Get your copy</h3>
+      <p class="sub" style="margin-bottom:16px">${already ? `You requested this on ${fmtDate(record.firstDownloadAt)} — I'll follow up by email.` : "Free, full PDF — sent to your inbox, not an instant download. I keep a simple record of who's asked for it — no spam, ever."}</p>
+      <button class="btn btn-solid" type="button" id="bookDownloadBtn" style="width:100%;justify-content:center">${already ? "Request Again" : "Get the Book"} <span class="arrow">→</span></button>
       <span class="form-msg" id="bookDownloadMsg" style="display:block;margin-top:10px"></span>
     </div>`;
     const btn = document.getElementById("bookDownloadBtn");
@@ -1201,11 +1195,6 @@ async function viewBook() {
     btn.onclick = async () => {
       btn.disabled = true; msg.className = "form-msg"; msg.textContent = "";
       try {
-        // Fetch first — only log a download once Storage's rules have
-        // actually granted the file, so the record can't be gamed by a
-        // request that was rejected.
-        await fetchAndTriggerDownload();
-
         const ref = doc(db, "bookDownloads", currentUser.uid);
         const existing = await getDoc(ref);
         if (existing.exists()) {
@@ -1225,15 +1214,18 @@ async function viewBook() {
             lastDownloadAt: serverTimestamp()
           });
         }
-        toast("Downloading — enjoy the book!");
+        openModal({
+          icon: "✉️",
+          title: "Keep an eye on your email",
+          body: `I've got your request — I send the book out personally rather than as an instant download. It'll land at ${currentUser.email} soon.`,
+          actionLabel: "Got it"
+        });
         const fresh = await getDoc(ref);
         renderDownloadCta(fresh.data());
       } catch (e) {
         msg.className = "form-msg err";
-        msg.textContent = String(e && e.code) === "book/not-found"
-          ? "The book file isn't uploaded yet — the site owner needs to run scripts/upload-book.js."
-          : String(e && e.code).includes("permission-denied")
-          ? "Your account isn't authorised to download this yet — try signing out and back in."
+        msg.textContent = String(e && e.code).includes("permission-denied")
+          ? "Your account isn't authorised to request this yet — try signing out and back in."
           : fbError(e);
       } finally { btn.disabled = false; }
     };
@@ -1242,7 +1234,7 @@ async function viewBook() {
   if (!CONFIGURED) {
     panel.innerHTML = "";
   } else if (!currentUser) {
-    panel.innerHTML = authPrompt("Create a free account to download the book — it takes under a minute.");
+    panel.innerHTML = authPrompt("Create a free account to request the book — it takes under a minute.");
   } else if (!currentUser.emailVerified) {
     panel.innerHTML = verifyPrompt();
     bindResendVerify();
@@ -1704,7 +1696,7 @@ async function viewAdmin() {
         <div class="stat"><b>${pend(c)}</b><span>pending consultations</span></div>
         <div class="stat"><b>${pend(i)}</b><span>pending invitations</span></div>
         <div class="stat"><b>${m.docs.filter(d => d.data().status === "new").length}</b><span>new messages</span></div>
-        <div class="stat"><b>${bk.size}</b><span>readers who've downloaded the book</span></div>
+        <div class="stat"><b>${bk.size}</b><span>readers who've requested the book</span></div>
         <div class="stat"><b>${s.docs.filter(d => d.data().status === "subscribed").length}</b><span>newsletter subscribers</span></div>
         <div class="stat"><b>${r.size}</b><span>reported threads</span></div>`;
     } catch (e) { console.error(e); }
@@ -2092,16 +2084,16 @@ async function adminBookDownloads(body) {
   body.innerHTML = `
   <div class="form-actions" style="margin-bottom:18px">
     <button class="btn small btn-solid" id="bookCsvBtn" ${rows.length ? "" : "disabled"}>Export CSV (${rows.length})</button>
-    <span class="form-msg">Everyone who has downloaded <i>${esc(BOOK.title)}</i> through the platform.</span>
+    <span class="form-msg">Everyone who has requested <i>${esc(BOOK.title)}</i> through the platform — email them the PDF directly.</span>
   </div>
   <div class="list">${rows.map(r => `
     <div class="list-item">
       <div class="li-main"><h3 style="font-size:14.5px">${esc(r.name || "(no name set)")}</h3>
-        <div class="meta">${esc(r.email)} · first downloaded ${fmtDate(r.firstDownloadAt)} · last ${fmtDate(r.lastDownloadAt)}</div></div>
+        <div class="meta">${esc(r.email)} · first requested ${fmtDate(r.firstDownloadAt)} · last ${fmtDate(r.lastDownloadAt)}</div></div>
       <div class="li-side" style="flex-direction:row;align-items:center">
-        <span class="badge">${r.downloadCount || 1} download${(r.downloadCount || 1) === 1 ? "" : "s"}</span>
+        <span class="badge">${r.downloadCount || 1} request${(r.downloadCount || 1) === 1 ? "" : "s"}</span>
       </div>
-    </div>`).join("") || `<div class="empty">No downloads yet — readers who sign in and download the book will appear here.</div>`}</div>`;
+    </div>`).join("") || `<div class="empty">No requests yet — readers who sign in and request the book will appear here.</div>`}</div>`;
 
   const csvBtn = document.getElementById("bookCsvBtn");
   if (csvBtn) csvBtn.onclick = () => {

--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -178,14 +178,14 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
   letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent);
 }
 .status-badge {
-  position: relative; z-index: 4; display: flex; align-items: center; gap: 8px;
-  width: fit-content; margin: 14px auto 0; padding: 7px 16px 7px 12px;
-  border: 1px solid var(--line); border-radius: 999px; background: var(--card);
-  font-size: 12.5px; font-weight: 600; color: var(--ink); text-transform: none;
-  letter-spacing: normal; box-shadow: var(--shadow-sm); transition: border-color .25s, transform .25s var(--ease);
+  position: relative; z-index: 4; display: flex; align-items: center; justify-content: center; gap: 8px;
+  margin-top: 10px; text-align: center;
+  font-size: clamp(10.5px, 1vw, 12px); font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-soft);
+  transition: color .25s;
 }
-.status-badge:hover { border-color: var(--accent); transform: translateY(-1px); }
-.status-dot { position: relative; width: 8px; height: 8px; border-radius: 50%; background: #2fbf6e; flex: none; }
+.status-badge:hover { color: var(--accent); }
+.status-dot { position: relative; width: 6px; height: 6px; border-radius: 50%; background: #2fbf6e; flex: none; }
 .status-dot::after {
   content: ""; position: absolute; inset: -4px; border-radius: 50%; background: #2fbf6e;
   opacity: .45; animation: statusPulse 2.2s ease-out infinite;

--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -177,6 +177,23 @@ h1 em, h2 em, h3 em { font-style: italic; color: inherit; }
   text-align: center; font-size: clamp(11px, 1.1vw, 13px); font-weight: 600;
   letter-spacing: 0.22em; text-transform: uppercase; color: var(--accent);
 }
+.status-badge {
+  position: relative; z-index: 4; display: flex; align-items: center; gap: 8px;
+  width: fit-content; margin: 14px auto 0; padding: 7px 16px 7px 12px;
+  border: 1px solid var(--line); border-radius: 999px; background: var(--card);
+  font-size: 12.5px; font-weight: 600; color: var(--ink); text-transform: none;
+  letter-spacing: normal; box-shadow: var(--shadow-sm); transition: border-color .25s, transform .25s var(--ease);
+}
+.status-badge:hover { border-color: var(--accent); transform: translateY(-1px); }
+.status-dot { position: relative; width: 8px; height: 8px; border-radius: 50%; background: #2fbf6e; flex: none; }
+.status-dot::after {
+  content: ""; position: absolute; inset: -4px; border-radius: 50%; background: #2fbf6e;
+  opacity: .45; animation: statusPulse 2.2s ease-out infinite;
+}
+@keyframes statusPulse {
+  0% { transform: scale(0.6); opacity: .45; }
+  100% { transform: scale(2.1); opacity: 0; }
+}
 .hero-stage {
   position: relative; z-index: 1;
   height: clamp(440px, 76vh, 760px);

--- a/index.html
+++ b/index.html
@@ -213,6 +213,10 @@
   <div class="hero-bg" aria-hidden="true"></div>
   <div class="container">
     <span class="hero-eyebrow">Postdoctoral Researcher · Senior Lecturer</span>
+    <a class="status-badge" href="contact.html">
+      <span class="status-dot" aria-hidden="true"></span>
+      Open to research collaborations &amp; new opportunities
+    </a>
     <div class="hero-stage">
       <h1 class="hero-name" aria-label="Yasas Sri Wickramasinghe">
         <span class="l1" data-parallax data-speed="0.16">Yasas</span>
@@ -308,7 +312,7 @@
       <span class="eyebrow">About</span>
       <h2>Collaborating at the intersection of spatial interfaces and human behavior.</h2>
       <p>I'm Dr. Yasas Sri Wickramasinghe — a Postdoctoral Researcher at HIT Lab NZ (University of Canterbury) and Senior Lecturer at Yoobee College of Creative Innovation. I hold a PhD in Human Interface Technology, with a dissertation on designing multiplayer location-based AR games that connect remote players and places.</p>
-      <p>My work is conducted with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc. Earlier I co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme and led Sri Lanka's first large-scale MOOC platform.</p>
+      <p>My work is conducted with industry partners including Sony Interactive Entertainment (Japan) and Niantic, Inc. Earlier I co-founded NavitaZ VR Labs under the MIT Global Startup Labs programme and served as Platform Lead for the Software Engineering strand of Sri Lanka's first large-scale MOOC platform, scaling it to 150,000+ registered learners. I also taught at the University of Moratuwa's Faculty of Information Technology, and spent four years as Technical Lead &amp; Senior Software Engineer at 99X Technology.</p>
       <div class="intro-meta">
         <span class="trust-label">Trusted by</span>
         <div class="trust-logos">

--- a/research.html
+++ b/research.html
@@ -317,11 +317,45 @@
   </div>
 </section>
 
+<!-- ===== Education & training ===== -->
+<section class="section">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">03</span>
+      <h2>Education &amp; <em>training</em></h2>
+    </div>
+    <div class="timeline">
+      <div class="timeline-item reveal">
+        <span class="timeline-date">Jun 2022 — Jun 2025</span>
+        <div class="timeline-body">
+          <h3>PhD, Human Interface Technology</h3>
+          <span class="org">University of Canterbury · Aotearoa New Zealand</span>
+          <p>Thesis: <em>Designing multiplayer location-based augmented reality games that connect remote players and places.</em> Fully funded under the Applied Immersive Gaming Initiative (AIGI) scholarship — full details above.</p>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.05s">
+        <span class="timeline-date">Oct 2019 — Oct 2020</span>
+        <div class="timeline-body">
+          <h3>Specialisation in Virtual Reality</h3>
+          <span class="org">Goldsmiths, University of London</span>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.1s">
+        <span class="timeline-date">May 2013 — Oct 2017</span>
+        <div class="timeline-body">
+          <h3>BSc (Hons) in Information Technology</h3>
+          <span class="org">University of Moratuwa · Sri Lanka — Faculty of Information Technology</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ===== The three studies ===== -->
 <section class="section soft">
   <div class="container">
     <div class="section-head reveal">
-      <span class="idx">03</span>
+      <span class="idx">04</span>
       <h2>Three <em>studies</em></h2>
       <p>Each study sharpens the next, building from how a remote place should look, to how players behave inside it, to the mechanics that make distributed play meaningful.</p>
     </div>
@@ -375,7 +409,7 @@
 <section class="section">
   <div class="container">
     <div class="section-head reveal">
-      <span class="idx">04</span>
+      <span class="idx">05</span>
       <h2>Design <em>guidelines</em></h2>
       <p>Synthesised from all three studies — practical guidance for designing AR games that connect remote players and places, and a throughline I bring directly into my <a href="teaching.html" style="color:var(--accent);font-weight:600;">postgraduate teaching</a>.</p>
     </div>
@@ -409,7 +443,7 @@
 <section class="section soft">
   <div class="container">
     <div class="section-head reveal">
-      <span class="idx">05</span>
+      <span class="idx">06</span>
       <h2>Other <em>projects</em></h2>
     </div>
 
@@ -442,7 +476,7 @@
 <section class="section" id="publications">
   <div class="container">
     <div class="section-head reveal">
-      <span class="idx">06</span>
+      <span class="idx">07</span>
       <h2>Publication <em>index</em></h2>
       <a class="link-arrow head-link" href="https://scholar.google.com/citations?user=sIFk7asAAAAJ" target="_blank" rel="noopener">Google Scholar ↗</a>
     </div>
@@ -604,7 +638,7 @@
 <section class="section soft">
   <div class="container split">
     <div class="sticky-col reveal">
-      <span class="eyebrow">07 — Network</span>
+      <span class="eyebrow">08 — Network</span>
       <h2>Collaborators &amp; <em>links</em></h2>
       <p style="color:var(--text-dim); font-weight:300; margin-top:20px; font-size:15px;">Co-authoring with researchers at HIT Lab NZ, University of Moratuwa, and Niantic Aotearoa.</p>
     </div>
@@ -629,6 +663,73 @@
         <h3>Yoobee Research Profile</h3>
         <p>Institutional research profile at Yoobee Colleges.</p>
       </a>
+    </div>
+  </div>
+</section>
+
+<!-- ===== Grants, awards & service ===== -->
+<section class="section soft">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">09</span>
+      <h2>Recognition &amp; <em>service</em></h2>
+      <p>Funding, honours and academic service alongside the research itself.</p>
+    </div>
+
+    <div class="grid-2">
+      <div class="card reveal">
+        <span class="kicker">Funding</span>
+        <h3>Grants &amp; scholarships</h3>
+        <p>PhD research fully funded under the Applied Immersive Gaming Initiative (AIGI); XR work at HIT Lab NZ backed by a Niantic Studio Developer Accelerator Grant.</p>
+        <div class="tags">
+          <span class="tag gold">Niantic Accelerator Grant · 2024</span>
+          <span class="tag">AIGI Full Scholarship · 2022–25</span>
+        </div>
+      </div>
+
+      <div class="card reveal" style="--d:.05s">
+        <span class="kicker">Recognition</span>
+        <h3>Awards &amp; distinctions</h3>
+        <p>From national hackathons in Sri Lanka to research and innovation awards at the University of Canterbury.</p>
+        <div class="tags">
+          <span class="tag gold">Napkin Challenge Winner · 2024</span>
+          <span class="tag">Visualize Your Thesis — People's Choice · 2022</span>
+          <span class="tag">99X Excellence Awards · 2018–20</span>
+          <span class="tag">99X Emerging Xian Nominee · 2020</span>
+          <span class="tag">Imagine Cup Runner-Up · 2015</span>
+          <span class="tag">Hackanix Champion · 2015</span>
+          <span class="tag">Fuegostica Runner-Up · 2015</span>
+          <span class="tag">Dialog “Mora Hack” · 2016</span>
+          <span class="tag">Google Translation Marathon · 2016</span>
+        </div>
+      </div>
+
+      <div class="card reveal" style="--d:.1s">
+        <span class="kicker">Service</span>
+        <h3>Academic service</h3>
+        <p>Reviewing and volunteering for the conferences and communities I publish in, plus mentoring postgraduate students at the University of Canterbury.</p>
+        <div class="tags">
+          <span class="tag gold">Reviewer, ACM VRST · 2025</span>
+          <span class="tag">Volunteer, IEEE VR · 2024</span>
+          <span class="tag">Volunteer, ISAGA · 2024</span>
+          <span class="tag">Postgrad Mentor, UC · 2024–25</span>
+        </div>
+      </div>
+
+      <div class="card reveal" style="--d:.15s">
+        <span class="kicker">Training</span>
+        <h3>Certifications</h3>
+        <p>Continuing education spanning AI fluency, higher-education pedagogy, agile delivery, and research methods.</p>
+        <div class="tags">
+          <span class="tag gold">AI Fluency for Educators, Anthropic · 2025</span>
+          <span class="tag">Certificate in Teaching Higher Education</span>
+          <span class="tag">Scrum Foundation Professional Certificate</span>
+          <span class="tag">Eye Trackers in Research, Tobii Academy</span>
+          <span class="tag">GitLab Certified Associate</span>
+          <span class="tag">Online Presence &amp; Digital Footprint, Edinburgh</span>
+          <span class="tag">Customer Journey Mapping, Coursera</span>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/teaching.html
+++ b/teaching.html
@@ -368,31 +368,88 @@
     </div>
     <div class="timeline">
       <div class="timeline-item reveal">
+        <span class="timeline-date">2023</span>
+        <div class="timeline-body">
+          <h3>HITD603 — Human Interface Technology (Master's)</h3>
+          <span class="org">HIT Lab NZ, University of Canterbury</span>
+          <p>Workshops on AR application development.</p>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.05s">
         <span class="timeline-date">2021 — 2022</span>
         <div class="timeline-body">
           <h3>Computer Architecture &amp; Enterprise Software</h3>
           <span class="org">University of Moratuwa · Sri Lanka</span>
         </div>
       </div>
-      <div class="timeline-item reveal" style="--d:.05s">
+      <div class="timeline-item reveal" style="--d:.1s">
+        <span class="timeline-date">2020 — 2022</span>
+        <div class="timeline-body">
+          <h3>IN2100 — Object Oriented Programming (BSc)</h3>
+          <span class="org">University of Moratuwa · Sri Lanka</span>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.15s">
+        <span class="timeline-date">2019 — 2022</span>
+        <div class="timeline-body">
+          <h3>IN1600 — Multimedia &amp; Web Technologies (BSc)</h3>
+          <span class="org">University of Moratuwa · Sri Lanka</span>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.2s">
         <span class="timeline-date">2018 — 2021</span>
         <div class="timeline-body">
           <h3>Database Management Systems</h3>
           <span class="org">SLIIT &amp; University of Moratuwa · Sri Lanka</span>
         </div>
       </div>
-      <div class="timeline-item reveal" style="--d:.1s">
+      <div class="timeline-item reveal" style="--d:.25s">
         <span class="timeline-date">2018 — 2022</span>
         <div class="timeline-body">
           <h3>Human-Computer Interaction</h3>
           <span class="org">University of Moratuwa &amp; SLIIT · Sri Lanka</span>
         </div>
       </div>
-      <div class="timeline-item reveal" style="--d:.15s">
+      <div class="timeline-item reveal" style="--d:.3s">
         <span class="timeline-date">2018 — 2022</span>
         <div class="timeline-body">
           <h3>Project Management &amp; Enterprise App Development</h3>
           <span class="org">SLIIT · Sri Lanka</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section soft" id="supervision">
+  <div class="container">
+    <div class="section-head reveal">
+      <span class="idx">06</span>
+      <h2>Postgraduate <em>Supervision</em></h2>
+    </div>
+    <div class="timeline">
+      <div class="timeline-item reveal">
+        <span class="timeline-date">2023 — Now</span>
+        <div class="timeline-body">
+          <h3>Kotuwegedara, H. — Master's Thesis</h3>
+          <span class="org">Yoobee Colleges · Primary Supervisor</span>
+          <p><em>Prompting for Security: LLM Code Generation in Angular.</em></p>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.05s">
+        <span class="timeline-date">2022 — 2024</span>
+        <div class="timeline-body">
+          <h3>Ritter, M. — Master's Thesis</h3>
+          <span class="org">HIT Lab NZ, University of Canterbury · Co-supervisor</span>
+          <p><em>Trust and trustworthiness while exchanging virtual items in shared augmented reality.</em> <a href="https://doi.org/10.26021/15296" target="_blank" rel="noopener" style="color:var(--accent);font-weight:600;">doi.org/10.26021/15296 ↗</a></p>
+        </div>
+      </div>
+      <div class="timeline-item reveal" style="--d:.1s">
+        <span class="timeline-date">2021 — 2022</span>
+        <div class="timeline-body">
+          <h3>Inparajah, J. — Final-Year Thesis</h3>
+          <span class="org">University of Moratuwa · Primary Supervisor</span>
+          <p><em>Reimagining Medical Education with VR in Emerging Medical Disciplines.</em></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- app/js/app.js, app/css/app.css, app/index.html: the book page no longer
  serves the PDF client-side. Requesting it still records the reader's
  name/email in Firestore (bookDownloads, unchanged rules), then shows a
  popup asking them to watch their email instead of triggering a download.
- index.html, assets/css/redesign.css: add an "open to research
  collaborations & new opportunities" badge under the hero eyebrow, linking
  to the contact page.
- research.html: add an Education & Training timeline (Goldsmiths VR
  specialisation, BSc IT) and a Recognition & Service section (grants,
  awards, academic service, certifications) pulled from the CV; renumber
  subsequent sections accordingly.
- teaching.html: add the missing HITD603/IN1600/IN2100 courses to the
  Previous Teaching timeline and a new Postgraduate Supervision section
  (Kotuwegedara, Ritter, Inparajah).
- index.html: expand the bio paragraph with the 99X Technology and
  University of Moratuwa Lecturer roles, and the Open Learning Platform
  Platform Lead title (150,000+ learners).