### PR TITLE
Stop the Google sign-in popup from opening more than once

### DIFF
--- a/PLATFORM_SETUP.md
+++ b/PLATFORM_SETUP.md
@@ -48,6 +48,29 @@ Firebase console → **Build → Authentication → Get started**:
 3. Under **Settings → Authorized domains**, add `www.yasassri.me` and
    `yasassri.me` (and your `*.github.io` domain if you use it).
 
+#### What the Google sign-in window says about you
+
+The Google window is rendered by Google, not by this site, so its wording comes
+from console settings rather than from any code here. It reads
+*"Sign in to **&lt;app name&gt;**"* and *"to continue to **&lt;auth domain&gt;**"*, and both
+halves are worth fixing:
+
+| Shown | Comes from | Fix |
+|---|---|---|
+| the app name | Google Cloud → **APIs & Services → OAuth consent screen → App name** | Set it to `Dr. Yasas Sri Wickramasinghe` (or `Yasas Sri Wickramasinghe — Academic Platform`), with your support email. Takes effect immediately. |
+| `angular5-firebase-project.firebaseapp.com` | the `authDomain` in `app/js/firebase-config.js` — this platform runs on a Firebase project recycled from an older app | Move it to `auth.yasassri.me` following the steps in the comment at the top of that file, **then** swap the two `authDomain` lines. |
+
+Adding a **logo** to the consent screen triggers Google's brand-verification
+review, which can take weeks. Do the name first and on its own — it is the part
+people actually read — and treat the logo as a separate, later errand.
+
+Switching `authDomain` before its three prerequisites are done (Firebase Hosting
+site + custom domain, authorized domain, OAuth client origins) breaks Google
+sign-in outright, so do them in order. Once `authDomain` is on `yasassri.me`,
+the sign-in code also gains a redirect fallback for browsers that block
+pop-ups — it stays switched off until then, because redirect sign-in cannot
+complete from a third-party `firebaseapp.com` domain in Safari or Chrome.
+
 ### 4. Create Firestore + deploy the security rules
 
 1. **Build → Firestore Database → Create database** → production mode →

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -15,6 +15,7 @@ const ADMIN_EMAILS = (window.PLATFORM_ADMINS || []).map(e => e.toLowerCase());
 
 let auth = null, db = null;
 let onAuthStateChanged, GoogleAuthProvider, signInWithPopup,
+    signInWithRedirect, getRedirectResult,
     createUserWithEmailAndPassword, signInWithEmailAndPassword,
     sendEmailVerification, sendPasswordResetEmail, signOut, updateProfile,
     collection, doc, addDoc, setDoc, getDoc, getDocs,
@@ -30,6 +31,7 @@ if (CONFIGURED) {
       import(`https://www.gstatic.com/firebasejs/${V}/firebase-firestore.js`)
     ]);
     ({ onAuthStateChanged, GoogleAuthProvider, signInWithPopup,
+       signInWithRedirect, getRedirectResult,
        createUserWithEmailAndPassword, signInWithEmailAndPassword,
        sendEmailVerification, sendPasswordResetEmail, signOut, updateProfile } = authM);
     ({ collection, doc, addDoc, setDoc, getDoc, getDocs,
@@ -55,10 +57,53 @@ let authReady = new Promise(resolve => {
   });
 });
 
+/* Completes a redirect sign-in when the page comes back from Google. Harmless
+   on every other load — it resolves to null. Errors go to the console rather
+   than a toast: the account view renders straight after and shows the state. */
+if (auth && getRedirectResult) {
+  getRedirectResult(auth)
+    .then(cred => { if (cred && cred.user) toast("Signed in ✓"); })
+    .catch(e => console.error("Redirect sign-in failed:", e));
+}
+
 const isAdmin = () =>
   !!(currentUser && currentUser.email &&
      currentUser.emailVerified &&
      ADMIN_EMAILS.includes(currentUser.email.toLowerCase()));
+
+/* ---------- Google sign-in ------------------------------------------------
+   One popup at a time. Without a guard, a second click while the first popup
+   is still opening (or has opened behind the window) starts a second sign-in
+   flow; Firebase then aborts the first with auth/cancelled-popup-request,
+   which is what the "popup keeps appearing again" behaviour actually is.
+   googleSignInPending is module-level, so it also survives the account view
+   being re-rendered underneath an open popup.
+
+   prompt=select_account makes the flow predictable: Google always shows the
+   account chooser instead of silently reusing whichever session it saw last,
+   which is what makes a second, unexpected-looking window appear for people
+   signed into more than one Google account. */
+let googleSignInPending = false;
+
+function googleProvider() {
+  const provider = new GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: "select_account" });
+  return provider;
+}
+
+/* Redirect sign-in only completes if the browser lets the auth domain set
+   cookies for this site. While authDomain is the project's *.firebaseapp.com
+   address that is a third-party context — Safari and Chrome drop the state
+   and the user lands back signed out. So redirect is used as the popup-blocked
+   fallback only once authDomain is a same-registrable-domain host (the
+   auth.yasassri.me setup described in firebase-config.js); until then a
+   blocked popup gets a clear message instead of a silent failure. */
+function redirectSignInUsable() {
+  const authDomain = String(CFG.authDomain || "");
+  if (!authDomain || !signInWithRedirect) return false;
+  const site = h => h.split(".").slice(-2).join(".");
+  return site(authDomain) === site(location.hostname);
+}
 
 /* ---------- Static content ------------------------------------------------ */
 
