### PR TITLE
Add peer review service section to research page

### DIFF
--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -757,3 +757,33 @@ html.lenis, html.lenis body { height: auto; }
 .faq-item summary::after { content: "+"; font-size: 22px; font-weight: 400; color: var(--accent); transition: transform .3s var(--ease); flex-shrink: 0; }
 .faq-item[open] summary::after { transform: rotate(45deg); }
 .faq-item p { color: var(--ink-soft); font-size: 14.5px; line-height: 1.65; padding: 0 0 20px; margin: 0; max-width: 72ch; }
+
+/* ---------- Peer review venues (Research) ---------- */
+.subhead { display: flex; align-items: baseline; gap: 8px 18px; flex-wrap: wrap; margin: 48px 0 0; }
+.subhead h3 { font-family: var(--serif); font-weight: 500; font-size: clamp(22px, 2.6vw, 28px); line-height: 1.2; letter-spacing: -0.015em; }
+.subhead h3 em { font-style: italic; }
+.subhead p { color: var(--ink-soft); font-size: 14.5px; max-width: 56ch; margin: 0; }
+
+.venue-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 22px; }
+.venue {
+  display: flex; align-items: flex-start; gap: 16px;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 20px; height: 100%;
+  transition: border-color .3s var(--ease), transform .3s var(--ease), box-shadow .3s var(--ease);
+}
+.venue:hover { transform: translateY(-3px); border-color: var(--line-strong); box-shadow: var(--shadow-sm); }
+.venue-mark { flex: 0 0 auto; width: 54px; height: 54px; border-radius: 14px; overflow: hidden; }
+.venue-mark img { width: 100%; height: 100%; object-fit: contain; }
+.venue-body { min-width: 0; }
+.venue-body h4 { font-size: 15px; font-weight: 650; line-height: 1.35; letter-spacing: -0.01em; margin: 2px 0 8px; }
+.venue-body .venue-org { display: block; font-size: 13px; color: var(--ink-soft); margin-bottom: 12px; }
+.venue-meta { display: flex; flex-wrap: wrap; gap: 7px; }
+.venue-meta span {
+  display: inline-flex; align-items: center; padding: 4px 11px; border-radius: 999px;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  background: var(--bg-panel); color: var(--ink-soft); border: 1px solid var(--line);
+}
+.venue-meta span.role { background: var(--accent-soft); color: var(--accent); border-color: transparent; }
+
+@media (max-width: 1040px) { .venue-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px) { .venue-grid { grid-template-columns: 1fr; } }

--- a/assets/images/venues/acm-vrst.svg
+++ b/assets/images/venues/acm-vrst.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="ACM Symposium on Virtual Reality Software and Technology">
+  <rect width="128" height="128" rx="30" fill="#eef1f5"/>
+  <rect x="0.75" y="0.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#d3dae4"/>
+  <text x="64" y="49" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="20" font-weight="700" fill="#5b6577" letter-spacing="1"
+        textLength="48" lengthAdjust="spacingAndGlyphs">ACM</text>
+  <text x="64" y="86" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="30" font-weight="700" fill="#2a3446"
+        textLength="72" lengthAdjust="spacingAndGlyphs">VRST</text>
+</svg>

--- a/assets/images/venues/ieee-vr.svg
+++ b/assets/images/venues/ieee-vr.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="IEEE Conference on Virtual Reality and 3D User Interfaces">
+  <rect width="128" height="128" rx="30" fill="#e6f1f8"/>
+  <rect x="0.75" y="0.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#bcd8ea"/>
+  <text x="64" y="49" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="22" font-weight="700" fill="#00629b" letter-spacing="1"
+        textLength="60" lengthAdjust="spacingAndGlyphs">IEEE</text>
+  <text x="64" y="86" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="34" font-weight="700" fill="#00476f"
+        textLength="48" lengthAdjust="spacingAndGlyphs">VR</text>
+</svg>

