### PR TITLE
Fix invisible modal-scrim blocking all clicks (nav bar unclickable)

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -322,6 +322,7 @@ a.list-item:hover, .list-item.clickable:hover { border-color: var(--line-strong)
   display: flex; align-items: center; justify-content: center; padding: 20px;
   z-index: 1300; opacity: 0; transition: opacity .25s var(--ease);
 }
+.modal-scrim[hidden] { display: none; }
 .modal-scrim.show { opacity: 1; }
 .modal-box {
   background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);


### PR DESCRIPTION
.modal-scrim set display:flex unconditionally, which won the specificity tie against the [hidden] attribute's UA display:none, leaving a full-viewport invisible overlay above the nav intercepting every click.