@@ -241,7 +286,9 @@ function fbError(e) {
   if (m.includes("auth/email-already-in-use")) return "An account with this email already exists — try signing in.";
   if (m.includes("auth/weak-password")) return "Password should be at least 6 characters.";
   if (m.includes("auth/invalid-email")) return "That email address doesn't look right.";
-  if (m.includes("auth/popup")) return "Sign-in popup was blocked or closed — please try again.";
+  if (m.includes("auth/popup-blocked")) return "Your browser blocked the Google sign-in window. Allow pop-ups for this site and try again, or use the email form below.";
+  if (m.includes("auth/unauthorized-domain")) return "Google sign-in isn't enabled for this address yet. Please use the email form below.";
+  if (m.includes("auth/popup")) return "The Google sign-in window closed before finishing — please try again.";
   if (m.includes("unavailable") || m.includes("network")) return "Network problem — please try again.";
   console.error(e);
   return "Something went wrong — please try again.";
@@ -1687,11 +1734,43 @@ function viewAccount() {
   });
 
   const msg = document.getElementById("authMsg");
-  document.getElementById("googleBtn").onclick = async () => {
+  const googleBtn = document.getElementById("googleBtn");
+  const googleBtnHtml = googleBtn.innerHTML;
+  if (googleSignInPending) {
+    googleBtn.disabled = true;
+    googleBtn.innerHTML = "Waiting for Google…";
+  }
+  googleBtn.onclick = async () => {
+    if (googleSignInPending) return;           // a popup is already open
+    googleSignInPending = true;
+    googleBtn.disabled = true;
+    googleBtn.innerHTML = "Waiting for Google…";
+    msg.className = "form-msg"; msg.textContent = "";
     try {
-      await signInWithPopup(auth, new GoogleAuthProvider());
+      await signInWithPopup(auth, googleProvider());
       toast("Signed in ✓"); route();
-    } catch (e) { msg.className = "form-msg err"; msg.textContent = fbError(e); }
+    } catch (e) {
+      const code = String(e && e.code || "");
+      /* The user closing the window, or a second click superseding the first,
+         is a normal outcome and not something to report as an error. */
+      if (code === "auth/popup-closed-by-user" || code === "auth/cancelled-popup-request") {
+        /* nothing to say */
+      } else if (code === "auth/popup-blocked" && redirectSignInUsable()) {
+        try {
+          await signInWithRedirect(auth, googleProvider());   // page navigates to Google
+        } catch (re) {
+          msg.className = "form-msg err"; msg.textContent = fbError(re);
+        }
+      } else {
+        msg.className = "form-msg err"; msg.textContent = fbError(e);
+      }
+    } finally {
+      googleSignInPending = false;
+      if (document.body.contains(googleBtn)) {
+        googleBtn.disabled = false;
+        googleBtn.innerHTML = googleBtnHtml;
+      }
+    }
   };
   document.getElementById("forgotBtn").onclick = async () => {
     const email = String(new FormData(document.getElementById("authForm")).get("email")).trim();


### PR DESCRIPTION
A second click while the first popup was still opening — or had opened behind the window — started a second sign-in flow, and Firebase aborted the first with auth/cancelled-popup-request. That is what the popup "appearing multiple times" was. The failed flow then surfaced as a red error message, so people clicked again and repeated it.

- one flow at a time: a module-level pending flag (it survives the account view re-rendering under an open popup) plus a disabled button labelled "Waiting for Google…"
- prompt=select_account, so Google always shows the account chooser instead of silently reusing whichever session it saw last — the other source of unexpected extra windows for multi-account users
- closing the popup, or superseding it with a second click, is a normal outcome and no longer shows an error
- a blocked popup now says so plainly and points at the email form; where authDomain is same-site with the page it falls back to redirect sign-in instead, which is off today because redirect cannot complete from a third-party firebaseapp.com domain in Safari or Chrome
- getRedirectResult on load, to complete that fallback when it applies

The app name in the Google window is console-side, not code: it comes from the OAuth consent screen, and the "continue to angular5-firebase-project.firebaseapp.com" line from authDomain. PLATFORM_SETUP.md now spells out both fixes and the order to do them in.


Claude-Session: https://claude.ai/code/session_01Grdsqg77nkYXb1WtYdKjmi