--- a/assets/images/venues/ijhci.svg
+++ b/assets/images/venues/ijhci.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="International Journal of Human-Computer Interaction">
+  <rect width="128" height="128" rx="30" fill="#eef1fe"/>
+  <rect x="0.75" y="0.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#c9d2f7"/>
+  <text x="64" y="66" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="30" font-weight="700" fill="#3a44a8"
+        textLength="90" lengthAdjust="spacingAndGlyphs">IJHCI</text>
+</svg>

--- a/assets/images/venues/mti.svg
+++ b/assets/images/venues/mti.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="Multimodal Technologies and Interaction">
+  <rect width="128" height="128" rx="30" fill="#e7f5f2"/>
+  <rect x="0.75" y="0.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#bfe0d9"/>
+  <text x="64" y="66" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="38" font-weight="700" fill="#0f766e"
+        textLength="70" lengthAdjust="spacingAndGlyphs">MTI</text>
+</svg>

--- a/assets/images/venues/ozchi.svg
+++ b/assets/images/venues/ozchi.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="OZCHI — Australian Conference on Human-Computer Interaction">
+  <rect width="128" height="128" rx="30" fill="#fdf0e8"/>
+  <rect x="0.75" y="0.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#f2d3bf"/>
+  <text x="64" y="66" text-anchor="middle" dominant-baseline="middle"
+        font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+        font-size="29" font-weight="700" fill="#b4460f"
+        textLength="88" lengthAdjust="spacingAndGlyphs">OzCHI</text>
+</svg>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -227,6 +227,13 @@ Learning Experience for Children. Wickramasinghe, W., & Gunasekara, E.H.D.A.
 — Research Symposium of the Information Technology Research Unit (ITRU
 2015). University of Moratuwa, Sri Lanka.
 
+**Peer review service.** Serves as a reviewer for the International Journal
+of Human-Computer Interaction (Taylor & Francis), the IEEE Conference on
+Virtual Reality and 3D User Interfaces (IEEE VR), OZCHI — the Australian
+Conference on Human-Computer Interaction (CHISIG / ACM Digital Library),
+Multimodal Technologies and Interaction (MTI, MDPI), and the ACM Symposium
+on Virtual Reality Software and Technology (VRST, since 2025).
+
 **Collaborators & links.** Co-authoring with researchers at HIT Lab NZ,
 University of Moratuwa, and Niantic Aotearoa. Google Scholar:
 https://scholar.google.com/citations?user=sIFk7asAAAAJ — HIT Lab NZ AR Games

--- a/llms.txt
+++ b/llms.txt
@@ -67,6 +67,14 @@ Ten interactive lesson decks, text-summarised as static pages for crawlers, each
 - On the Impact of Augmented Reality Game Mechanics on the Player Experience in Remote Multiplayer Gameplay — OzCHI '25, ACM. https://doi.org/10.1145/3764687.3764699
 - Trustful Trading in Shared Augmented Reality — ACM SUI '24. https://doi.org/10.1145/3677386.3682086
 
+## Peer review service (reviewer)
+
+- International Journal of Human-Computer Interaction — Taylor & Francis (journal)
+- IEEE Conference on Virtual Reality and 3D User Interfaces (IEEE VR) — IEEE (conference)
+- OZCHI, the Australian Conference on Human-Computer Interaction — CHISIG / ACM Digital Library (conference)
+- Multimodal Technologies and Interaction (MTI) — MDPI (journal)
+- ACM Symposium on Virtual Reality Software and Technology (VRST) — ACM (conference), since 2025
+
 ## Profiles and links
 
 - Google Scholar: https://scholar.google.com/citations?user=sIFk7asAAAAJ

--- a/research.html
+++ b/research.html
@@ -707,9 +707,9 @@
       <div class="card reveal" style="--d:.1s">
         <span class="kicker">Service</span>
         <h3>Academic service</h3>
-        <p>Reviewing and volunteering for the conferences and communities I publish in, plus mentoring postgraduate students at the University of Canterbury.</p>
+        <p>Peer reviewing for the journals and conferences I publish in (listed below), volunteering for the communities behind them, and mentoring postgraduate students at the University of Canterbury.</p>
         <div class="tags">
-          <span class="tag gold">Reviewer, ACM VRST · 2025</span>
+          <span class="tag gold">Reviewer · 5 venues</span>
           <span class="tag">Volunteer, IEEE VR · 2024</span>
           <span class="tag">Volunteer, ISAGA · 2024</span>
           <span class="tag">Postgrad Mentor, UC · 2024–25</span>
@@ -728,6 +728,84 @@
           <span class="tag">GitLab Certified Associate</span>
           <span class="tag">Online Presence &amp; Digital Footprint, Edinburgh</span>
           <span class="tag">Customer Journey Mapping, Coursera</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Peer review venues -->
+    <div class="subhead reveal">
+      <h3>Peer <em>review</em></h3>
+      <p>Journals and conferences I serve as a reviewer for, across HCI, virtual reality and interaction design.</p>
+    </div>
+
+    <div class="venue-grid">
+      <div class="venue reveal">
+        <div class="venue-mark">
+          <img src="assets/images/venues/ijhci.svg" alt="International Journal of Human-Computer Interaction" loading="lazy" decoding="async" width="128" height="128" />
+        </div>
+        <div class="venue-body">
+          <h4>International Journal of Human-Computer Interaction</h4>
+          <span class="venue-org">Taylor &amp; Francis</span>
+          <div class="venue-meta">
+            <span class="role">Reviewer</span>
+            <span>Journal</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="venue reveal" style="--d:.05s">
+        <div class="venue-mark">
+          <img src="assets/images/venues/ieee-vr.svg" alt="IEEE Conference on Virtual Reality and 3D User Interfaces" loading="lazy" decoding="async" width="128" height="128" />
+        </div>
+        <div class="venue-body">
+          <h4>IEEE Conference on Virtual Reality &amp; 3D User Interfaces (IEEE VR)</h4>
+          <span class="venue-org">IEEE</span>
+          <div class="venue-meta">
+            <span class="role">Reviewer</span>
+            <span>Conference</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="venue reveal" style="--d:.1s">
+        <div class="venue-mark">
+          <img src="assets/images/venues/ozchi.svg" alt="OZCHI, the Australian Conference on Human-Computer Interaction" loading="lazy" decoding="async" width="128" height="128" />
+        </div>
+        <div class="venue-body">
+          <h4>OZCHI — Australian Conference on Human-Computer Interaction</h4>
+          <span class="venue-org">CHISIG · ACM Digital Library</span>
+          <div class="venue-meta">
+            <span class="role">Reviewer</span>
+            <span>Conference</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="venue reveal" style="--d:.15s">
+        <div class="venue-mark">
+          <img src="assets/images/venues/mti.svg" alt="Multimodal Technologies and Interaction journal" loading="lazy" decoding="async" width="128" height="128" />
+        </div>
+        <div class="venue-body">
+          <h4>Multimodal Technologies and Interaction (MTI)</h4>
+          <span class="venue-org">MDPI</span>
+          <div class="venue-meta">
+            <span class="role">Reviewer</span>
+            <span>Journal</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="venue reveal" style="--d:.2s">
+        <div class="venue-mark">
+          <img src="assets/images/venues/acm-vrst.svg" alt="ACM Symposium on Virtual Reality Software and Technology" loading="lazy" decoding="async" width="128" height="128" />
+        </div>
+        <div class="venue-body">
+          <h4>ACM Symposium on Virtual Reality Software &amp; Technology (VRST)</h4>
+          <span class="venue-org">ACM · Since 2025</span>
+          <div class="venue-meta">
+            <span class="role">Reviewer</span>
+            <span>Conference</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds a "Peer review" block under Recognition & service on research.html listing the journals and conferences reviewed for: IJHCI (Taylor & Francis), IEEE VR, OZCHI, MTI (MDPI), and ACM VRST.

- New .venue-grid / .venue card styles in redesign.css (3/2/1 column responsive), matching the existing card language
- Custom SVG venue marks in assets/images/venues/ (official publisher logos are trademarked and not redistributable)
- Academic service card now points at the new list instead of carrying a single reviewer tag
- Mirrors the reviewer record into llms.txt and llms-full.txt


Claude-Session: https://claude.ai/code/session_01Pb5DXwqmsY5X5bnQbQN5qq